### PR TITLE
feat: per-organization and per-course-family scoped roles

### DIFF
--- a/computor-backend/src/computor_backend/alembic/versions/c8d9e0f1a2b3_add_scoped_roles_org_course_family.py
+++ b/computor-backend/src/computor_backend/alembic/versions/c8d9e0f1a2b3_add_scoped_roles_org_course_family.py
@@ -1,0 +1,194 @@
+"""add scoped roles for organization and course_family
+
+Revision ID: c8d9e0f1a2b3
+Revises: b7c8d9e0f1a2
+Create Date: 2026-04-26 13:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c8d9e0f1a2b3'
+down_revision: Union[str, None] = 'b7c8d9e0f1a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add per-organization and per-course-family scoped role tables.
+
+    Mirrors the existing course_role / course_member pattern. Seeds two
+    built-in roles per scope: _owner, _manager. _owner > _manager in
+    hierarchy. Roles only grant write/admin privileges on the scope
+    itself; read visibility continues to use the course-membership
+    cascade — these roles do not cascade up or down.
+    """
+    # organization_role
+    op.create_table(
+        'organization_role',
+        sa.Column('id', sa.String(255), primary_key=True),
+        sa.Column('title', sa.String(255)),
+        sa.Column('description', sa.String(4096)),
+        sa.Column('builtin', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.CheckConstraint("(NOT builtin) OR ((id)::text ~ '^_'::text)"),
+        sa.CheckConstraint(
+            "(builtin AND computor_valid_slug(SUBSTRING(id FROM 2))) "
+            "OR ((NOT builtin) AND computor_valid_slug((id)::text))"
+        ),
+    )
+
+    # organization_member
+    op.create_table(
+        'organization_member',
+        sa.Column(
+            'id', sa.dialects.postgresql.UUID(as_uuid=False),
+            primary_key=True, server_default=sa.text('uuid_generate_v4()'),
+        ),
+        sa.Column('version', sa.BigInteger(), server_default=sa.text('0')),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True),
+            nullable=False, server_default=sa.func.now(),
+        ),
+        sa.Column(
+            'updated_at', sa.DateTime(timezone=True),
+            nullable=False, server_default=sa.func.now(),
+        ),
+        sa.Column(
+            'created_by', sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey('user.id', ondelete='SET NULL'),
+        ),
+        sa.Column(
+            'updated_by', sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey('user.id', ondelete='SET NULL'),
+        ),
+        sa.Column('properties', sa.dialects.postgresql.JSONB()),
+        sa.Column(
+            'user_id', sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey('user.id', ondelete='CASCADE', onupdate='RESTRICT'),
+            nullable=False,
+        ),
+        sa.Column(
+            'organization_id', sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey('organization.id', ondelete='CASCADE', onupdate='RESTRICT'),
+            nullable=False,
+        ),
+        sa.Column(
+            'organization_role_id', sa.String(255),
+            sa.ForeignKey('organization_role.id', ondelete='RESTRICT', onupdate='RESTRICT'),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        'organization_member_user_org_key',
+        'organization_member',
+        ['user_id', 'organization_id'],
+        unique=True,
+    )
+    op.create_index(
+        'ix_organization_member_organization_id',
+        'organization_member',
+        ['organization_id'],
+    )
+
+    # course_family_role
+    op.create_table(
+        'course_family_role',
+        sa.Column('id', sa.String(255), primary_key=True),
+        sa.Column('title', sa.String(255)),
+        sa.Column('description', sa.String(4096)),
+        sa.Column('builtin', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.CheckConstraint("(NOT builtin) OR ((id)::text ~ '^_'::text)"),
+        sa.CheckConstraint(
+            "(builtin AND computor_valid_slug(SUBSTRING(id FROM 2))) "
+            "OR ((NOT builtin) AND computor_valid_slug((id)::text))"
+        ),
+    )
+
+    # course_family_member
+    op.create_table(
+        'course_family_member',
+        sa.Column(
+            'id', sa.dialects.postgresql.UUID(as_uuid=False),
+            primary_key=True, server_default=sa.text('uuid_generate_v4()'),
+        ),
+        sa.Column('version', sa.BigInteger(), server_default=sa.text('0')),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True),
+            nullable=False, server_default=sa.func.now(),
+        ),
+        sa.Column(
+            'updated_at', sa.DateTime(timezone=True),
+            nullable=False, server_default=sa.func.now(),
+        ),
+        sa.Column(
+            'created_by', sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey('user.id', ondelete='SET NULL'),
+        ),
+        sa.Column(
+            'updated_by', sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey('user.id', ondelete='SET NULL'),
+        ),
+        sa.Column('properties', sa.dialects.postgresql.JSONB()),
+        sa.Column(
+            'user_id', sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey('user.id', ondelete='CASCADE', onupdate='RESTRICT'),
+            nullable=False,
+        ),
+        sa.Column(
+            'course_family_id', sa.dialects.postgresql.UUID(as_uuid=False),
+            sa.ForeignKey('course_family.id', ondelete='CASCADE', onupdate='RESTRICT'),
+            nullable=False,
+        ),
+        sa.Column(
+            'course_family_role_id', sa.String(255),
+            sa.ForeignKey('course_family_role.id', ondelete='RESTRICT', onupdate='RESTRICT'),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        'course_family_member_user_family_key',
+        'course_family_member',
+        ['user_id', 'course_family_id'],
+        unique=True,
+    )
+    op.create_index(
+        'ix_course_family_member_course_family_id',
+        'course_family_member',
+        ['course_family_id'],
+    )
+
+    # Seed builtin roles. Three-level hierarchy: owner > manager > developer.
+    #   _developer  → can read and edit the scope; cannot assign roles
+    #   _manager    → can edit and assign roles, except cannot assign _owner
+    #   _owner      → full control: edit, delete/archive, assign any role
+    op.execute("""
+        INSERT INTO organization_role (id, title, description, builtin) VALUES
+            ('_owner',     'Owner',     'Full control: edit, delete/archive, assign any role.', true),
+            ('_manager',   'Manager',   'Edit and assign roles (except _owner).',               true),
+            ('_developer', 'Developer', 'Edit the organization but cannot assign roles.',       true)
+        ON CONFLICT (id) DO NOTHING;
+    """)
+    op.execute("""
+        INSERT INTO course_family_role (id, title, description, builtin) VALUES
+            ('_owner',     'Owner',     'Full control: edit, delete/archive, assign any role.', true),
+            ('_manager',   'Manager',   'Edit and assign roles (except _owner).',               true),
+            ('_developer', 'Developer', 'Edit the course family but cannot assign roles.',      true)
+        ON CONFLICT (id) DO NOTHING;
+    """)
+
+
+def downgrade() -> None:
+    """Drop scoped role tables (best-effort; data is destroyed)."""
+    op.drop_index('ix_course_family_member_course_family_id', table_name='course_family_member')
+    op.drop_index('course_family_member_user_family_key', table_name='course_family_member')
+    op.drop_table('course_family_member')
+    op.drop_table('course_family_role')
+
+    op.drop_index('ix_organization_member_organization_id', table_name='organization_member')
+    op.drop_index('organization_member_user_org_key', table_name='organization_member')
+    op.drop_table('organization_member')
+    op.drop_table('organization_role')

--- a/computor-backend/src/computor_backend/api/api_builder.py
+++ b/computor-backend/src/computor_backend/api/api_builder.py
@@ -334,6 +334,31 @@ class CrudRouter:
                             entity_id=course_id,
                         )
 
+            # Same shape as course_member: when an organization_member
+            # row is created/updated/deleted the affected user's scoped
+            # claims change, so all of their cached list_courses /
+            # course-detail views are stale until TTL. Clear by user_id;
+            # the org_id tag flushes any current/future caches that get
+            # tagged with the org's id.
+            elif table_name == "organization_member":
+                if hasattr(entity, 'user_id') and entity.user_id is not None:
+                    cache.invalidate_user_views(user_id=str(entity.user_id))
+                if hasattr(entity, 'organization_id') and entity.organization_id is not None:
+                    cache.invalidate_user_views(
+                        entity_type="organization_id",
+                        entity_id=str(entity.organization_id),
+                    )
+
+            # Same as organization_member but scoped to course_family.
+            elif table_name == "course_family_member":
+                if hasattr(entity, 'user_id') and entity.user_id is not None:
+                    cache.invalidate_user_views(user_id=str(entity.user_id))
+                if hasattr(entity, 'course_family_id') and entity.course_family_id is not None:
+                    cache.invalidate_user_views(
+                        entity_type="course_family_id",
+                        entity_id=str(entity.course_family_id),
+                    )
+
             # Handle CourseContent specifically
             elif table_name == "course_content" and hasattr(entity, 'course_id'):
                 # Invalidate all lecturer views for this course

--- a/computor-backend/src/computor_backend/interfaces/__init__.py
+++ b/computor-backend/src/computor_backend/interfaces/__init__.py
@@ -39,6 +39,10 @@ from computor_backend.interfaces.submission_group_members import SubmissionGroup
 from computor_backend.interfaces.submission_groups import SubmissionGroupInterface
 from computor_backend.interfaces.course_groups import CourseGroupInterface
 from computor_backend.interfaces.course_roles import CourseRoleInterface
+from computor_backend.interfaces.organization_roles import OrganizationRoleInterface
+from computor_backend.interfaces.organization_member import OrganizationMemberInterface
+from computor_backend.interfaces.course_family_roles import CourseFamilyRoleInterface
+from computor_backend.interfaces.course_family_member import CourseFamilyMemberInterface
 from computor_backend.interfaces.course_content_types import CourseContentTypeInterface
 from computor_backend.interfaces.course_content_kind import CourseContentKindInterface
 from computor_backend.interfaces.languages import LanguageInterface
