### PR TITLE
fix: invalidate tutor/lecturer views on message create/delete

### DIFF
--- a/computor-backend/src/computor_backend/api/messages.py
+++ b/computor-backend/src/computor_backend/api/messages.py
@@ -25,6 +25,7 @@ from computor_backend.business_logic.messages import (
     create_message_with_author,
     get_message_with_read_status,
     get_message_thread,
+    invalidate_tutor_lecturer_views_for_message,
     list_messages_with_read_status,
     list_messages_with_filters,
     mark_message_as_read,
@@ -61,6 +62,9 @@ async def create_message(
     db_message = message_repo.get_by_id_optional(str(message.id))
     if db_message:
         create_message_audit(db_message, permissions, db)
+        # Invalidate tutor/lecturer course views so unread_message_count badges
+        # reflect the new message without waiting for the 3-min TTL.
+        invalidate_tutor_lecturer_views_for_message(db_message, db, cache)
 
     # Enrich message with author info before broadcasting
     enriched_message = get_message_with_read_status(message.id, message, permissions, db)
@@ -154,18 +158,23 @@ async def delete_message(
     id: UUID | str,
     permissions: Annotated[Principal, Depends(get_current_principal)],
     db: Session = Depends(get_db),
+    cache: Cache = Depends(get_cache),
 ):
     """Soft delete a message (preserves thread structure)."""
     # Verify user has access and get message for broadcast
     message = await get_id_db(permissions, db, id, MessageInterface)
 
     # Soft delete with audit
-    soft_delete_message(
+    deleted = soft_delete_message(
         message_id=id,
         principal=permissions,
         db=db,
         reason="user_request"
     )
+
+    # Invalidate tutor/lecturer course views so unread_message_count drops for
+    # other users who hadn't yet read this message.
+    invalidate_tutor_lecturer_views_for_message(deleted, db, cache)
 
     # Broadcast to WebSocket subscribers (use DTO which has target fields)
     await ws_broadcast.message_deleted(message, str(id))

--- a/computor-backend/src/computor_backend/business_logic/messages.py
+++ b/computor-backend/src/computor_backend/business_logic/messages.py
@@ -7,7 +7,7 @@ from computor_backend.api.exceptions import BadRequestException, NotImplementedE
 from computor_backend.permissions.principal import Principal
 from computor_backend.permissions.core import check_permissions
 from computor_backend.model.message import MessageRead, Message
-from computor_backend.model.course import CourseMember, SubmissionGroup, SubmissionGroupMember
+from computor_backend.model.course import CourseContent, CourseMember, SubmissionGroup, SubmissionGroupMember
 from computor_backend.model.auth import User
 from computor_types.messages import (
     MessageCreate, MessageGet, MessageList, MessageQuery,
@@ -483,6 +483,48 @@ def list_messages_with_read_status(
         })
         for item in items
     ]
+
+
+def invalidate_tutor_lecturer_views_for_message(
+    message: Message,
+    db: Session,
+    cache: Optional[Cache] = None,
+) -> None:
+    """
+    Clear cached tutor and lecturer course views affected by a message create/delete.
+
+    Every tutor's `unread_message_count` badge for a course member depends on the
+    set of non-archived messages scoped to that member's submission group. When a
+    new message is posted (or soft-deleted), that set changes, so every tutor's
+    cached view for the course must be invalidated.
+
+    Resolves the effective course_id via the message's scope hierarchy when
+    `message.course_id` itself is NULL (submission-group-scoped messages):
+        submission_group.course_id -> course_content.course_id
+
+    Note: this is a no-op for read/unread state changes — those are per-user and
+    are handled by `_invalidate_message_cache`.
+    """
+    if cache is None or message is None:
+        return
+
+    course_id = message.course_id
+
+    if course_id is None and message.submission_group_id:
+        course_id = db.query(SubmissionGroup.course_id).filter(
+            SubmissionGroup.id == message.submission_group_id
+        ).scalar()
+
+    if course_id is None and message.course_content_id:
+        course_id = db.query(CourseContent.course_id).filter(
+            CourseContent.id == message.course_content_id
+        ).scalar()
+
+    if course_id is None:
+        return
+
+    cache.invalidate_tags(f"tutor_view:{course_id}")
+    cache.invalidate_tags(f"lecturer_view:{course_id}")
 
 
 def _invalidate_message_cache(

--- a/tests/seed/verify_message_invalidation.py
+++ b/tests/seed/verify_message_invalidation.py
@@ -1,0 +1,177 @@
+"""Verify that posting or deleting a message invalidates tutor_view cache.
+
+Flow:
+  1. Prime the tutor cache by calling list_tutor_course_members.
+  2. Confirm the cache key exists in Redis.
+  3. Create a new submission-group-scoped message (course_id=NULL on Message row).
+  4. Confirm the tutor cache entry is gone.
+  5. Repeat for soft-delete.
+"""
+import os
+from uuid import UUID
+
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_USER", "postgres")
+os.environ.setdefault("POSTGRES_PASSWORD", "postgres_secret")
+os.environ.setdefault("POSTGRES_DB", "codeability")
+os.environ.setdefault("REDIS_HOST", "localhost")
+os.environ.setdefault("REDIS_PORT", "6379")
+os.environ.setdefault("REDIS_PASSWORD", "redis_password")
+
+from sqlalchemy import text
+
+from computor_backend.database import SessionLocal
+from computor_backend.redis_cache import get_cache
+from computor_backend.business_logic.tutor import list_tutor_course_members
+from computor_backend.business_logic.messages import (
+    create_message_with_author,
+    invalidate_tutor_lecturer_views_for_message,
+)
+from computor_backend.business_logic.message_operations import soft_delete_message
+from computor_backend.permissions.principal import Principal, Claims
+from computor_types.course_members import CourseMemberQuery
+from computor_types.messages import MessageCreate
+from computor_backend.model.message import Message
+from computor_backend.model.course import CourseMember
+
+
+COURSE_ID = "2fc15de7-40a7-4e85-b633-448823184684"
+
+
+def tutor_cache_key_exists(cache) -> bool:
+    """Return True if any cached tutor:course_members entry exists for any user."""
+    # The cache key is user-scoped: computor:user_view:{user_id}:tutor:course_members:{params_hash}
+    client = cache.client
+    keys = list(client.scan_iter(match="computor:user_view:*:tutor:course_members:*"))
+    return len(keys) > 0, keys
+
+
+def make_principal(user_id: str, is_admin: bool = False) -> Principal:
+    return Principal(
+        is_admin=is_admin,
+        user_id=user_id,
+        roles=[],
+        claims=Claims(general={}, dependent={}),
+        permissions={},
+    )
+
+
+def step(label: str) -> None:
+    print(f"\n=== {label} ===")
+
+
+def main():
+    cache = get_cache()
+
+    # Resolve tutor + one seeded submission_group
+    with SessionLocal() as db:
+        row = db.execute(text("""
+            SELECT cm.id AS tutor_member_id, cm.user_id AS tutor_user_id
+            FROM course_member cm
+            JOIN "user" u ON u.id = cm.user_id
+            WHERE cm.course_role_id = '_tutor'
+              AND cm.course_id = :cid
+              AND u.username LIKE 'bench_%%'
+            ORDER BY u.created_at DESC LIMIT 1
+        """), {"cid": COURSE_ID}).first()
+        if not row:
+            print("No benchmark tutor found. Run seed_tutor_benchmark.sql first.")
+            return
+        tutor_user_id = str(row.tutor_user_id)
+
+        sg_row = db.execute(text("""
+            SELECT sg.id AS sg_id, sg.course_content_id
+            FROM submission_group sg
+            JOIN course_content cc ON cc.id = sg.course_content_id
+            WHERE sg.course_id = :cid
+            LIMIT 1
+        """), {"cid": COURSE_ID}).first()
+        sg_id = str(sg_row.sg_id)
+        cc_id = str(sg_row.course_content_id)
+
+        # Find a student member of that submission_group to act as message author
+        student_row = db.execute(text("""
+            SELECT cm.user_id
+            FROM submission_group_member sgm
+            JOIN course_member cm ON cm.id = sgm.course_member_id
+            WHERE sgm.submission_group_id = :sgid
+            LIMIT 1
+        """), {"sgid": sg_id}).first()
+        author_user_id = str(student_row.user_id)
+
+    print(f"tutor_user_id      = {tutor_user_id}")
+    print(f"submission_group   = {sg_id}")
+    print(f"course_content     = {cc_id}")
+    print(f"author_user_id     = {author_user_id}")
+
+    # ------------------------------------------------------------------
+    # 1. Prime the tutor cache
+    # ------------------------------------------------------------------
+    step("1. Prime tutor cache (first call populates Redis)")
+    cache.invalidate_tags(f"tutor_view:{COURSE_ID}")  # clean slate
+
+    principal = make_principal(tutor_user_id)
+    params = CourseMemberQuery(course_id=COURSE_ID)
+    with SessionLocal() as db:
+        list_tutor_course_members(principal, params, db, cache=cache)
+
+    exists, keys = tutor_cache_key_exists(cache)
+    print(f"cache keys after prime: {len(keys)}  -> {'PRESENT' if exists else 'MISSING'}")
+    assert exists, "Cache should contain tutor view after first call"
+
+    # ------------------------------------------------------------------
+    # 2. Post a submission-group-scoped message (course_id=NULL on row)
+    # ------------------------------------------------------------------
+    step("2. Post new submission-group message as student author")
+
+    author_principal = make_principal(author_user_id)
+    with SessionLocal() as db:
+        payload = MessageCreate(
+            title="Invalidation test",
+            content="Does this invalidate the tutor cache?",
+            submission_group_id=sg_id,
+            level=0,
+        )
+        model_dump = create_message_with_author(payload, author_principal, db)
+        msg = Message(**model_dump)
+        db.add(msg)
+        db.commit()
+        db.refresh(msg)
+        print(f"created message {msg.id}  (course_id on row = {msg.course_id})")
+        # Call the invalidation helper as the endpoint would
+        invalidate_tutor_lecturer_views_for_message(msg, db, cache)
+        created_msg_id = msg.id
+
+    exists, keys = tutor_cache_key_exists(cache)
+    print(f"cache keys after create: {len(keys)}  -> {'PRESENT (BUG)' if exists else 'CLEARED ✓'}")
+    assert not exists, "Cache should be cleared after message create"
+
+    # ------------------------------------------------------------------
+    # 3. Re-prime, then soft-delete, verify invalidation
+    # ------------------------------------------------------------------
+    step("3. Re-prime, then soft-delete and check again")
+    with SessionLocal() as db:
+        list_tutor_course_members(principal, params, db, cache=cache)
+    exists, _ = tutor_cache_key_exists(cache)
+    print(f"cache keys after re-prime: {'PRESENT' if exists else 'MISSING'}")
+    assert exists
+
+    with SessionLocal() as db:
+        deleted = soft_delete_message(
+            message_id=created_msg_id,
+            principal=author_principal,
+            db=db,
+            reason="verification_test",
+        )
+        invalidate_tutor_lecturer_views_for_message(deleted, db, cache)
+
+    exists, _ = tutor_cache_key_exists(cache)
+    print(f"cache keys after delete: {'PRESENT (BUG)' if exists else 'CLEARED ✓'}")
+    assert not exists, "Cache should be cleared after message delete"
+
+    print("\nAll assertions passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `invalidate_tutor_lecturer_views_for_message` helper that resolves a message's effective `course_id` via `submission_group → course_content → course_id` and clears the `tutor_view:{course_id}` / `lecturer_view:{course_id}` tags.
- Calls it from the message-create and message-delete endpoints so tutor `unread_message_count` badges don't lag by up to 3 min after a new post.
- Verification script in `tests/seed/verify_message_invalidation.py` primes the cache, creates/deletes a submission-group-scoped message, asserts the key disappears.

## Why

Caveat 2 from the audit on #102: a submission-group-scoped message has `course_id=NULL` on the `message` row itself, so neither the generic CRUD invalidation nor `_invalidate_message_cache` (which only fires on read/unread) clears the tutor's cached `/tutors/course-members` list. Tutors would see stale unread-message badges.

Worth noting for review: while wiring this up I discovered that the message-create path (`messages_router.post`) goes through `business_logic/crud.create_entity`, which does **no** cache invalidation at all — unlike the generic `CrudRouter` in `api_builder`. So the gap wasn't a "forgot a tag" bug, it was "this endpoint doesn't use the invalidation machinery at all." No behavior changed beyond the scope of this PR, but worth filing away.

## Test plan

- [x] `python tests/seed/verify_message_invalidation.py` passes on the seeded dev DB (requires `seed_tutor_benchmark.sql` to be run first).
- [x] Manual: log in as a tutor in the VSCode extension, watch a student post a message on their submission group, verify the `📝` badge updates within the next tutor-list refresh (no 3-min lag).

Closes follow-up caveat 2 from #102.