@@ -71,6 +75,10 @@ __all__ = [
     "SubmissionGroupInterface",
     "CourseGroupInterface",
     "CourseRoleInterface",
+    "OrganizationRoleInterface",
+    "OrganizationMemberInterface",
+    "CourseFamilyRoleInterface",
+    "CourseFamilyMemberInterface",
     "CourseContentTypeInterface",
     "CourseContentKindInterface",
     "LanguageInterface",

--- a/computor-backend/src/computor_backend/interfaces/course_family.py
+++ b/computor-backend/src/computor_backend/interfaces/course_family.py
@@ -1,6 +1,8 @@
 """Backend CourseFamily interface with SQLAlchemy model."""
 
+import logging
 from typing import Optional
+
 from sqlalchemy.orm import Session
 
 from computor_types.course_families import (
@@ -9,7 +11,46 @@ from computor_types.course_families import (
 )
 from computor_types.custom_types import Ltree
 from computor_backend.interfaces.base import BackendEntityInterface
-from computor_backend.model.course import CourseFamily
+from computor_backend.model.course import CourseFamily, CourseFamilyMember
+
+logger = logging.getLogger(__name__)
+
+
+async def post_create_course_family(course_family, db: Session):
+    """Auto-grant the creating user ``_owner`` on the new course family."""
+    if course_family is None or course_family.created_by is None:
+        return
+    try:
+        existing = (
+            db.query(CourseFamilyMember)
+            .filter(
+                CourseFamilyMember.user_id == course_family.created_by,
+                CourseFamilyMember.course_family_id == course_family.id,
+            )
+            .first()
+        )
+        if existing is not None:
+            return
+
+        member = CourseFamilyMember(
+            user_id=course_family.created_by,
+            course_family_id=course_family.id,
+            course_family_role_id="_owner",
+            created_by=course_family.created_by,
+            updated_by=course_family.created_by,
+        )
+        db.add(member)
+        db.flush()
+        logger.info(
+            "Auto-assigned creator %s as _owner of course_family %s",
+            course_family.created_by,
+            course_family.id,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "Failed to auto-assign creator as _owner for course_family %s",
+            getattr(course_family, "id", None),
+        )
 
 
 class CourseFamilyInterface(CourseFamilyInterfaceBase, BackendEntityInterface):
@@ -18,6 +59,7 @@ class CourseFamilyInterface(CourseFamilyInterfaceBase, BackendEntityInterface):
     model = CourseFamily
     endpoint = "course-families"
     cache_ttl = 600
+    post_create = post_create_course_family
 
     @staticmethod
     def search(db: Session, query, params: Optional[CourseFamilyQuery]):

--- a/computor-backend/src/computor_backend/interfaces/course_family_member.py
+++ b/computor-backend/src/computor_backend/interfaces/course_family_member.py
@@ -10,6 +10,21 @@ from computor_types.course_family_members import (
 )
 from computor_backend.interfaces.base import BackendEntityInterface
 from computor_backend.model.course import CourseFamilyMember
+from computor_backend.permissions.handlers_impl import (
+    make_scope_member_custom_permissions,
+)
+
+
+# See organization_member.py for the rationale: UPDATE must inspect
+# the new-role payload to prevent a ``_manager`` from PATCHing an
+# existing member to ``_owner`` (privilege escalation that the row-
+# level filter alone does not catch).
+custom_permissions_course_family_member = make_scope_member_custom_permissions(
+    CourseFamilyMember,
+    scope="course_family",
+    scope_fk="course_family_id",
+    role_fk="course_family_role_id",
+)
 
 
 class CourseFamilyMemberInterface(
@@ -20,6 +35,7 @@ class CourseFamilyMemberInterface(
     model = CourseFamilyMember
     endpoint = "course-family-members"
     cache_ttl = 300
+    custom_permissions = custom_permissions_course_family_member
 
     @staticmethod
     def search(db: Session, query, params: Optional[CourseFamilyMemberQuery]):

--- a/computor-backend/src/computor_backend/interfaces/course_family_member.py
+++ b/computor-backend/src/computor_backend/interfaces/course_family_member.py
@@ -1,0 +1,41 @@
+"""Backend CourseFamilyMemberInterface with SQLAlchemy model."""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from computor_types.course_family_members import (
+    CourseFamilyMemberInterface as CourseFamilyMemberInterfaceBase,
+    CourseFamilyMemberQuery,
+)
+from computor_backend.interfaces.base import BackendEntityInterface
+from computor_backend.model.course import CourseFamilyMember
+
+
+class CourseFamilyMemberInterface(
+    CourseFamilyMemberInterfaceBase, BackendEntityInterface
+):
+    """Backend-specific CourseFamilyMember interface."""
+
+    model = CourseFamilyMember
+    endpoint = "course-family-members"
+    cache_ttl = 300
+
+    @staticmethod
+    def search(db: Session, query, params: Optional[CourseFamilyMemberQuery]):
+        if params is None:
+            return query
+        if params.id is not None:
+            query = query.filter(CourseFamilyMember.id == params.id)
+        if params.user_id is not None:
+            query = query.filter(CourseFamilyMember.user_id == params.user_id)
+        if params.course_family_id is not None:
+            query = query.filter(
+                CourseFamilyMember.course_family_id == params.course_family_id
+            )
+        if params.course_family_role_id is not None:
+            query = query.filter(
+                CourseFamilyMember.course_family_role_id
+                == params.course_family_role_id
+            )
+        return query

--- a/computor-backend/src/computor_backend/interfaces/course_family_roles.py
+++ b/computor-backend/src/computor_backend/interfaces/course_family_roles.py
@@ -1,0 +1,34 @@
+"""Backend CourseFamilyRoleInterface with SQLAlchemy model."""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from computor_types.course_family_roles import (
+    CourseFamilyRoleInterface as CourseFamilyRoleInterfaceBase,
+    CourseFamilyRoleQuery,
+)
+from computor_backend.interfaces.base import BackendEntityInterface
+from computor_backend.model.course import CourseFamilyRole
+
+
+class CourseFamilyRoleInterface(
+    CourseFamilyRoleInterfaceBase, BackendEntityInterface
+):
+    """Backend-specific CourseFamilyRoleInterface with model and routing."""
+
+    model = CourseFamilyRole
+    endpoint = "course-family-roles"
+    cache_ttl = 600
+
+    @staticmethod
+    def search(db: Session, query, params: Optional[CourseFamilyRoleQuery]):
+        if params is None:
+            return query
+        if params.id is not None:
+            query = query.filter(CourseFamilyRole.id == params.id)
+        if params.title is not None:
+            query = query.filter(CourseFamilyRole.title == params.title)
+        if params.builtin is not None:
+            query = query.filter(CourseFamilyRole.builtin == params.builtin)
+        return query

--- a/computor-backend/src/computor_backend/interfaces/organization.py
+++ b/computor-backend/src/computor_backend/interfaces/organization.py
@@ -1,6 +1,8 @@
 """Backend Organization interface with SQLAlchemy model."""
 
+import logging
 from typing import Optional
+
 from sqlalchemy.orm import Session
 
 from computor_types.organizations import (
@@ -9,7 +11,55 @@ from computor_types.organizations import (
 )
 from computor_types.custom_types import Ltree
 from computor_backend.interfaces.base import BackendEntityInterface
-from computor_backend.model.organization import Organization
+from computor_backend.model.organization import (
+    Organization,
+    OrganizationMember,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def post_create_organization(organization, db: Session):
+    """Auto-grant the creating user ``_owner`` on the new organization.
+
+    Without this, a non-admin user who has the global
+    ``organization:create`` permission could create an organization but
+    would have no scoped role on it afterwards — locking themselves out
+    of editing it. Admins skip this (they already bypass scope checks).
+    """
+    if organization is None or organization.created_by is None:
+        return
+    try:
+        existing = (
+            db.query(OrganizationMember)
+            .filter(
+                OrganizationMember.user_id == organization.created_by,
+                OrganizationMember.organization_id == organization.id,
+            )
+            .first()
+        )
+        if existing is not None:
+            return
+
+        member = OrganizationMember(
+            user_id=organization.created_by,
+            organization_id=organization.id,
+            organization_role_id="_owner",
+            created_by=organization.created_by,
+            updated_by=organization.created_by,
+        )
+        db.add(member)
+        db.flush()
+        logger.info(
+            "Auto-assigned creator %s as _owner of organization %s",
+            organization.created_by,
+            organization.id,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "Failed to auto-assign creator as _owner for organization %s",
+            getattr(organization, "id", None),
+        )
 
 
 class OrganizationInterface(OrganizationInterfaceBase, BackendEntityInterface):
@@ -18,6 +68,7 @@ class OrganizationInterface(OrganizationInterfaceBase, BackendEntityInterface):
     model = Organization
     endpoint = "organizations"
     cache_ttl = 600
+    post_create = post_create_organization
 
     @staticmethod
     def search(db: Session, query, params: Optional[OrganizationQuery]):

--- a/computor-backend/src/computor_backend/interfaces/organization_member.py
+++ b/computor-backend/src/computor_backend/interfaces/organization_member.py
@@ -1,0 +1,40 @@
+"""Backend OrganizationMemberInterface with SQLAlchemy model."""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from computor_types.organization_members import (
+    OrganizationMemberInterface as OrganizationMemberInterfaceBase,
+    OrganizationMemberQuery,
+)
+from computor_backend.interfaces.base import BackendEntityInterface
+from computor_backend.model.organization import OrganizationMember
+
+
+class OrganizationMemberInterface(
+    OrganizationMemberInterfaceBase, BackendEntityInterface
+):
+    """Backend-specific OrganizationMember interface."""
+
+    model = OrganizationMember
+    endpoint = "organization-members"
+    cache_ttl = 300
+
+    @staticmethod
+    def search(db: Session, query, params: Optional[OrganizationMemberQuery]):
+        if params is None:
+            return query
+        if params.id is not None:
+            query = query.filter(OrganizationMember.id == params.id)
+        if params.user_id is not None:
+            query = query.filter(OrganizationMember.user_id == params.user_id)
+        if params.organization_id is not None:
+            query = query.filter(
+                OrganizationMember.organization_id == params.organization_id
+            )
+        if params.organization_role_id is not None:
+            query = query.filter(
+                OrganizationMember.organization_role_id == params.organization_role_id
+            )
+        return query

--- a/computor-backend/src/computor_backend/interfaces/organization_member.py
+++ b/computor-backend/src/computor_backend/interfaces/organization_member.py
@@ -10,6 +10,21 @@ from computor_types.organization_members import (
 )
 from computor_backend.interfaces.base import BackendEntityInterface
 from computor_backend.model.organization import OrganizationMember
+from computor_backend.permissions.handlers_impl import (
+    make_scope_member_custom_permissions,
+)
+
+
+# UPDATE goes through ``custom_permissions`` instead of the generic
+# ``build_query`` path, so we can inspect the *new* role being assigned
+# in the payload — a ``_manager`` must not be able to PATCH a member
+# to ``_owner``, even if they are otherwise allowed to edit the row.
+custom_permissions_organization_member = make_scope_member_custom_permissions(
+    OrganizationMember,
+    scope="organization",
+    scope_fk="organization_id",
+    role_fk="organization_role_id",
+)
 
 
 class OrganizationMemberInterface(
@@ -20,6 +35,7 @@ class OrganizationMemberInterface(
     model = OrganizationMember
     endpoint = "organization-members"
     cache_ttl = 300
+    custom_permissions = custom_permissions_organization_member
 
     @staticmethod
     def search(db: Session, query, params: Optional[OrganizationMemberQuery]):

--- a/computor-backend/src/computor_backend/interfaces/organization_roles.py
+++ b/computor-backend/src/computor_backend/interfaces/organization_roles.py
@@ -1,0 +1,34 @@
+"""Backend OrganizationRoleInterface with SQLAlchemy model."""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from computor_types.organization_roles import (
+    OrganizationRoleInterface as OrganizationRoleInterfaceBase,
+    OrganizationRoleQuery,
+)
+from computor_backend.interfaces.base import BackendEntityInterface
+from computor_backend.model.organization import OrganizationRole
+
+
+class OrganizationRoleInterface(
+    OrganizationRoleInterfaceBase, BackendEntityInterface
+):
+    """Backend-specific OrganizationRoleInterface with model and routing."""
+
+    model = OrganizationRole
+    endpoint = "organization-roles"
+    cache_ttl = 600
+
+    @staticmethod
+    def search(db: Session, query, params: Optional[OrganizationRoleQuery]):
+        if params is None:
+            return query
+        if params.id is not None:
+            query = query.filter(OrganizationRole.id == params.id)
+        if params.title is not None:
+            query = query.filter(OrganizationRole.title == params.title)
+        if params.builtin is not None:
+            query = query.filter(OrganizationRole.builtin == params.builtin)
+        return query

--- a/computor-backend/src/computor_backend/model/__init__.py
+++ b/computor-backend/src/computor_backend/model/__init__.py
@@ -1,11 +1,13 @@
 from .base import Base, metadata
 from .auth import User, Account, Profile, StudentProfile, Session
 from .language import Language
-from .organization import Organization
+from .organization import Organization, OrganizationRole, OrganizationMember
 from .course import (
     CourseContentKind,
     CourseRole,
     CourseFamily,
+    CourseFamilyRole,
+    CourseFamilyMember,
     Course,
     CourseContentType,
     CourseGroup,
@@ -57,10 +59,14 @@ __all__ = [
     'Language',
     # Organization
     'Organization',
+    'OrganizationRole',
+    'OrganizationMember',
     # Course models
     'CourseContentKind',
     'CourseRole',
     'CourseFamily',
+    'CourseFamilyRole',
+    'CourseFamilyMember',
     'Course',
     'CourseContentType',
     'CourseGroup',

--- a/computor-backend/src/computor_backend/model/course.py
+++ b/computor-backend/src/computor_backend/model/course.py
@@ -83,6 +83,92 @@ class CourseFamily(Base):
     updated_by_user = relationship('User', foreign_keys=[updated_by])
     organization = relationship('Organization', back_populates='course_families')
     courses = relationship('Course', back_populates='course_family')
+    course_family_members = relationship(
+        'CourseFamilyMember',
+        back_populates='course_family',
+        cascade='all, delete-orphan',
+    )
+
+
+class CourseFamilyRole(Base):
+    """Per-course-family role analogous to CourseRole.
+
+    Role IDs are scoped to this table; built-in roles seeded via
+    migration: ``_owner``, ``_manager``.
+    """
+    __tablename__ = 'course_family_role'
+    __table_args__ = (
+        CheckConstraint("(NOT builtin) OR ((id)::text ~ '^_'::text)"),
+        CheckConstraint(
+            "(builtin AND computor_valid_slug(SUBSTRING(id FROM 2))) "
+            "OR ((NOT builtin) AND computor_valid_slug((id)::text))"
+        ),
+    )
+
+    id = Column(String(255), primary_key=True)
+    title = Column(String(255))
+    description = Column(String(4096))
+    builtin = Column(Boolean, nullable=False, server_default=text("false"))
+
+    course_family_members = relationship(
+        'CourseFamilyMember', back_populates='course_family_role'
+    )
+
+
+class CourseFamilyMember(Base):
+    """Membership linking a user to a course_family with a scoped role.
+
+    Independent of ``organization_member`` and ``course_member`` — does
+    not cascade up or down. Used for write/admin authorization on the
+    course_family. Read visibility continues to use course-membership
+    cascade.
+    """
+    __tablename__ = 'course_family_member'
+    __table_args__ = (
+        Index(
+            'course_family_member_user_family_key',
+            'user_id', 'course_family_id',
+            unique=True,
+        ),
+    )
+
+    id = Column(UUID, primary_key=True, server_default=text("uuid_generate_v4()"))
+    version = Column(BigInteger, server_default=text("0"))
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    created_by = Column(ForeignKey('user.id', ondelete='SET NULL'))
+    updated_by = Column(ForeignKey('user.id', ondelete='SET NULL'))
+    properties = Column(JSONB)
+
+    user_id = Column(
+        ForeignKey('user.id', ondelete='CASCADE', onupdate='RESTRICT'),
+        nullable=False,
+    )
+    course_family_id = Column(
+        ForeignKey('course_family.id', ondelete='CASCADE', onupdate='RESTRICT'),
+        nullable=False,
+        index=True,
+    )
+    course_family_role_id = Column(
+        ForeignKey(
+            'course_family_role.id', ondelete='RESTRICT', onupdate='RESTRICT'
+        ),
+        nullable=False,
+    )
+
+    user = relationship('User', foreign_keys=[user_id])
+    course_family = relationship(
+        'CourseFamily', back_populates='course_family_members'
+    )
+    course_family_role = relationship(
+        'CourseFamilyRole', back_populates='course_family_members'
+    )
+    created_by_user = relationship('User', foreign_keys=[created_by])
+    updated_by_user = relationship('User', foreign_keys=[updated_by])
 
 
 class Course(Base):

--- a/computor-backend/src/computor_backend/model/organization.py
+++ b/computor-backend/src/computor_backend/model/organization.py
@@ -1,5 +1,5 @@
 from sqlalchemy import (
-    BigInteger, CheckConstraint, Column, DateTime, 
+    BigInteger, Boolean, CheckConstraint, Column, DateTime,
     Enum, ForeignKey, Index, String, text, Computed
 , func)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -60,3 +60,87 @@ class Organization(Base):
     courses = relationship('Course', back_populates='organization', uselist=True, lazy='select')
     example_repositories = relationship('ExampleRepository', back_populates='organization', uselist=True, lazy='select')
     student_profiles = relationship('StudentProfile', back_populates='organization', uselist=True, lazy='select')
+    organization_members = relationship(
+        'OrganizationMember',
+        back_populates='organization',
+        cascade='all, delete-orphan',
+    )
+
+
+class OrganizationRole(Base):
+    """Per-organization role analogous to CourseRole.
+
+    Role IDs are scoped to this table (no clash with course_role / role).
+    Built-in roles seeded via migration: ``_owner``, ``_manager``.
+    """
+    __tablename__ = 'organization_role'
+    __table_args__ = (
+        CheckConstraint("(NOT builtin) OR ((id)::text ~ '^_'::text)"),
+        CheckConstraint(
+            "(builtin AND computor_valid_slug(SUBSTRING(id FROM 2))) "
+            "OR ((NOT builtin) AND computor_valid_slug((id)::text))"
+        ),
+    )
+
+    id = Column(String(255), primary_key=True)
+    title = Column(String(255))
+    description = Column(String(4096))
+    builtin = Column(Boolean, nullable=False, server_default=text("false"))
+
+    organization_members = relationship(
+        'OrganizationMember', back_populates='organization_role'
+    )
+
+
+class OrganizationMember(Base):
+    """Membership linking a user to an organization with a scoped role.
+
+    Independent of ``course_member`` — does not cascade up or down. Used
+    for write/admin authorization (create/update/delete on the org and
+    descendants where applicable). Read visibility for organizations
+    continues to use the course-membership cascade.
+    """
+    __tablename__ = 'organization_member'
+    __table_args__ = (
+        Index(
+            'organization_member_user_org_key',
+            'user_id', 'organization_id',
+            unique=True,
+        ),
+    )
+
+    id = Column(UUID, primary_key=True, server_default=text("uuid_generate_v4()"))
+    version = Column(BigInteger, server_default=text("0"))
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    created_by = Column(ForeignKey('user.id', ondelete='SET NULL'))
+    updated_by = Column(ForeignKey('user.id', ondelete='SET NULL'))
+    properties = Column(JSONB)
+
+    user_id = Column(
+        ForeignKey('user.id', ondelete='CASCADE', onupdate='RESTRICT'),
+        nullable=False,
+    )
+    organization_id = Column(
+        ForeignKey('organization.id', ondelete='CASCADE', onupdate='RESTRICT'),
+        nullable=False,
+        index=True,
+    )
+    organization_role_id = Column(
+        ForeignKey('organization_role.id', ondelete='RESTRICT', onupdate='RESTRICT'),
+        nullable=False,
+    )
+
+    user = relationship('User', foreign_keys=[user_id])
+    organization = relationship(
+        'Organization', back_populates='organization_members'
+    )
+    organization_role = relationship(
+        'OrganizationRole', back_populates='organization_members'
+    )
+    created_by_user = relationship('User', foreign_keys=[created_by])
+    updated_by_user = relationship('User', foreign_keys=[updated_by])

--- a/computor-backend/src/computor_backend/permissions/auth.py
+++ b/computor-backend/src/computor_backend/permissions/auth.py
@@ -52,7 +52,12 @@ import logging
 
 # Import refactored permission components
 from computor_backend.permissions.principal import Principal, build_claims
-from computor_backend.permissions.core import db_get_claims, db_get_course_claims
+from computor_backend.permissions.core import (
+    db_get_claims,
+    db_get_course_claims,
+    db_get_organization_claims,
+    db_get_course_family_claims,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -311,9 +316,12 @@ class PrincipalBuilder:
         # Get user claims from database
         claim_values = db_get_claims(auth_result.user_id, db)
 
-        # Get course-specific claims
-        course_claims = db_get_course_claims(auth_result.user_id, db)
-        claim_values.extend(course_claims)
+        # Get scoped claims (course / organization / course_family). Each
+        # emits ``("permissions", "<scope>:<role>:<scope_id>")`` tuples
+        # which build_claims files under Claims.dependent[<scope>].
+        claim_values.extend(db_get_course_claims(auth_result.user_id, db))
+        claim_values.extend(db_get_organization_claims(auth_result.user_id, db))
+        claim_values.extend(db_get_course_family_claims(auth_result.user_id, db))
 
         # Convert API token scopes to claims (if present)
         # API token scopes use the same format as claims: "resource:action" or "resource:action:resource_id"

--- a/computor-backend/src/computor_backend/permissions/core.py
+++ b/computor-backend/src/computor_backend/permissions/core.py
@@ -16,7 +16,9 @@ from computor_backend.permissions.handlers_impl import (
     StudentProfilePermissionHandler,
     CoursePermissionHandler,
     OrganizationPermissionHandler,
+    OrganizationMemberPermissionHandler,
     CourseFamilyPermissionHandler,
+    CourseFamilyMemberPermissionHandler,
     CourseContentTypePermissionHandler,
     CourseContentPermissionHandler,
     CourseMemberPermissionHandler,
@@ -39,10 +41,15 @@ from computor_backend.model.auth import User, Account, Profile, StudentProfile, 
 from computor_backend.model.course import (
     Course, CourseFamily, CourseMember, CourseContent,
     CourseContentType, CourseContentKind, CourseRole, CourseGroup,
+    CourseFamilyRole, CourseFamilyMember,
     CourseMemberComment,
     SubmissionGroup, SubmissionGroupMember
 )
-from computor_backend.model.organization import Organization
+from computor_backend.model.organization import (
+    Organization,
+    OrganizationRole,
+    OrganizationMember,
+)
 from computor_backend.model.result import Result
 from computor_backend.model.message import Message
 from computor_backend.model.artifact import (
@@ -82,8 +89,14 @@ def initialize_permission_handlers():
     
     # Read-only entities
     permission_registry.register(CourseRole, ReadOnlyPermissionHandler(CourseRole))
+    permission_registry.register(OrganizationRole, ReadOnlyPermissionHandler(OrganizationRole))
+    permission_registry.register(CourseFamilyRole, ReadOnlyPermissionHandler(CourseFamilyRole))
     permission_registry.register(CourseContentKind, ReadOnlyPermissionHandler(CourseContentKind))
     permission_registry.register(Language, ReadOnlyPermissionHandler(Language))
+
+    # Scoped membership entities
+    permission_registry.register(OrganizationMember, OrganizationMemberPermissionHandler(OrganizationMember))
+    permission_registry.register(CourseFamilyMember, CourseFamilyMemberPermissionHandler(CourseFamilyMember))
     
     # Example entities (lecturer-only access)
     permission_registry.register(Example, ExamplePermissionHandler(Example))
@@ -321,8 +334,50 @@ def db_get_course_claims(user_id: str, db: Session) -> List[tuple]: #TODO: PERMI
             ("permissions", f"{Example.__tablename__}:upload"),
             ("permissions", f"{Example.__tablename__}:download"),
         ])
-    
+
     return course_claims
+
+
+def db_get_organization_claims(user_id: str, db: Session) -> List[tuple]:
+    """Synthesize organization-scoped role claims for a user.
+
+    Emits one claim per ``organization_member`` row, in the form
+    ``("permissions", f"organization:<role>:<org_id>")`` — the same
+    shape as ``course:<role>:<course_id>`` so ``build_claims`` files it
+    under ``Claims.dependent["organization"]``.
+    """
+    rows = (
+        db.query(
+            OrganizationMember.organization_id,
+            OrganizationMember.organization_role_id,
+        )
+        .filter(OrganizationMember.user_id == user_id)
+        .all()
+    )
+    return [
+        ("permissions", f"organization:{role_id}:{org_id}")
+        for org_id, role_id in rows
+    ]
+
+
+def db_get_course_family_claims(user_id: str, db: Session) -> List[tuple]:
+    """Synthesize course_family-scoped role claims for a user.
+
+    Emits one claim per ``course_family_member`` row, in the form
+    ``("permissions", f"course_family:<role>:<family_id>")``.
+    """
+    rows = (
+        db.query(
+            CourseFamilyMember.course_family_id,
+            CourseFamilyMember.course_family_role_id,
+        )
+        .filter(CourseFamilyMember.user_id == user_id)
+        .all()
+    )
+    return [
+        ("permissions", f"course_family:{role_id}:{family_id}")
+        for family_id, role_id in rows
+    ]
 
 
 def db_get_roles_claims(user_id: str, db: Session) -> tuple:

--- a/computor-backend/src/computor_backend/permissions/handlers_impl.py
+++ b/computor-backend/src/computor_backend/permissions/handlers_impl.py
@@ -992,14 +992,13 @@ class _ScopeMemberPermissionHandler(PermissionHandler):
 
     A user always sees their own membership row regardless of role.
 
-    Note: for ``update``, this handler restricts which rows are visible
-    to the update query but does NOT inspect the *new* role payload —
-    that means a manager can in theory promote an existing manager/
-    developer membership to ``_owner`` via PATCH. Tightening that would
-    require either a custom-permissions hook with payload access or
-    moving the role-change rule into the business-logic layer. Tracked
-    as a follow-up; the seam to do it is the ``custom_permissions``
-    attribute on ``BackendEntityInterface``.
+    The ``UPDATE`` path uses a ``custom_permissions`` callable
+    (``make_scope_member_custom_permissions`` below) to additionally
+    inspect the new-role payload — this prevents a manager from
+    promoting an existing membership to ``_owner`` via PATCH, which
+    the row-level filter alone would not catch. ``DELETE`` does not
+    need the extra hook because ``build_query`` already excludes
+    ``_owner`` rows from a manager's deletable set.
     """
 
     SCOPE: str = ""
@@ -1104,3 +1103,66 @@ class CourseFamilyMemberPermissionHandler(_ScopeMemberPermissionHandler):
     SCOPE = "course_family"
     SCOPE_FK = "course_family_id"
     ROLE_FK = "course_family_role_id"
+
+
+def make_scope_member_custom_permissions(
+    model: type, scope: str, scope_fk: str, role_fk: str
+):
+    """Return a ``custom_permissions`` callable for a scoped member entity.
+
+    The build_query filter already restricts which rows a principal can
+    delete (a ``_manager`` cannot see ``_owner`` rows), but UPDATE goes
+    through ``custom_permissions`` and the row-level filter alone does
+    not inspect the *new* role being assigned. This callable closes
+    that gap by examining the request payload:
+
+    * Reject the update if the row does not exist (NotFound -> empty).
+    * Require the principal to have at least ``_manager`` on the scope.
+    * Reject if the row is currently ``_owner`` and the principal is
+      not ``_owner`` (a manager cannot demote an owner).
+    * Reject if the payload tries to set the role to ``_owner`` and the
+      principal is not ``_owner`` (a manager cannot promote to owner).
+
+    Returns a passthrough query that the CRUD layer narrows to ``id``.
+    """
+
+    def custom_permissions(
+        principal: Principal,
+        db: Session,
+        id,
+        entity,
+    ) -> Query:
+        if principal.is_admin:
+            return db.query(model)
+
+        row = db.query(model).filter(model.id == id).first()
+        if row is None:
+            return db.query(model).filter(model.id == id)
+
+        scope_id = str(getattr(row, scope_fk))
+        current_role = getattr(row, role_fk)
+
+        if not principal.has_scope_role(scope, scope_id, "_manager"):
+            raise ForbiddenException(
+                detail=(
+                    f"You need at least _manager on this {scope} to modify "
+                    "its memberships."
+                )
+            )
+
+        is_scope_owner = principal.has_scope_role(scope, scope_id, "_owner")
+
+        if current_role == "_owner" and not is_scope_owner:
+            raise ForbiddenException(
+                detail="Only an _owner of this scope can modify an _owner membership."
+            )
+
+        new_role = getattr(entity, role_fk, None)
+        if new_role is not None and new_role == "_owner" and not is_scope_owner:
+            raise ForbiddenException(
+                detail="Only an _owner of this scope can grant the _owner role."
+            )
+
+        return db.query(model)
+
+    return custom_permissions

--- a/computor-backend/src/computor_backend/permissions/handlers_impl.py
+++ b/computor-backend/src/computor_backend/permissions/handlers_impl.py
@@ -237,99 +237,181 @@ class CoursePermissionHandler(PermissionHandler):
 
 
 class OrganizationPermissionHandler(PermissionHandler):
-    """Permission handler for Organization entity"""
-    
-    ACTION_ROLE_MAP = {
-        "get": "_student",
-        "list": "_student",
-        "update": None,  # Only through general permission
-        "create": None,  # Only through general permission
-        "delete": None   # Only through general permission
+    """Permission handler for Organization entity.
+
+    Read visibility is *additive*: a principal sees an organization if
+    any of these is true (admin / general permission shortcut aside) —
+
+    - they are a member of any course inside the org (existing behavior,
+      kept for back-compat: course role cascade UP for read only); or
+    - they are an OrganizationMember with any scoped role on the org.
+
+    Write actions (``update`` / ``delete``) require an explicit scoped
+    role on the org itself (or admin / general permission). Scoped
+    roles do NOT cascade between scopes — being an org ``_owner`` does
+    not grant any course_family or course privilege.
+    """
+
+    # Course-membership cascade only powers the read filter.
+    READ_COURSE_ROLE = "_student"
+
+    ACTION_ORG_ROLE_MAP = {
+        # update / archive / delete: developer can edit, owner-only deletes.
+        "update": "_developer",
+        "archive": "_owner",
+        "delete": "_owner",
     }
-    
-    def can_perform_action(self, principal: Principal, action: str, resource_id: Optional[str] = None, context: Optional[dict] = None) -> bool:
+
+    def can_perform_action(
+        self,
+        principal: Principal,
+        action: str,
+        resource_id: Optional[str] = None,
+        context: Optional[dict] = None,
+    ) -> bool:
         if self.check_admin(principal):
             return True
-        
+
         if self.check_general_permission(principal, action):
             return True
-        
-        # Users can view organizations of courses they're in
-        if action in ["get", "list"]:
-            return True  # Will be filtered by query
-        
+
+        if action in ("get", "list"):
+            return True  # build_query applies the actual filter
+
+        min_org_role = self.ACTION_ORG_ROLE_MAP.get(action)
+        if min_org_role and resource_id:
+            return principal.has_organization_role(resource_id, min_org_role)
+
         return False
-    
+
     def build_query(self, principal: Principal, action: str, db: Session) -> Query:
         if self.check_admin(principal):
             return db.query(self.entity)
-        
+
         if self.check_general_permission(principal, action):
             return db.query(self.entity)
-        
-        min_role = self.ACTION_ROLE_MAP.get(action)
-        if min_role:
-            return OrganizationPermissionQueryBuilder.filter_by_course_organization(
-                self.entity, principal.user_id, min_role, db
+
+        if action in ("get", "list"):
+            # Visible if course-cascade OR org_member: union of two id sets.
+            from sqlalchemy import or_
+
+            course_subquery = (
+                CoursePermissionQueryBuilder.user_courses_subquery(
+                    principal.user_id, self.READ_COURSE_ROLE, db
+                )
             )
-        
+            from computor_backend.model.course import Course as _Course
+
+            org_via_course = (
+                db.query(_Course.organization_id)
+                .filter(_Course.id.in_(course_subquery))
+            )
+
+            org_via_member_ids = principal.get_scoped_ids_with_role(
+                "organization", "_developer"
+            )
+            # _developer is the lowest scoped role; hierarchy includes
+            # _manager and _owner.
+
+            return db.query(self.entity).filter(
+                or_(
+                    self.entity.id.in_(org_via_course),
+                    self.entity.id.in_(org_via_member_ids)
+                    if org_via_member_ids
+                    else False,
+                )
+            )
+
+        min_org_role = self.ACTION_ORG_ROLE_MAP.get(action)
+        if min_org_role:
+            org_ids = principal.get_scoped_ids_with_role("organization", min_org_role)
+            if not org_ids:
+                # Empty filter → empty result, not a 403.
+                return db.query(self.entity).filter(self.entity.id.in_([]))
+            return db.query(self.entity).filter(self.entity.id.in_(org_ids))
+
         raise ForbiddenException(detail={"entity": self.resource_name})
 
 
 class CourseFamilyPermissionHandler(PermissionHandler):
-    """Permission handler for CourseFamily entity"""
-    
-    ACTION_ROLE_MAP = {
-        "get": "_student",
-        "list": "_student",
-        "update": None,  # Only through general permission
-        "create": None,  # Only through general permission
-        "delete": None   # Only through general permission
+    """Permission handler for CourseFamily entity.
+
+    Symmetric to ``OrganizationPermissionHandler``. Read visibility is
+    additive (course-membership cascade UP, plus explicit scoped role
+    on the family). Write actions need an explicit scoped role on the
+    family itself.
+    """
+
+    READ_COURSE_ROLE = "_student"
+
+    ACTION_FAMILY_ROLE_MAP = {
+        "update": "_developer",
+        "archive": "_owner",
+        "delete": "_owner",
     }
-    
-    def can_perform_action(self, principal: Principal, action: str, resource_id: Optional[str] = None, context: Optional[dict] = None) -> bool:
+
+    def can_perform_action(
+        self,
+        principal: Principal,
+        action: str,
+        resource_id: Optional[str] = None,
+        context: Optional[dict] = None,
+    ) -> bool:
         if self.check_admin(principal):
             return True
-        
+
         if self.check_general_permission(principal, action):
             return True
-        
-        if action in ["get", "list"]:
-            return True  # Will be filtered by query
-        
+
+        if action in ("get", "list"):
+            return True
+
+        min_family_role = self.ACTION_FAMILY_ROLE_MAP.get(action)
+        if min_family_role and resource_id:
+            return principal.has_course_family_role(resource_id, min_family_role)
+
         return False
-    
+
     def build_query(self, principal: Principal, action: str, db: Session) -> Query:
         if self.check_admin(principal):
             return db.query(self.entity)
-        
+
         if self.check_general_permission(principal, action):
             return db.query(self.entity)
-        
-        min_role = self.ACTION_ROLE_MAP.get(action)
-        if min_role:
-            from sqlalchemy.orm import aliased
-            from sqlalchemy import select
-            
-            cm_other = aliased(CourseMember)
-            
-            subquery = CoursePermissionQueryBuilder.user_courses_subquery(
-                principal.user_id, min_role, db
+
+        if action in ("get", "list"):
+            from sqlalchemy import or_
+
+            course_subquery = CoursePermissionQueryBuilder.user_courses_subquery(
+                principal.user_id, self.READ_COURSE_ROLE, db
             )
-            
-            query = (
-                db.query(self.entity)
-                .select_from(User)
-                .outerjoin(cm_other, cm_other.user_id == User.id)
-                .outerjoin(Course, cm_other.course_id == Course.id)
-                .outerjoin(self.entity, self.entity.id == Course.course_family_id)
-                .filter(
-                    cm_other.course_id.in_(subquery)
+            family_via_course = (
+                db.query(Course.course_family_id)
+                .filter(Course.id.in_(course_subquery))
+            )
+
+            family_via_member_ids = principal.get_scoped_ids_with_role(
+                "course_family", "_developer"
+            )
+
+            return db.query(self.entity).filter(
+                or_(
+                    self.entity.id.in_(family_via_course),
+                    self.entity.id.in_(family_via_member_ids)
+                    if family_via_member_ids
+                    else False,
                 )
             )
-            
-            return query
-        
+
+        min_family_role = self.ACTION_FAMILY_ROLE_MAP.get(action)
+        if min_family_role:
+            family_ids = principal.get_scoped_ids_with_role(
+                "course_family", min_family_role
+            )
+            if not family_ids:
+                return db.query(self.entity).filter(self.entity.id.in_([]))
+            return db.query(self.entity).filter(self.entity.id.in_(family_ids))
+
         raise ForbiddenException(detail={"entity": self.resource_name})
 
 
@@ -886,3 +968,139 @@ class MessagePermissionHandler(PermissionHandler):
             )
 
         return query
+
+
+class _ScopeMemberPermissionHandler(PermissionHandler):
+    """Shared logic for OrganizationMember / CourseFamilyMember handlers.
+
+    Subclasses set:
+
+    * ``SCOPE``  — the claim namespace, e.g. ``"organization"`` /
+      ``"course_family"``;
+    * ``SCOPE_FK`` — column on the entity pointing to the parent scope,
+      e.g. ``"organization_id"``;
+    * ``ROLE_FK`` — column on the entity holding the assigned role,
+      e.g. ``"organization_role_id"``.
+
+    Permission model:
+
+    * ``_developer``  → read scope only; cannot read/write members.
+    * ``_manager``    → read all members of the scope; create / update /
+                        delete members whose role is **not** ``_owner``.
+                        A manager cannot grant or revoke ``_owner``.
+    * ``_owner``      → full CRUD on members, including ``_owner`` rows.
+
+    A user always sees their own membership row regardless of role.
+
+    Note: for ``update``, this handler restricts which rows are visible
+    to the update query but does NOT inspect the *new* role payload —
+    that means a manager can in theory promote an existing manager/
+    developer membership to ``_owner`` via PATCH. Tightening that would
+    require either a custom-permissions hook with payload access or
+    moving the role-change rule into the business-logic layer. Tracked
+    as a follow-up; the seam to do it is the ``custom_permissions``
+    attribute on ``BackendEntityInterface``.
+    """
+
+    SCOPE: str = ""
+    SCOPE_FK: str = ""
+    ROLE_FK: str = ""
+
+    def can_perform_action(
+        self,
+        principal: Principal,
+        action: str,
+        resource_id: Optional[str] = None,
+        context: Optional[dict] = None,
+    ) -> bool:
+        if self.check_admin(principal):
+            return True
+        if self.check_general_permission(principal, action):
+            return True
+
+        if action == "create":
+            ctx = context or {}
+            scope_id = ctx.get(self.SCOPE_FK)
+            target_role = ctx.get(self.ROLE_FK)
+            if not scope_id or not target_role:
+                return False
+            scope_id = str(scope_id)
+            # Owner can assign any role.
+            if principal.has_scope_role(self.SCOPE, scope_id, "_owner"):
+                return True
+            # Manager can assign anything except _owner.
+            if (
+                principal.has_scope_role(self.SCOPE, scope_id, "_manager")
+                and target_role != "_owner"
+            ):
+                return True
+            return False
+
+        if action in ("update", "delete") and resource_id:
+            # build_query applies the row-level restriction.
+            return True
+
+        if action in ("list", "get"):
+            return True
+
+        return False
+
+    def build_query(self, principal: Principal, action: str, db: Session) -> Query:
+        from sqlalchemy import and_, or_
+
+        scope_fk = getattr(self.entity, self.SCOPE_FK)
+        role_fk = getattr(self.entity, self.ROLE_FK)
+
+        if self.check_admin(principal):
+            return db.query(self.entity)
+        if self.check_general_permission(principal, action):
+            return db.query(self.entity)
+
+        owner_scopes = principal.get_scoped_ids_with_role(self.SCOPE, "_owner")
+        manager_scopes = principal.get_scoped_ids_with_role(self.SCOPE, "_manager")
+        # Restrict manager-only set to scopes where principal is NOT owner,
+        # so each filter clause stays well-defined.
+        manager_only_scopes = manager_scopes - owner_scopes
+
+        if action in ("update", "delete"):
+            clauses = []
+            if owner_scopes:
+                # Owners can edit any row in their scopes.
+                clauses.append(scope_fk.in_(owner_scopes))
+            if manager_only_scopes:
+                # Managers can edit non-_owner rows only.
+                clauses.append(
+                    and_(
+                        scope_fk.in_(manager_only_scopes),
+                        role_fk != "_owner",
+                    )
+                )
+            if not clauses:
+                return db.query(self.entity).filter(self.entity.id.in_([]))
+            return db.query(self.entity).filter(or_(*clauses))
+
+        if action in ("list", "get"):
+            # Members of the scope visible to anyone with at least
+            # _manager (they need to see the roster). Plus the user's
+            # own membership row.
+            visible_scopes = owner_scopes | manager_only_scopes
+            user_filter = self.entity.user_id == principal.user_id
+            if visible_scopes:
+                return db.query(self.entity).filter(
+                    or_(scope_fk.in_(visible_scopes), user_filter)
+                )
+            return db.query(self.entity).filter(user_filter)
+
+        raise ForbiddenException(detail={"entity": self.resource_name})
+
+
+class OrganizationMemberPermissionHandler(_ScopeMemberPermissionHandler):
+    SCOPE = "organization"
+    SCOPE_FK = "organization_id"
+    ROLE_FK = "organization_role_id"
+
+
+class CourseFamilyMemberPermissionHandler(_ScopeMemberPermissionHandler):
+    SCOPE = "course_family"
+    SCOPE_FK = "course_family_id"
+    ROLE_FK = "course_family_role_id"

--- a/computor-backend/src/computor_backend/permissions/principal.py
+++ b/computor-backend/src/computor_backend/permissions/principal.py
@@ -6,10 +6,48 @@ from computor_backend.api.exceptions import NotFoundException
 from functools import lru_cache
 
 
-class CourseRoleHierarchy:
-    """Manages course role hierarchy and inheritance"""
+class ScopedRoleHierarchy:
+    """Generic per-scope role hierarchy.
 
-    # Default hierarchy - can be made configurable later
+    A scope is e.g. ``course``, ``organization``, ``course_family``.
+    For each scope we maintain a mapping of ``role -> [roles that
+    satisfy this role]`` (the role itself plus any higher role) and a
+    numeric level mapping for comparisons.
+
+    The class is intentionally minimal so the same machinery powers
+    course roles, organization roles, and course-family roles.
+    """
+
+    def __init__(
+        self,
+        hierarchy: Dict[str, List[str]],
+        levels: Dict[str, int],
+    ) -> None:
+        self.hierarchy = hierarchy
+        self.levels = levels
+
+    @lru_cache(maxsize=128)
+    def get_allowed_roles(self, role: str) -> List[str]:
+        """Roles that meet or exceed the given role (incl. the role itself)."""
+        return self.hierarchy.get(role, [])
+
+    def has_role_permission(self, user_role: str, required_role: str) -> bool:
+        return user_role in self.get_allowed_roles(required_role)
+
+    def get_role_level(self, role: str) -> int:
+        return self.levels.get(role, 0)
+
+    def can_assign_role(self, assigner_role: str, target_role: str) -> bool:
+        return self.get_role_level(assigner_role) >= self.get_role_level(target_role)
+
+
+# Course role hierarchy — kept for back-compat under its previous name.
+# ``CourseRoleHierarchy`` (legacy class name) and ``course_role_hierarchy``
+# (legacy module-level instance) remain importable from existing call
+# sites; both are now backed by the generic ``ScopedRoleHierarchy``.
+class CourseRoleHierarchy(ScopedRoleHierarchy):
+    """Backwards-compatible course-role hierarchy."""
+
     DEFAULT_HIERARCHY = {
         "_owner": ["_owner"],
         "_maintainer": ["_maintainer", "_owner"],
@@ -17,8 +55,6 @@ class CourseRoleHierarchy:
         "_tutor": ["_tutor", "_lecturer", "_maintainer", "_owner"],
         "_student": ["_student", "_tutor", "_lecturer", "_maintainer", "_owner"],
     }
-
-    # Numeric levels for role comparison (higher = more privilege)
     ROLE_LEVELS = {
         "_owner": 5,
         "_maintainer": 4,
@@ -27,31 +63,48 @@ class CourseRoleHierarchy:
         "_student": 1,
     }
 
-    def __init__(self, hierarchy: Optional[Dict[str, List[str]]] = None):
-        self.hierarchy = hierarchy or self.DEFAULT_HIERARCHY
+    def __init__(self, hierarchy: Optional[Dict[str, List[str]]] = None) -> None:
+        super().__init__(
+            hierarchy=hierarchy or self.DEFAULT_HIERARCHY,
+            levels=self.ROLE_LEVELS,
+        )
 
-    @lru_cache(maxsize=128)
-    def get_allowed_roles(self, role: str) -> List[str]:
-        """Get all roles that meet or exceed the given role"""
-        return self.hierarchy.get(role, [])
 
-    def has_role_permission(self, user_role: str, required_role: str) -> bool:
-        """Check if user_role has permission for required_role"""
-        return user_role in self.get_allowed_roles(required_role)
+# Per-scope hierarchies. Three-level: owner > manager > developer.
+#   developer → can read & edit the scope; cannot assign roles
+#   manager   → can edit and assign roles except _owner
+#   owner     → full control: edit, delete/archive, assign any role
+# No cross-scope inheritance.
+_SCOPE_HIERARCHY = {
+    "_owner": ["_owner"],
+    "_manager": ["_manager", "_owner"],
+    "_developer": ["_developer", "_manager", "_owner"],
+}
+_SCOPE_LEVELS = {"_owner": 3, "_manager": 2, "_developer": 1}
 
-    def get_role_level(self, role: str) -> int:
-        """Get numeric level for a role (higher = more privilege)."""
-        return self.ROLE_LEVELS.get(role, 0)
+organization_role_hierarchy = ScopedRoleHierarchy(
+    hierarchy=_SCOPE_HIERARCHY,
+    levels=_SCOPE_LEVELS,
+)
 
-    def can_assign_role(self, assigner_role: str, target_role: str) -> bool:
-        """Check if assigner can assign target role (must have equal or higher level)."""
-        assigner_level = self.get_role_level(assigner_role)
-        target_level = self.get_role_level(target_role)
-        return assigner_level >= target_level
+course_family_role_hierarchy = ScopedRoleHierarchy(
+    hierarchy=_SCOPE_HIERARCHY,
+    levels=_SCOPE_LEVELS,
+)
 
 
 # Global instance - can be configured at startup
 course_role_hierarchy = CourseRoleHierarchy()
+
+
+# Map scope name -> hierarchy. Keep in sync with the keys used in
+# ``Claims.dependent`` and the claim-emission code in
+# ``permissions/core.py::db_get_*_claims``.
+SCOPE_HIERARCHIES: Dict[str, ScopedRoleHierarchy] = {
+    "course": course_role_hierarchy,
+    "organization": organization_role_hierarchy,
+    "course_family": course_family_role_hierarchy,
+}
 
 
 class Claims(BaseModel):
@@ -179,25 +232,82 @@ class Principal(BaseModel):
             return True
         return self.claims.has_dependent_permission(resource, resource_id, action)
     
-    def has_course_role(self, course_id: str, required_role: str) -> bool:
-        """Check if user has required role in a course"""
+    def has_scope_role(
+        self, scope: str, scope_id: str, required_role: str
+    ) -> bool:
+        """Generic per-scope role check.
+
+        ``scope`` is one of the keys in ``SCOPE_HIERARCHIES`` (currently
+        ``"course"``, ``"organization"``, ``"course_family"``). Admins
+        always pass. Returns False for unknown scopes.
+        """
         if self.is_admin:
             return True
 
-        if "course" not in self.claims.dependent:
+        hierarchy = SCOPE_HIERARCHIES.get(scope)
+        if hierarchy is None:
             return False
 
-        if course_id not in self.claims.dependent["course"]:
+        scope_claims = self.claims.dependent.get(scope)
+        if not scope_claims:
             return False
 
-        user_roles = self.claims.dependent["course"][course_id]
+        user_roles = scope_claims.get(scope_id)
+        if not user_roles:
+            return False
 
-        # Check if any of the user's roles in this course meet the requirement
         for user_role in user_roles:
-            if user_role.startswith("_") and course_role_hierarchy.has_role_permission(user_role, required_role):
+            if user_role.startswith("_") and hierarchy.has_role_permission(
+                user_role, required_role
+            ):
                 return True
-
         return False
+
+    def get_scoped_ids_with_role(
+        self, scope: str, minimum_role: str
+    ) -> Set[str]:
+        """Return scope_ids where the principal has at least ``minimum_role``.
+
+        For admins this returns an empty set — callers treat that as a
+        sentinel meaning "no filtering needed" (admin sees everything).
+        """
+        if self.is_admin:
+            return set()
+
+        hierarchy = SCOPE_HIERARCHIES.get(scope)
+        if hierarchy is None:
+            return set()
+
+        scope_claims = self.claims.dependent.get(scope)
+        if not scope_claims:
+            return set()
+
+        allowed = set(hierarchy.get_allowed_roles(minimum_role))
+        result: Set[str] = set()
+        for scope_id, user_roles in scope_claims.items():
+            for ur in user_roles:
+                if ur in allowed:
+                    result.add(scope_id)
+                    break
+        return result
+
+    def has_course_role(self, course_id: str, required_role: str) -> bool:
+        """Check if user has required role in a course."""
+        return self.has_scope_role("course", course_id, required_role)
+
+    def has_organization_role(
+        self, organization_id: str, required_role: str
+    ) -> bool:
+        """Check if user has at least required_role on an organization."""
+        return self.has_scope_role("organization", organization_id, required_role)
+
+    def has_course_family_role(
+        self, course_family_id: str, required_role: str
+    ) -> bool:
+        """Check if user has at least required_role on a course family."""
+        return self.has_scope_role(
+            "course_family", course_family_id, required_role
+        )
 
     def get_highest_course_role(self, course_id: str) -> Optional[str]:
         """Get the user's highest privilege role in a course.
@@ -240,24 +350,16 @@ class Principal(BaseModel):
         return False
 
     def get_courses_with_role(self, minimum_role: str) -> Set[str]:
-        """Get all course IDs where user has at least the minimum role"""
-        if self.is_admin:
-            return set()  # Admin has access to all, return empty to avoid filtering
-        
-        course_ids = set()
-        
-        if "course" not in self.claims.dependent:
-            return course_ids
-        
-        allowed_roles = course_role_hierarchy.get_allowed_roles(minimum_role)
-        
-        for course_id, user_roles in self.claims.dependent["course"].items():
-            for user_role in user_roles:
-                if user_role in allowed_roles:
-                    course_ids.add(course_id)
-                    break
-        
-        return course_ids
+        """Get all course IDs where user has at least the minimum role."""
+        return self.get_scoped_ids_with_role("course", minimum_role)
+
+    def get_organizations_with_role(self, minimum_role: str) -> Set[str]:
+        """Get all organization IDs where user has at least minimum_role."""
+        return self.get_scoped_ids_with_role("organization", minimum_role)
+
+    def get_course_families_with_role(self, minimum_role: str) -> Set[str]:
+        """Get all course_family IDs where user has at least minimum_role."""
+        return self.get_scoped_ids_with_role("course_family", minimum_role)
     
     def permitted(self, resource: str, action: str | List[str], 
                  resource_id: Optional[str] = None, 

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -37,6 +37,10 @@ from computor_backend.interfaces import (
     SubmissionGroupInterface,
     CourseGroupInterface,
     CourseRoleInterface,
+    OrganizationRoleInterface,
+    OrganizationMemberInterface,
+    CourseFamilyRoleInterface,
+    CourseFamilyMemberInterface,
     CourseContentTypeInterface,
     CourseContentKindInterface,
     LanguageInterface,
@@ -292,6 +296,10 @@ course_family_router.register_routes(app)
 CrudRouter(CourseGroupInterface).register_routes(app)
 CrudRouter(CourseMemberInterface).register_routes(app)
 LookUpRouter(CourseRoleInterface).register_routes(app)
+LookUpRouter(OrganizationRoleInterface).register_routes(app)
+LookUpRouter(CourseFamilyRoleInterface).register_routes(app)
+CrudRouter(OrganizationMemberInterface).register_routes(app)
+CrudRouter(CourseFamilyMemberInterface).register_routes(app)
 LookUpRouter(RoleInterface).register_routes(app)
 LookUpRouter(LanguageInterface).register_routes(app)
 CrudRouter(ExampleRepositoryInterface).register_routes(app)

--- a/computor-backend/src/computor_backend/tests/test_scoped_role_principal.py
+++ b/computor-backend/src/computor_backend/tests/test_scoped_role_principal.py
@@ -1,0 +1,161 @@
+"""Unit tests for the per-scope role API on ``Principal``.
+
+Covers the generic ``has_scope_role`` / ``get_scoped_ids_with_role``
+helpers and the back-compat course/organization/course_family wrappers
+introduced for organization and course_family scoped roles.
+
+No DB or HTTP. Pure ``Principal`` + claim-string round-tripping.
+"""
+
+import pytest
+
+from computor_backend.permissions.principal import (
+    Principal,
+    build_claims,
+    organization_role_hierarchy,
+    course_family_role_hierarchy,
+    course_role_hierarchy,
+    SCOPE_HIERARCHIES,
+)
+
+
+def _principal(*claim_strings: str) -> Principal:
+    return Principal(
+        user_id="u-1",
+        claims=build_claims([("permissions", c) for c in claim_strings]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy semantics
+# ---------------------------------------------------------------------------
+
+
+class TestScopedHierarchies:
+    def test_org_three_level_inclusion(self):
+        h = organization_role_hierarchy
+        # _owner satisfies every role in scope.
+        assert h.has_role_permission("_owner", "_owner")
+        assert h.has_role_permission("_owner", "_manager")
+        assert h.has_role_permission("_owner", "_developer")
+        # _manager satisfies _manager and _developer but not _owner.
+        assert not h.has_role_permission("_manager", "_owner")
+        assert h.has_role_permission("_manager", "_manager")
+        assert h.has_role_permission("_manager", "_developer")
+        # _developer is the lowest tier.
+        assert not h.has_role_permission("_developer", "_owner")
+        assert not h.has_role_permission("_developer", "_manager")
+        assert h.has_role_permission("_developer", "_developer")
+
+    def test_family_uses_same_hierarchy_shape(self):
+        # We deliberately share the same hierarchy across org and family.
+        h_org = organization_role_hierarchy
+        h_fam = course_family_role_hierarchy
+        for role in ("_owner", "_manager", "_developer"):
+            assert h_org.get_allowed_roles(role) == h_fam.get_allowed_roles(role)
+
+    def test_no_cross_scope_inheritance(self):
+        # An organization claim does NOT grant a course_family or course role
+        # on the same id, even with identical role names.
+        p = _principal("organization:_owner:scope-1")
+        assert p.has_organization_role("scope-1", "_owner")
+        # course_family + course on the same id should NOT see it.
+        assert not p.has_course_family_role("scope-1", "_developer")
+        assert not p.has_course_role("scope-1", "_student")
+
+    def test_scope_hierarchies_registry_contents(self):
+        # Sanity: registry keys match the claim namespaces emitted by the
+        # ``db_get_*_claims`` helpers and the prefixes used in the
+        # ``<scope>:<role>:<id>`` claim format.
+        assert set(SCOPE_HIERARCHIES) == {"course", "organization", "course_family"}
+        assert SCOPE_HIERARCHIES["course"] is course_role_hierarchy
+        assert SCOPE_HIERARCHIES["organization"] is organization_role_hierarchy
+        assert SCOPE_HIERARCHIES["course_family"] is course_family_role_hierarchy
+
+
+# ---------------------------------------------------------------------------
+# build_claims + Principal end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestPrincipalScopedRoles:
+    def test_owner_satisfies_all_lower_roles_on_same_scope(self):
+        p = _principal("organization:_owner:o1")
+        assert p.has_organization_role("o1", "_owner")
+        assert p.has_organization_role("o1", "_manager")
+        assert p.has_organization_role("o1", "_developer")
+
+    def test_manager_does_not_satisfy_owner(self):
+        p = _principal("organization:_manager:o2")
+        assert not p.has_organization_role("o2", "_owner")
+        assert p.has_organization_role("o2", "_manager")
+        assert p.has_organization_role("o2", "_developer")
+
+    def test_developer_only_satisfies_developer(self):
+        p = _principal("organization:_developer:o3")
+        assert not p.has_organization_role("o3", "_owner")
+        assert not p.has_organization_role("o3", "_manager")
+        assert p.has_organization_role("o3", "_developer")
+
+    def test_unknown_scope_id_returns_false(self):
+        p = _principal("organization:_owner:o1")
+        assert not p.has_organization_role("o-not-mine", "_developer")
+
+    def test_unknown_scope_returns_false(self):
+        # ``has_scope_role`` must reject scopes not in SCOPE_HIERARCHIES.
+        p = _principal("organization:_owner:o1")
+        assert not p.has_scope_role("does-not-exist", "o1", "_owner")
+
+    def test_admin_short_circuits_all_scope_checks(self):
+        admin = Principal(user_id="a1", is_admin=True)
+        assert admin.has_organization_role("anything", "_owner")
+        assert admin.has_course_family_role("anything", "_owner")
+        # ``get_scoped_ids_with_role`` returns an empty set for admins
+        # (sentinel meaning "no filtering needed").
+        assert admin.get_organizations_with_role("_owner") == set()
+
+
+class TestGetScopedIdsWithRole:
+    def test_collects_scopes_at_or_above_minimum(self):
+        p = _principal(
+            "organization:_owner:o1",
+            "organization:_manager:o2",
+            "organization:_developer:o3",
+        )
+        # Every id qualifies for >= _developer.
+        assert p.get_organizations_with_role("_developer") == {"o1", "o2", "o3"}
+        # Only _owner and _manager qualify for >= _manager.
+        assert p.get_organizations_with_role("_manager") == {"o1", "o2"}
+        # Only _owner qualifies for >= _owner.
+        assert p.get_organizations_with_role("_owner") == {"o1"}
+
+    def test_empty_when_principal_has_no_scope_claims(self):
+        p = _principal("course:_lecturer:c1")  # course only
+        assert p.get_organizations_with_role("_developer") == set()
+        assert p.get_course_families_with_role("_developer") == set()
+
+    def test_unknown_scope_returns_empty(self):
+        p = _principal("organization:_owner:o1")
+        assert p.get_scoped_ids_with_role("does-not-exist", "_owner") == set()
+
+
+# ---------------------------------------------------------------------------
+# Course-role back-compat — the existing helpers must still work after the
+# refactor that delegates to the generic ``has_scope_role``.
+# ---------------------------------------------------------------------------
+
+
+class TestCourseBackCompat:
+    def test_course_role_helpers_still_work(self):
+        p = _principal("course:_lecturer:c1")
+        assert p.has_course_role("c1", "_student")
+        assert p.has_course_role("c1", "_lecturer")
+        assert not p.has_course_role("c1", "_owner")
+
+    def test_get_courses_with_role_uses_generic(self):
+        p = _principal(
+            "course:_lecturer:c1",
+            "course:_student:c2",
+        )
+        assert p.get_courses_with_role("_student") == {"c1", "c2"}
+        assert p.get_courses_with_role("_lecturer") == {"c1"}

--- a/computor-backend/src/computor_backend/tests/test_scoped_role_principal.py
+++ b/computor-backend/src/computor_backend/tests/test_scoped_role_principal.py
@@ -4,11 +4,25 @@ Covers the generic ``has_scope_role`` / ``get_scoped_ids_with_role``
 helpers and the back-compat course/organization/course_family wrappers
 introduced for organization and course_family scoped roles.
 
-No DB or HTTP. Pure ``Principal`` + claim-string round-tripping.
+The ``TestScopeMemberCustomPermissions`` block exercises the
+``make_scope_member_custom_permissions`` factory used to plug an
+update-payload-aware permission check into the CRUD layer for
+OrganizationMember / CourseFamilyMember.
+
+No DB. Pure ``Principal`` + claim-string round-tripping plus a small
+in-memory SQLite session for the custom-permissions tests.
 """
 
-import pytest
+from types import SimpleNamespace
 
+import pytest
+from sqlalchemy import Column, String, create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+from computor_backend.api.exceptions import ForbiddenException
+from computor_backend.permissions.handlers_impl import (
+    make_scope_member_custom_permissions,
+)
 from computor_backend.permissions.principal import (
     Principal,
     build_claims,
@@ -159,3 +173,134 @@ class TestCourseBackCompat:
         )
         assert p.get_courses_with_role("_student") == {"c1", "c2"}
         assert p.get_courses_with_role("_lecturer") == {"c1"}
+
+
+# ---------------------------------------------------------------------------
+# UPDATE-time custom permissions (the role-escalation guard)
+# ---------------------------------------------------------------------------
+
+
+class TestScopeMemberCustomPermissions:
+    """Cover ``make_scope_member_custom_permissions`` against a fake model.
+
+    A tiny SQLAlchemy declarative model on an in-memory SQLite database
+    stands in for ``OrganizationMember`` / ``CourseFamilyMember`` — the
+    helper is generic over scope, so any model with ``id``, scope_fk
+    and role_fk columns exercises the same code path.
+    """
+
+    @pytest.fixture
+    def session_with_member(self):
+        Base = declarative_base()
+
+        class FakeMember(Base):
+            __tablename__ = "fake_member"
+            id = Column(String, primary_key=True)
+            scope_id = Column(String, nullable=False)
+            role_id = Column(String, nullable=False)
+
+        engine = create_engine("sqlite://")
+        Base.metadata.create_all(engine)
+        SessionLocal = sessionmaker(bind=engine)
+        db = SessionLocal()
+
+        # Two existing rows on the same scope: one developer, one owner.
+        db.add(FakeMember(id="row-dev", scope_id="o1", role_id="_developer"))
+        db.add(FakeMember(id="row-owner", scope_id="o1", role_id="_owner"))
+        db.commit()
+
+        custom_permissions = make_scope_member_custom_permissions(
+            FakeMember,
+            scope="organization",
+            scope_fk="scope_id",
+            role_fk="role_id",
+        )
+
+        try:
+            yield db, FakeMember, custom_permissions
+        finally:
+            db.close()
+
+    def test_admin_passes_through(self, session_with_member):
+        db, FakeMember, custom = session_with_member
+        admin = Principal(user_id="a1", is_admin=True)
+        # Promoting a developer to _owner is allowed for admin.
+        payload = SimpleNamespace(role_id="_owner")
+        q = custom(admin, db, "row-dev", payload)
+        # Returned query reaches both rows (filtering to id happens later).
+        assert q.count() == 2
+
+    def test_manager_can_edit_developer_to_manager(self, session_with_member):
+        db, FakeMember, custom = session_with_member
+        mgr = _principal("organization:_manager:o1")
+        payload = SimpleNamespace(role_id="_manager")
+        # Should succeed — manager promoting developer to manager is OK.
+        q = custom(mgr, db, "row-dev", payload)
+        assert q is not None
+
+    def test_manager_cannot_promote_to_owner(self, session_with_member):
+        db, FakeMember, custom = session_with_member
+        mgr = _principal("organization:_manager:o1")
+        payload = SimpleNamespace(role_id="_owner")
+        with pytest.raises(ForbiddenException):
+            custom(mgr, db, "row-dev", payload)
+
+    def test_manager_cannot_modify_owner_row(self, session_with_member):
+        db, FakeMember, custom = session_with_member
+        mgr = _principal("organization:_manager:o1")
+        payload = SimpleNamespace(role_id="_developer")
+        # Even if the new role is harmless, manager cannot touch an _owner row.
+        with pytest.raises(ForbiddenException):
+            custom(mgr, db, "row-owner", payload)
+
+    def test_owner_can_promote_to_owner(self, session_with_member):
+        db, FakeMember, custom = session_with_member
+        owner = _principal("organization:_owner:o1")
+        payload = SimpleNamespace(role_id="_owner")
+        q = custom(owner, db, "row-dev", payload)
+        assert q is not None
+
+    def test_owner_can_modify_owner_row(self, session_with_member):
+        db, FakeMember, custom = session_with_member
+        owner = _principal("organization:_owner:o1")
+        payload = SimpleNamespace(role_id="_manager")
+        q = custom(owner, db, "row-owner", payload)
+        assert q is not None
+
+    def test_developer_blocked_outright(self, session_with_member):
+        db, FakeMember, custom = session_with_member
+        dev = _principal("organization:_developer:o1")
+        payload = SimpleNamespace(role_id="_developer")
+        with pytest.raises(ForbiddenException):
+            custom(dev, db, "row-dev", payload)
+
+    def test_principal_with_no_scope_role_blocked(self, session_with_member):
+        db, FakeMember, custom = session_with_member
+        outsider = _principal("organization:_owner:other-scope")
+        payload = SimpleNamespace(role_id="_developer")
+        with pytest.raises(ForbiddenException):
+            custom(outsider, db, "row-dev", payload)
+
+    def test_missing_row_returns_empty_query(self, session_with_member):
+        db, FakeMember, custom = session_with_member
+        admin = Principal(user_id="a", is_admin=True)
+        # Non-existent id — handler returns an empty query rather than raising
+        # so the CRUD layer can yield NotFoundException.
+        q = custom(admin, db, "nope", SimpleNamespace(role_id="_owner"))
+        assert q.count() == 2  # admin shortcut returns full query unchanged
+        # And for a non-admin, the row-not-found path yields empty:
+        mgr = _principal("organization:_manager:o1")
+        q = custom(mgr, db, "nope", SimpleNamespace(role_id="_developer"))
+        assert q.first() is None
+
+    def test_payload_without_role_change_still_checks_current_role(
+        self, session_with_member
+    ):
+        # A manager touching an _owner row without changing the role must
+        # still be blocked — the row-restriction rule applies regardless of
+        # whether the payload includes a role change.
+        db, FakeMember, custom = session_with_member
+        mgr = _principal("organization:_manager:o1")
+        payload = SimpleNamespace()  # no role_id attribute
+        with pytest.raises(ForbiddenException):
+            custom(mgr, db, "row-owner", payload)

--- a/computor-client/src/computor_client/endpoints/__init__.py
+++ b/computor-client/src/computor_client/endpoints/__init__.py
@@ -11,6 +11,8 @@ from computor_client.endpoints.course_content_kinds import CourseContentKindsCli
 from computor_client.endpoints.course_content_types import CourseContentTypesClient
 from computor_client.endpoints.course_contents import CourseContentsClient
 from computor_client.endpoints.course_families import CourseFamiliesClient
+from computor_client.endpoints.course_family_members import CourseFamilyMembersClient
+from computor_client.endpoints.course_family_roles import CourseFamilyRolesClient
 from computor_client.endpoints.course_groups import CourseGroupsClient
 from computor_client.endpoints.course_member_comments import CourseMemberCommentsClient
 from computor_client.endpoints.course_member_gradings import CourseMemberGradingsClient
@@ -25,6 +27,8 @@ from computor_client.endpoints.groups import GroupsClient
 from computor_client.endpoints.languages import LanguagesClient
 from computor_client.endpoints.lecturers import LecturersClient
 from computor_client.endpoints.messages import MessagesClient
+from computor_client.endpoints.organization_members import OrganizationMembersClient
+from computor_client.endpoints.organization_roles import OrganizationRolesClient
 from computor_client.endpoints.organizations import OrganizationsClient
 from computor_client.endpoints.profiles import ProfilesClient
 from computor_client.endpoints.results import ResultsClient
@@ -46,6 +50,7 @@ from computor_client.endpoints.tokens import TokensClient
 from computor_client.endpoints.tutors import TutorsClient
 from computor_client.endpoints.user import UserClient
 from computor_client.endpoints.users import UsersClient
+from computor_client.endpoints.workspaces import WorkspacesClient
 
 __all__ = [
     "AccountsClient",
@@ -54,6 +59,8 @@ __all__ = [
     "CourseContentTypesClient",
     "CourseContentsClient",
     "CourseFamiliesClient",
+    "CourseFamilyMembersClient",
+    "CourseFamilyRolesClient",
     "CourseGroupsClient",
     "CourseMemberCommentsClient",
     "CourseMemberGradingsClient",
@@ -68,6 +75,8 @@ __all__ = [
     "LanguagesClient",
     "LecturersClient",
     "MessagesClient",
+    "OrganizationMembersClient",
+    "OrganizationRolesClient",
     "OrganizationsClient",
     "ProfilesClient",
     "ResultsClient",
@@ -89,4 +98,5 @@ __all__ = [
     "TutorsClient",
     "UserClient",
     "UsersClient",
+    "WorkspacesClient",
 ]

--- a/computor-client/src/computor_client/endpoints/authentication.py
+++ b/computor-client/src/computor_client/endpoints/authentication.py
@@ -157,6 +157,14 @@ class AuthenticationClient:
         response = await self._http.post(f"/auth/refresh", json_data=data, params=kwargs)
         return TokenRefreshResponse.model_validate(response.json())
 
+    async def auth_verify_coder_access(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Verify Coder Access"""
+        response = await self._http.get(f"/auth/verify-coder-access", params=kwargs)
+        return response.json()
+
     async def password_status(
         self,
         **kwargs: Any,

--- a/computor-client/src/computor_client/endpoints/course_contents.py
+++ b/computor-client/src/computor_client/endpoints/course_contents.py
@@ -31,15 +31,6 @@ class CourseContentsClient:
     def __init__(self, http_client: AsyncHTTPClient) -> None:
         self._http = http_client
 
-    async def assign_example(
-        self,
-        content_id: str,
-        **kwargs: Any,
-    ) -> DeploymentWithHistory:
-        """Assign Example To Content"""
-        response = await self._http.post(f"/course-contents/{content_id}/assign-example", params=kwargs)
-        return DeploymentWithHistory.model_validate(response.json())
-
     async def example(
         self,
         content_id: str,
@@ -75,6 +66,15 @@ class CourseContentsClient:
         """Get Content Deployment"""
         response = await self._http.get(f"/course-contents/{content_id}/deployment", params=kwargs)
         return DeploymentWithHistory.model_validate(response.json())
+
+    async def move(
+        self,
+        content_id: str,
+        **kwargs: Any,
+    ) -> CourseContentGet:
+        """Move Course Content"""
+        response = await self._http.patch(f"/course-contents/{content_id}/move", params=kwargs)
+        return CourseContentGet.model_validate(response.json())
 
     async def create(
         self,
@@ -137,5 +137,14 @@ class CourseContentsClient:
     ) -> None:
         """Route Course-Contents"""
         response = await self._http.patch(f"/course-contents/{id}/archive", params=kwargs)
+        return
+
+    async def unarchive(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> None:
+        """Unarchive Course-Contents"""
+        response = await self._http.patch(f"/course-contents/{id}/unarchive", params=kwargs)
         return
 

--- a/computor-client/src/computor_client/endpoints/course_family_members.py
+++ b/computor-client/src/computor_client/endpoints/course_family_members.py
@@ -1,0 +1,72 @@
+"""
+Auto-generated endpoint client.
+
+This module is auto-generated from the OpenAPI specification.
+Run `bash generate.sh python-client` to regenerate.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel
+
+
+from computor_client.http import AsyncHTTPClient
+
+
+class CourseFamilyMembersClient:
+    """
+    Client for course family members endpoints.
+    """
+
+    def __init__(self, http_client: AsyncHTTPClient) -> None:
+        self._http = http_client
+
+    async def create(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Create Course-Family-Members"""
+        response = await self._http.post(f"/course-family-members", params=kwargs)
+        return response.json()
+
+    async def list(
+        self,
+        query: Optional[BaseModel] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """List Course-Family-Members"""
+        params = query.model_dump(exclude_none=True) if query else {}
+        params.update(kwargs)
+        response = await self._http.get(
+            f"/course-family-members",
+            params=params,
+        )
+        return response.json()
+
+    async def get(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Get Course-Family-Members"""
+        response = await self._http.get(f"/course-family-members/{id}", params=kwargs)
+        return response.json()
+
+    async def update(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Update Course-Family-Members"""
+        response = await self._http.patch(f"/course-family-members/{id}", params=kwargs)
+        return response.json()
+
+    async def delete(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> None:
+        """Delete Course-Family-Members"""
+        await self._http.delete(f"/course-family-members/{id}", params=kwargs)
+        return
+

--- a/computor-client/src/computor_client/endpoints/course_family_roles.py
+++ b/computor-client/src/computor_client/endpoints/course_family_roles.py
@@ -1,0 +1,46 @@
+"""
+Auto-generated endpoint client.
+
+This module is auto-generated from the OpenAPI specification.
+Run `bash generate.sh python-client` to regenerate.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel
+
+
+from computor_client.http import AsyncHTTPClient
+
+
+class CourseFamilyRolesClient:
+    """
+    Client for course family roles endpoints.
+    """
+
+    def __init__(self, http_client: AsyncHTTPClient) -> None:
+        self._http = http_client
+
+    async def get(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Get Course-Family-Roles"""
+        response = await self._http.get(f"/course-family-roles/{id}", params=kwargs)
+        return response.json()
+
+    async def list(
+        self,
+        query: Optional[BaseModel] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """List Course-Family-Roles"""
+        params = query.model_dump(exclude_none=True) if query else {}
+        params.update(kwargs)
+        response = await self._http.get(
+            f"/course-family-roles",
+            params=params,
+        )
+        return response.json()
+

--- a/computor-client/src/computor_client/endpoints/lecturers.py
+++ b/computor-client/src/computor_client/endpoints/lecturers.py
@@ -22,6 +22,7 @@ from computor_types.lecturer_course_contents import (
     CourseContentLecturerList,
 )
 from computor_types.lecturer_deployments import (
+    AssignExampleRequest,
     AssignExampleResponse,
     DeploymentGet,
     UnassignExampleResponse,
@@ -85,10 +86,11 @@ class LecturersClient:
     async def course_contents_assign_example(
         self,
         course_content_id: str,
+        data: Union[AssignExampleRequest, Dict[str, Any]],
         **kwargs: Any,
     ) -> AssignExampleResponse:
         """Assign Example To Course Content"""
-        response = await self._http.post(f"/lecturers/course-contents/{course_content_id}/assign-example", params=kwargs)
+        response = await self._http.post(f"/lecturers/course-contents/{course_content_id}/assign-example", json_data=data, params=kwargs)
         return AssignExampleResponse.model_validate(response.json())
 
     async def course_contents_deployment(
@@ -108,6 +110,24 @@ class LecturersClient:
         """Unassign Example From Course Content"""
         await self._http.delete(f"/lecturers/course-contents/{course_content_id}/deployment", params=kwargs)
         return
+
+    async def courses_deployments(
+        self,
+        course_id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Get Course Deployments Endpoint"""
+        response = await self._http.get(f"/lecturers/courses/{course_id}/deployments", params=kwargs)
+        return response.json()
+
+    async def courses_upgrade_versions(
+        self,
+        course_id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Batch Upgrade Versions Endpoint"""
+        response = await self._http.post(f"/lecturers/courses/{course_id}/upgrade-versions", params=kwargs)
+        return response.json()
 
     async def courses_validate(
         self,

--- a/computor-client/src/computor_client/endpoints/messages.py
+++ b/computor-client/src/computor_client/endpoints/messages.py
@@ -13,7 +13,6 @@ from computor_types.messages import (
     MessageCreate,
     MessageGet,
     MessageList,
-    MessageThread,
     MessageUpdate,
 )
 
@@ -104,10 +103,10 @@ class MessagesClient:
         self,
         id: str,
         **kwargs: Any,
-    ) -> MessageThread:
-        """Get Message Thread"""
+    ) -> Dict[str, Any]:
+        """Get Message Thread Endpoint"""
         response = await self._http.get(f"/messages/{id}/thread", params=kwargs)
-        return MessageThread.model_validate(response.json())
+        return response.json()
 
     async def audit(
         self,

--- a/computor-client/src/computor_client/endpoints/organization_members.py
+++ b/computor-client/src/computor_client/endpoints/organization_members.py
@@ -1,0 +1,72 @@
+"""
+Auto-generated endpoint client.
+
+This module is auto-generated from the OpenAPI specification.
+Run `bash generate.sh python-client` to regenerate.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel
+
+
+from computor_client.http import AsyncHTTPClient
+
+
+class OrganizationMembersClient:
+    """
+    Client for organization members endpoints.
+    """
+
+    def __init__(self, http_client: AsyncHTTPClient) -> None:
+        self._http = http_client
+
+    async def create(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Create Organization-Members"""
+        response = await self._http.post(f"/organization-members", params=kwargs)
+        return response.json()
+
+    async def list(
+        self,
+        query: Optional[BaseModel] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """List Organization-Members"""
+        params = query.model_dump(exclude_none=True) if query else {}
+        params.update(kwargs)
+        response = await self._http.get(
+            f"/organization-members",
+            params=params,
+        )
+        return response.json()
+
+    async def get(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Get Organization-Members"""
+        response = await self._http.get(f"/organization-members/{id}", params=kwargs)
+        return response.json()
+
+    async def update(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Update Organization-Members"""
+        response = await self._http.patch(f"/organization-members/{id}", params=kwargs)
+        return response.json()
+
+    async def delete(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> None:
+        """Delete Organization-Members"""
+        await self._http.delete(f"/organization-members/{id}", params=kwargs)
+        return
+

--- a/computor-client/src/computor_client/endpoints/organization_roles.py
+++ b/computor-client/src/computor_client/endpoints/organization_roles.py
@@ -1,0 +1,46 @@
+"""
+Auto-generated endpoint client.
+
+This module is auto-generated from the OpenAPI specification.
+Run `bash generate.sh python-client` to regenerate.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel
+
+
+from computor_client.http import AsyncHTTPClient
+
+
+class OrganizationRolesClient:
+    """
+    Client for organization roles endpoints.
+    """
+
+    def __init__(self, http_client: AsyncHTTPClient) -> None:
+        self._http = http_client
+
+    async def get(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Get Organization-Roles"""
+        response = await self._http.get(f"/organization-roles/{id}", params=kwargs)
+        return response.json()
+
+    async def list(
+        self,
+        query: Optional[BaseModel] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """List Organization-Roles"""
+        params = query.model_dump(exclude_none=True) if query else {}
+        params.update(kwargs)
+        response = await self._http.get(
+            f"/organization-roles",
+            params=params,
+        )
+        return response.json()
+

--- a/computor-client/src/computor_client/endpoints/organizations.py
+++ b/computor-client/src/computor_client/endpoints/organizations.py
@@ -110,3 +110,12 @@ class OrganizationsClient:
         response = await self._http.patch(f"/organizations/{id}/archive", params=kwargs)
         return
 
+    async def unarchive(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> None:
+        """Unarchive Organizations"""
+        response = await self._http.patch(f"/organizations/{id}/unarchive", params=kwargs)
+        return
+

--- a/computor-client/src/computor_client/endpoints/submissions.py
+++ b/computor-client/src/computor_client/endpoints/submissions.py
@@ -59,6 +59,14 @@ class SubmissionsClient:
             return [SubmissionArtifactList.model_validate(item) for item in data]
         return []
 
+    async def artifacts_download(
+        self,
+        **kwargs: Any,
+    ) -> bytes:
+        """Download Latest Submission"""
+        response = await self._http.get(f"/submissions/artifacts/download", params=kwargs)
+        return response.content
+
     async def get_missions_artifacts_artifact_id(
         self,
         artifact_id: str,
@@ -77,14 +85,6 @@ class SubmissionsClient:
         """Update Submission Artifact"""
         response = await self._http.patch(f"/submissions/artifacts/{artifact_id}", json_data=data, params=kwargs)
         return SubmissionArtifactGet.model_validate(response.json())
-
-    async def artifacts_download(
-        self,
-        **kwargs: Any,
-    ) -> bytes:
-        """Download Latest Submission"""
-        response = await self._http.get(f"/submissions/artifacts/download", params=kwargs)
-        return response.content
 
     async def get_artifacts_download(
         self,
@@ -118,6 +118,17 @@ class SubmissionsClient:
         return []
 
     async def grades(
+        self,
+        **kwargs: Any,
+    ) -> List[SubmissionGradeList]:
+        """List Grades"""
+        response = await self._http.get(f"/submissions/grades", params=kwargs)
+        data = response.json()
+        if isinstance(data, list):
+            return [SubmissionGradeList.model_validate(item) for item in data]
+        return []
+
+    async def patch_grades(
         self,
         grade_id: str,
         data: Union[SubmissionGradeUpdate, Dict[str, Any]],

--- a/computor-client/src/computor_client/endpoints/system.py
+++ b/computor-client/src/computor_client/endpoints/system.py
@@ -113,3 +113,43 @@ class SystemClient:
         response = await self._http.get(f"/system/hierarchy/status/{workflow_id}", params=kwargs)
         return response.json()
 
+    async def maintenance_status(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Get Maintenance Status"""
+        response = await self._http.get(f"/system/maintenance/status", params=kwargs)
+        return response.json()
+
+    async def maintenance_activate(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Activate Maintenance"""
+        response = await self._http.post(f"/system/maintenance/activate", params=kwargs)
+        return response.json()
+
+    async def maintenance_deactivate(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Deactivate Maintenance"""
+        response = await self._http.post(f"/system/maintenance/deactivate", params=kwargs)
+        return response.json()
+
+    async def maintenance_schedule(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Schedule Maintenance"""
+        response = await self._http.post(f"/system/maintenance/schedule", params=kwargs)
+        return response.json()
+
+    async def delete_maintenance_schedule(
+        self,
+        **kwargs: Any,
+    ) -> None:
+        """Cancel Scheduled Maintenance"""
+        await self._http.delete(f"/system/maintenance/schedule", params=kwargs)
+        return
+

--- a/computor-client/src/computor_client/endpoints/tutors.py
+++ b/computor-client/src/computor_client/endpoints/tutors.py
@@ -197,3 +197,30 @@ class TutorsClient:
         response = await self._http.get(f"/tutors/tests/{test_id}/artifacts/download", params=kwargs)
         return response.content
 
+    async def tests_input_download(
+        self,
+        test_id: str,
+        **kwargs: Any,
+    ) -> bytes:
+        """Download Tutor Test Input"""
+        response = await self._http.get(f"/tutors/tests/{test_id}/input/download", params=kwargs)
+        return response.content
+
+    async def tests_results(
+        self,
+        test_id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Submit Tutor Test Results"""
+        response = await self._http.post(f"/tutors/tests/{test_id}/results", params=kwargs)
+        return response.json()
+
+    async def tests_artifacts_upload(
+        self,
+        test_id: str,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Upload Tutor Test Artifacts"""
+        response = await self._http.post(f"/tutors/tests/{test_id}/artifacts/upload", params=kwargs)
+        return response.json()
+

--- a/computor-client/src/computor_client/endpoints/users.py
+++ b/computor-client/src/computor_client/endpoints/users.py
@@ -90,3 +90,12 @@ class UsersClient:
         response = await self._http.patch(f"/users/{id}/archive", params=kwargs)
         return
 
+    async def unarchive(
+        self,
+        id: str,
+        **kwargs: Any,
+    ) -> None:
+        """Unarchive Users"""
+        response = await self._http.patch(f"/users/{id}/unarchive", params=kwargs)
+        return
+

--- a/computor-client/src/computor_client/endpoints/workspaces.py
+++ b/computor-client/src/computor_client/endpoints/workspaces.py
@@ -1,0 +1,49 @@
+"""
+Auto-generated endpoint client.
+
+This module is auto-generated from the OpenAPI specification.
+Run `bash generate.sh python-client` to regenerate.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel
+
+
+from computor_client.http import AsyncHTTPClient
+
+
+class WorkspacesClient:
+    """
+    Client for workspaces endpoints.
+    """
+
+    def __init__(self, http_client: AsyncHTTPClient) -> None:
+        self._http = http_client
+
+    async def roles_users(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """List all users with their workspace roles"""
+        response = await self._http.get(f"/workspaces/roles/users", params=kwargs)
+        return response.json()
+
+    async def roles_assign(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Assign a workspace role by email"""
+        response = await self._http.post(f"/workspaces/roles/assign", params=kwargs)
+        return response.json()
+
+    async def delete_roles_users(
+        self,
+        user_id: str,
+        role_id: str,
+        **kwargs: Any,
+    ) -> None:
+        """Remove a workspace role from a user"""
+        await self._http.delete(f"/workspaces/roles/users/{user_id}/{role_id}", params=kwargs)
+        return
+

--- a/computor-types/src/computor_types/course_family_members.py
+++ b/computor-types/src/computor_types/course_family_members.py
@@ -1,0 +1,61 @@
+"""DTOs for CourseFamilyMember — per-course-family role membership.
+
+Mirrors :mod:`computor_types.course_members` but for the course_family
+scope. Used to grant explicit write/admin rights on a course_family to
+a user.
+"""
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from computor_types.base import BaseEntityGet, EntityInterface, ListQuery
+from computor_types.users import UserList
+
+
+class CourseFamilyMemberCreate(BaseModel):
+    id: Optional[str] = None
+    properties: Optional[dict] = None
+    user_id: str
+    course_family_id: str
+    course_family_role_id: str
+
+
+class CourseFamilyMemberGet(BaseEntityGet):
+    id: str
+    properties: Optional[dict] = None
+    user_id: str
+    course_family_id: str
+    course_family_role_id: str
+    user: Optional[UserList] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CourseFamilyMemberList(BaseModel):
+    id: str
+    user_id: str
+    course_family_id: str
+    course_family_role_id: str
+    user: Optional[UserList] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CourseFamilyMemberUpdate(BaseModel):
+    properties: Optional[dict] = None
+    course_family_role_id: Optional[str] = None
+
+
+class CourseFamilyMemberQuery(ListQuery):
+    id: Optional[str] = None
+    user_id: Optional[str] = None
+    course_family_id: Optional[str] = None
+    course_family_role_id: Optional[str] = None
+
+
+class CourseFamilyMemberInterface(EntityInterface):
+    create = CourseFamilyMemberCreate
+    get = CourseFamilyMemberGet
+    list = CourseFamilyMemberList
+    update = CourseFamilyMemberUpdate
+    query = CourseFamilyMemberQuery

--- a/computor-types/src/computor_types/course_family_roles.py
+++ b/computor-types/src/computor_types/course_family_roles.py
@@ -1,0 +1,40 @@
+"""DTOs for CourseFamilyRole — per-course-family role labels.
+
+Mirrors :mod:`computor_types.course_roles`. Built-in roles seeded by
+migration ``c8d9e0f1a2b3``: ``_owner``, ``_manager``.
+"""
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from computor_types.base import EntityInterface, ListQuery
+
+
+class CourseFamilyRoleGet(BaseModel):
+    id: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    builtin: bool = False
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CourseFamilyRoleList(CourseFamilyRoleGet):
+    pass
+
+
+class CourseFamilyRoleQuery(ListQuery):
+    id: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    builtin: Optional[bool] = None
+
+
+class CourseFamilyRoleInterface(EntityInterface):
+    """Read-only role registry — create/update/delete go through migrations."""
+
+    create = None
+    get = CourseFamilyRoleGet
+    list = CourseFamilyRoleList
+    update = None
+    query = CourseFamilyRoleQuery

--- a/computor-types/src/computor_types/generated/error_codes.py
+++ b/computor-types/src/computor_types/generated/error_codes.py
@@ -2,7 +2,7 @@
 Auto-generated error code constants
 
 DO NOT EDIT MANUALLY
-Generated at: 2026-03-11T16:21:57.158205
+Generated at: 2026-04-27T22:41:25.349046
 
 To regenerate: bash generate_error_codes.sh
 """

--- a/computor-types/src/computor_types/organization_members.py
+++ b/computor-types/src/computor_types/organization_members.py
@@ -1,0 +1,62 @@
+"""DTOs for OrganizationMember — per-organization role membership.
+
+Mirrors :mod:`computor_types.course_members` but for the organization
+scope. Used to grant explicit write/admin rights on an organization to
+a user. Read visibility for organizations is unrelated — it continues
+to be derived from course-membership cascade.
+"""
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from computor_types.base import BaseEntityGet, EntityInterface, ListQuery
+from computor_types.users import UserList
+
+
+class OrganizationMemberCreate(BaseModel):
+    id: Optional[str] = None
+    properties: Optional[dict] = None
+    user_id: str
+    organization_id: str
+    organization_role_id: str
+
+
+class OrganizationMemberGet(BaseEntityGet):
+    id: str
+    properties: Optional[dict] = None
+    user_id: str
+    organization_id: str
+    organization_role_id: str
+    user: Optional[UserList] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OrganizationMemberList(BaseModel):
+    id: str
+    user_id: str
+    organization_id: str
+    organization_role_id: str
+    user: Optional[UserList] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OrganizationMemberUpdate(BaseModel):
+    properties: Optional[dict] = None
+    organization_role_id: Optional[str] = None
+
+
+class OrganizationMemberQuery(ListQuery):
+    id: Optional[str] = None
+    user_id: Optional[str] = None
+    organization_id: Optional[str] = None
+    organization_role_id: Optional[str] = None
+
+
+class OrganizationMemberInterface(EntityInterface):
+    create = OrganizationMemberCreate
+    get = OrganizationMemberGet
+    list = OrganizationMemberList
+    update = OrganizationMemberUpdate
+    query = OrganizationMemberQuery

--- a/computor-types/src/computor_types/organization_roles.py
+++ b/computor-types/src/computor_types/organization_roles.py
@@ -1,0 +1,40 @@
+"""DTOs for OrganizationRole — per-organization role labels.
+
+Mirrors :mod:`computor_types.course_roles`. Built-in roles seeded by
+migration ``c8d9e0f1a2b3``: ``_owner``, ``_manager``.
+"""
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from computor_types.base import EntityInterface, ListQuery
+
+
+class OrganizationRoleGet(BaseModel):
+    id: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    builtin: bool = False
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OrganizationRoleList(OrganizationRoleGet):
+    pass
+
+
+class OrganizationRoleQuery(ListQuery):
+    id: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    builtin: Optional[bool] = None
+
+
+class OrganizationRoleInterface(EntityInterface):
+    """Read-only role registry — create/update/delete go through migrations."""
+
+    create = None
+    get = OrganizationRoleGet
+    list = OrganizationRoleList
+    update = None
+    query = OrganizationRoleQuery

--- a/computor-web/src/generated/errors/ERROR_CODES.md
+++ b/computor-web/src/generated/errors/ERROR_CODES.md
@@ -1,7 +1,7 @@
 # Error Code Reference
 
 **Auto-generated documentation**
-**Generated:** 2026-03-11 16:21:57
+**Generated:** 2026-04-27 22:41:25
 **Total errors:** 66
 
 To regenerate: `bash generate_error_codes.sh`

--- a/computor-web/src/generated/errors/error-catalog.json
+++ b/computor-web/src/generated/errors/error-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-11T16:21:57.156218",
+  "generated_at": "2026-04-27T22:41:25.344811",
   "error_count": 66,
   "errors": {
     "AUTH_001": {

--- a/computor-web/src/generated/errors/error-catalog.vscode.json
+++ b/computor-web/src/generated/errors/error-catalog.vscode.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-11T16:21:57.157306",
+  "generated_at": "2026-04-27T22:41:25.347141",
   "error_count": 66,
   "errors": {
     "AUTH_001": {

--- a/computor-web/src/generated/types/common.ts
+++ b/computor-web/src/generated/types/common.ts
@@ -1155,6 +1155,8 @@ export interface ServiceTypeBase {
   color?: string | null;
   /** Whether this service type is enabled */
   enabled?: boolean;
+  /** Whether services of this type need a workspace (e.g. a GitLab repository) provisioned for their course members. When False, the CourseMember post-create hook skips workspace provisioning. */
+  requires_workspace?: boolean;
   /** Additional properties */
   properties?: any | null;
 }
@@ -1181,6 +1183,8 @@ export interface ServiceTypeCreate {
   color?: string | null;
   /** Whether this service type is enabled */
   enabled?: boolean;
+  /** Whether services of this type need a workspace (e.g. a GitLab repository) provisioned for their course members. When False, the CourseMember post-create hook skips workspace provisioning. */
+  requires_workspace?: boolean;
   /** Additional properties */
   properties?: any | null;
 }
@@ -1197,6 +1201,8 @@ export interface ServiceTypeUpdate {
   icon?: string | null;
   color?: string | null;
   enabled?: boolean | null;
+  /** Whether services of this type need a workspace provisioned for their course members. */
+  requires_workspace?: boolean | null;
   properties?: any | null;
 }
 
@@ -1256,6 +1262,8 @@ export interface ServiceTypeGet {
   color?: string | null;
   /** Enabled status */
   enabled: boolean;
+  /** Whether services of this type need a workspace provisioned for their course members. */
+  requires_workspace?: boolean;
   /** Additional properties */
   properties?: any;
   /** Version number */

--- a/computor-web/src/generated/types/courses.ts
+++ b/computor-web/src/generated/types/courses.ts
@@ -28,6 +28,29 @@ export interface CourseContentMoveRequest {
   position: number;
 }
 
+export interface CourseFamilyRoleGet {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean;
+}
+
+export interface CourseFamilyRoleList {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean;
+}
+
+export interface CourseFamilyRoleQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean | null;
+}
+
 /**
  * Repository information for course content in lecturer view.
  */
@@ -644,6 +667,51 @@ export interface CourseContentStudentQuery {
   nlevel?: number | null;
   descendants?: string | null;
   ascendants?: string | null;
+}
+
+export interface CourseFamilyMemberCreate {
+  id?: string | null;
+  properties?: any | null;
+  user_id: string;
+  course_family_id: string;
+  course_family_role_id: string;
+}
+
+export interface CourseFamilyMemberGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  properties?: any | null;
+  user_id: string;
+  course_family_id: string;
+  course_family_role_id: string;
+  user?: UserList | null;
+}
+
+export interface CourseFamilyMemberList {
+  id: string;
+  user_id: string;
+  course_family_id: string;
+  course_family_role_id: string;
+  user?: UserList | null;
+}
+
+export interface CourseFamilyMemberUpdate {
+  properties?: any | null;
+  course_family_role_id?: string | null;
+}
+
+export interface CourseFamilyMemberQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  user_id?: string | null;
+  course_family_id?: string | null;
+  course_family_role_id?: string | null;
 }
 
 /**

--- a/computor-web/src/generated/types/error-codes.ts
+++ b/computor-web/src/generated/types/error-codes.ts
@@ -2,7 +2,7 @@
  * Auto-generated error code definitions
  *
  * DO NOT EDIT MANUALLY
- * Generated at: 2026-03-12T09:41:25.568207
+ * Generated at: 2026-04-27T22:41:25.344182
  *
  * To regenerate: bash generate_error_codes.sh
  */

--- a/computor-web/src/generated/types/messages.ts
+++ b/computor-web/src/generated/types/messages.ts
@@ -15,7 +15,8 @@ import type { MessageAuthor, MessageAuthorCourseMember } from './auth';
 export interface MessageCreate {
   parent_id?: string | null;
   level?: number;
-  title: string;
+  /** Message title (optional, used for tags like #ai) */
+  title?: string | null;
   content: string;
   /** Organization-level message */
   organization_id?: string | null;
@@ -48,7 +49,7 @@ export interface MessageGet {
   created_by?: string | null;
   updated_by?: string | null;
   id: string;
-  title: string;
+  title?: string | null;
   content: string;
   level: number;
   parent_id?: string | null;
@@ -82,7 +83,7 @@ export interface MessageList {
   /** Update timestamp */
   updated_at?: string | null;
   id: string;
-  title: string;
+  title?: string | null;
   content: string;
   level: number;
   parent_id?: string | null;
@@ -132,12 +133,27 @@ export interface MessageQuery {
   created_before?: string | null;
   /** Filter by read status: True = unread only, False = read only, None = all */
   unread?: boolean | null;
-  /** Filter by tags in title (e.g., ['ai::request', 'priority::high']) */
+  /** Filter by tags in title (e.g., ['ai', 'ai-help', 'review']). Without # prefix. */
   tags?: string[] | null;
   /** True = must match ALL tags (AND), False = match ANY tag (OR) */
   tags_match_all?: boolean | null;
-  /** Filter by tag scope prefix (e.g., 'ai' matches any #ai::* tag) */
+  /** Filter by tag prefix (e.g., 'ai' matches #ai, #ai-help, #ai-response, etc.) */
   tag_scope?: string | null;
+}
+
+/**
+ * Full conversation thread for a message.
+ * 
+ * Returns all messages sharing the same root, ordered by created_at.
+ * Used by agents to get full conversation context for follow-up detection.
+ */
+export interface MessageThread {
+  /** ID of the root message in the thread */
+  root_message_id: string;
+  /** All messages in the thread, ordered by created_at ascending */
+  messages?: MessageList[];
+  /** Total number of messages in the thread */
+  total?: number;
 }
 
 /**

--- a/computor-web/src/generated/types/organizations.ts
+++ b/computor-web/src/generated/types/organizations.ts
@@ -10,6 +10,8 @@
 
 import type { GitLabConfig, GitLabConfigGet, GitLabCredentials } from './common';
 
+import type { UserList } from './users';
+
 
 
 export interface OrganizationProperties {
@@ -157,6 +159,51 @@ export interface OrganizationQuery {
   country?: string | null;
 }
 
+export interface OrganizationMemberCreate {
+  id?: string | null;
+  properties?: any | null;
+  user_id: string;
+  organization_id: string;
+  organization_role_id: string;
+}
+
+export interface OrganizationMemberGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  properties?: any | null;
+  user_id: string;
+  organization_id: string;
+  organization_role_id: string;
+  user?: UserList | null;
+}
+
+export interface OrganizationMemberList {
+  id: string;
+  user_id: string;
+  organization_id: string;
+  organization_role_id: string;
+  user?: UserList | null;
+}
+
+export interface OrganizationMemberUpdate {
+  properties?: any | null;
+  organization_role_id?: string | null;
+}
+
+export interface OrganizationMemberQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  user_id?: string | null;
+  organization_id?: string | null;
+  organization_role_id?: string | null;
+}
+
 /**
  * Request to create an organization via Temporal workflow.
  */
@@ -164,6 +211,29 @@ export interface OrganizationTaskRequest {
   organization: Record<string, any>;
   gitlab: GitLabCredentials;
   parent_group_id: number;
+}
+
+export interface OrganizationRoleGet {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean;
+}
+
+export interface OrganizationRoleList {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean;
+}
+
+export interface OrganizationRoleQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean | null;
 }
 
 


### PR DESCRIPTION
Closes #111

## Summary

Adds two new role+member tables that mirror the existing \`course_role\` / \`course_member\` pattern:

- \`organization_role\` / \`organization_member\`
- \`course_family_role\` / \`course_family_member\`

Three built-in roles per scope, with a strict hierarchy (\`_owner\` > \`_manager\` > \`_developer\`):

| role | edit scope | assign roles | delete/archive |
|---|---|---|---|
| \`_developer\` | ✓ | — | — |
| \`_manager\` | ✓ | except \`_owner\` | — |
| \`_owner\` | ✓ | any (incl. \`_owner\`) | ✓ |

No cross-scope inheritance — an organization role does **not** grant any course_family or course privilege, and vice versa. Read visibility for organizations and course_families continues to use the existing course-membership cascade for back-compat (additive: cascade ∪ scoped role).

## Schema

Alembic migration \`c8d9e0f1a2b3\` (chains off \`b7c8d9e0f1a2\`) creates the four tables and seeds six built-in roles.

## Code

- \`ScopedRoleHierarchy\` is a new generic class; the legacy \`CourseRoleHierarchy\` is a thin subclass. \`SCOPE_HIERARCHIES\` registry powers the generic principal API.
- Generic \`Principal.has_scope_role\` / \`get_scoped_ids_with_role\`. Existing course helpers keep their signatures and delegate. New \`has_organization_role\` / \`has_course_family_role\` (and \`get_*_with_role\` variants) added.
- Claims serialise uniformly as \`\"<scope>:<role>:<scope_id>\"\`. Two new emitters in \`permissions/core.py\` plug into \`PrincipalBuilder.build\`.
- \`OrganizationPermissionHandler\` / \`CourseFamilyPermissionHandler\` rewritten with the new scoped-role checks. Also fixes the duplicate-rows defect on \`CourseFamilyPermissionHandler.build_query\` (the same \`select_from(User).outerjoin(...)\` pattern we removed for Course/Organization in #110).
- \`_ScopeMemberPermissionHandler\` (parent of the two new member handlers) enforces the assignment rules: \`_owner\` grants any role, \`_manager\` grants non-\`_owner\` only, \`_developer\` cannot manage members.
- \`post_create\` hooks on \`OrganizationInterface\` and \`CourseFamilyInterface\` auto-grant the creating user \`_owner\` on the new scope (admins skip — they bypass scope checks anyway). Without it, a non-admin with global \`organization:create\` would lock themselves out of editing the org they just made.
- Pure-Python unit tests at \`computor-backend/src/computor_backend/tests/test_scoped_role_principal.py\` (15 cases, all green).

## Endpoints (new)

| route | shape | notes |
|---|---|---|
| \`GET /organization-roles\` | list of role labels | read-only lookup |
| \`GET /course-family-roles\` | list of role labels | read-only lookup |
| \`GET|POST|PATCH|DELETE /organization-members\` | full CRUD | filtered by scoped role |
| \`GET|POST|PATCH|DELETE /course-family-members\` | full CRUD | filtered by scoped role |

## Out of scope (Phase 2, separate PR)

- Deployment YAML support (\`organization_members:\` / \`course_family_members:\` keys).
- Web UI screens and CLI helpers.
- Tightening: a \`_manager\` cannot currently *promote* an existing member to \`_owner\` via PATCH — the row-level filter restricts visibility but does not inspect the new-role payload. Tracked in the handler docstring; needs a custom-permissions hook with payload access to fix.

## Test plan

- [ ] \`alembic upgrade head\` against a clean dev DB → both role tables seeded with 3 builtins each, member tables empty.
- [ ] \`GET /organization-roles\` and \`GET /course-family-roles\` return all three roles.
- [ ] As a non-admin, create an Organization → confirm an \`organization_member\` row with role \`_owner\` is auto-created for the creator.
- [ ] As that creator (\`_owner\`), \`POST /organization-members\` with target role \`_developer\`, \`_manager\`, \`_owner\` → all succeed.
- [ ] As a \`_manager\` of the same org, repeat: target \`_owner\` should 403, others succeed.
- [ ] As a \`_developer\`, all create attempts should 403.
- [ ] As a course-only member of an org (no scoped role), \`GET /organizations\` still returns that org (course-cascade read path still works).
- [ ] \`pytest tests/test_scoped_role_principal.py\` → all 15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)