### PR TITLE
fix: block non-admin _admin role assignment via /user-roles

### DIFF
--- a/computor-backend/src/computor_backend/permissions/core.py
+++ b/computor-backend/src/computor_backend/permissions/core.py
@@ -25,7 +25,8 @@ from computor_backend.permissions.handlers_impl import (
     ReadOnlyPermissionHandler,
     ResultPermissionHandler,
     MessagePermissionHandler,
-    ExamplePermissionHandler
+    ExamplePermissionHandler,
+    UserRolePermissionHandler,
 )
 
 # Import refactored Principal and related classes
@@ -107,7 +108,11 @@ def initialize_permission_handlers():
     # System entities - admin only by default
     permission_registry.register(Role, ReadOnlyPermissionHandler(Role))  # Roles are read-only lookup tables
     permission_registry.register(RoleClaim, ReadOnlyPermissionHandler(RoleClaim))  # Role claims are read-only
-    permission_registry.register(UserRole, ReadOnlyPermissionHandler(UserRole))  # UserRole associations are read-only
+    # UserRole is the global-role junction table. Reads are open;
+    # writes are gated by the ``user_role:<action>`` claim AND blocked
+    # for the ``_admin`` role itself so a non-admin _user_manager can't
+    # escalate themselves or anyone else.
+    permission_registry.register(UserRole, UserRolePermissionHandler(UserRole))
     permission_registry.register(Group, ReadOnlyPermissionHandler(Group))  # Groups are read-only lookup tables
     permission_registry.register(GroupClaim, ReadOnlyPermissionHandler(GroupClaim))  # Group claims are read-only
     permission_registry.register(UserGroup, UserPermissionHandler(UserGroup))  # UserGroup can be managed

--- a/computor-backend/src/computor_backend/permissions/handlers_impl.py
+++ b/computor-backend/src/computor_backend/permissions/handlers_impl.py
@@ -748,28 +748,105 @@ class ResultPermissionHandler(PermissionHandler):
 
 class ReadOnlyPermissionHandler(PermissionHandler):
     """Permission handler for read-only entities like CourseRole, CourseContentKind"""
-    
-    def can_perform_action(self, principal: Principal, action: str, resource_id: Optional[str] = None) -> bool:
+
+    def can_perform_action(
+        self,
+        principal: Principal,
+        action: str,
+        resource_id: Optional[str] = None,
+        context: Optional[dict] = None,
+    ) -> bool:
+        # ``context`` is accepted for signature parity with the base
+        # ``PermissionHandler.can_perform_action`` and the call site in
+        # ``business_logic/crud.py::create_entity`` — read-only entities
+        # don't actually consult it. Without this kwarg the create path
+        # raised a TypeError for any registered ReadOnly entity.
         if self.check_admin(principal):
             return True
-        
+
         # Everyone can read these entities
         if action in ["list", "get"]:
             return True
-        
+
         # Only admin can modify
         return self.check_general_permission(principal, action)
-    
+
     def build_query(self, principal: Principal, action: str, db: Session) -> Query:
         if self.check_admin(principal):
             return db.query(self.entity)
-        
+
         if action in ["list", "get"]:
             return db.query(self.entity)
-        
+
         if self.check_general_permission(principal, action):
             return db.query(self.entity)
-        
+
+        raise ForbiddenException(detail={"entity": self.resource_name})
+
+
+class UserRolePermissionHandler(PermissionHandler):
+    """Permission handler for the ``user_role`` junction table.
+
+    Reads are open (every authenticated user can list / get user-role
+    assignments). Writes are gated by the standard ``user_role:<action>``
+    claim — held by the ``_user_manager`` role today.
+
+    Critical extra rule: even with the claim, non-admins cannot
+    create / update / delete a row whose ``role_id`` is ``_admin``.
+    Without this, anyone with ``_user_manager`` could grant themselves
+    or others the ``_admin`` system role and escalate. Mirrors the
+    ``_manager``-can't-promote-to-``_owner`` pattern that landed for
+    scoped roles in PR #112.
+
+    The ``context`` dict that ``business_logic/crud.py::create_entity``
+    builds from the request payload includes ``role_id`` (any
+    ``*_id`` field is folded in), so the create path sees the target
+    role before it commits. The ``build_query`` path filters out admin
+    rows for non-admins so update / delete URLs that target an admin
+    row resolve to ``NotFound`` rather than succeed silently.
+    """
+
+    PROTECTED_ROLE_ID = "_admin"
+
+    def can_perform_action(
+        self,
+        principal: Principal,
+        action: str,
+        resource_id: Optional[str] = None,
+        context: Optional[dict] = None,
+    ) -> bool:
+        if self.check_admin(principal):
+            return True
+
+        if action in ("list", "get"):
+            return True
+
+        # Writes require the general claim (typically held by
+        # ``_user_manager``).
+        if not self.check_general_permission(principal, action):
+            return False
+
+        # Even with the claim, only admins may grant ``_admin``.
+        if context and context.get("role_id") == self.PROTECTED_ROLE_ID:
+            return False
+
+        return True
+
+    def build_query(self, principal: Principal, action: str, db: Session) -> Query:
+        if self.check_admin(principal):
+            return db.query(self.entity)
+
+        if action in ("list", "get"):
+            return db.query(self.entity)
+
+        if self.check_general_permission(principal, action):
+            # Filter out admin rows so non-admins targeting an
+            # admin assignment by (user_id, role_id) get a clean
+            # NotFound, not a successful update / delete.
+            return db.query(self.entity).filter(
+                self.entity.role_id != self.PROTECTED_ROLE_ID
+            )
+
         raise ForbiddenException(detail={"entity": self.resource_name})
 
 

--- a/computor-backend/src/computor_backend/tests/test_user_role_admin_escalation.py
+++ b/computor-backend/src/computor_backend/tests/test_user_role_admin_escalation.py
@@ -1,0 +1,191 @@
+"""Regression tests for the ``POST /user-roles`` privilege-escalation
+fix.
+
+Two bugs landed together:
+
+1. ``ReadOnlyPermissionHandler.can_perform_action`` had no ``context``
+   keyword arg, but ``business_logic/crud.py::create_entity`` passes
+   one. Every POST to a ReadOnly-registered entity 500'd with
+   ``TypeError``. Test below: the handler now accepts ``context``.
+
+2. Once that 500 was fixed, a non-admin holding ``_user_manager``
+   would have been able to POST ``/user-roles`` with
+   ``role_id='_admin'`` and grant themselves (or anyone) the system
+   ``_admin`` role. ``UserRole`` is now registered with a dedicated
+   ``UserRolePermissionHandler`` that mirrors the
+   ``_manager``-can't-promote-to-``_owner`` rule from PR #112: the
+   ``user_role:create/update/delete`` claim is necessary but never
+   sufficient for the protected ``_admin`` role.
+
+These tests are pure-Python — no DB, no auth machinery — so they
+stay fast and independent of the example fixtures.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from computor_backend.permissions.handlers_impl import (
+    ReadOnlyPermissionHandler,
+    UserRolePermissionHandler,
+)
+from computor_backend.permissions.principal import Principal
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin() -> Principal:
+    return Principal(user_id="u-admin", is_admin=True)
+
+
+def _user_manager() -> Principal:
+    """A non-admin principal that holds the ``_user_manager`` role.
+
+    The handler treats ``user_role:<action>`` as the gating claim, so
+    we model that with a fake claims object whose
+    ``has_general_permission`` answers True for the relevant resource.
+    Avoids spinning up the full claim-builder pipeline.
+    """
+    p = Principal(user_id="u-mgr", is_admin=False)
+    p.claims = SimpleNamespace(
+        has_general_permission=lambda resource, action: resource == "user_role",
+        has_dependent_permission=lambda *a, **kw: False,
+        dependent={},
+    )
+    return p
+
+
+def _outsider() -> Principal:
+    """Non-admin with no relevant claims — baseline negative case."""
+    p = Principal(user_id="u-out", is_admin=False)
+    p.claims = SimpleNamespace(
+        has_general_permission=lambda *a, **kw: False,
+        has_dependent_permission=lambda *a, **kw: False,
+        dependent={},
+    )
+    return p
+
+
+@pytest.fixture
+def handler():
+    """Build the handler against a model-shaped stub.
+
+    ``__tablename__`` drives ``check_general_permission``'s claim name
+    lookup (``user_role:<action>``). ``role_id`` is referenced by
+    ``build_query`` for the ``!= "_admin"`` filter; SQLAlchemy
+    expression objects are not needed since we never execute the query
+    here — we only assert it was filtered.
+    """
+    fake_model = SimpleNamespace(
+        __tablename__="user_role",
+        __name__="UserRole",
+        role_id=SimpleNamespace(__ne__=lambda other: ("role_id != ", other)),
+    )
+    return UserRolePermissionHandler(fake_model)
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — ReadOnlyPermissionHandler signature
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyHandlerAcceptsContext:
+    """The crash that hid the security hole. Caller passes
+    ``context=...`` per the base ``PermissionHandler`` signature; if
+    the subclass doesn't accept it we get a TypeError → 500."""
+
+    def test_signature_accepts_context_kwarg(self):
+        # Build a minimal handler instance; context is ignored for
+        # read-only entities but must not raise.
+        fake_model = SimpleNamespace(__tablename__="role", __name__="Role")
+        h = ReadOnlyPermissionHandler(fake_model)
+        # Admin short-circuits — exercising the kwarg, not the body.
+        assert h.can_perform_action(
+            _admin(), "create", resource_id=None, context={"role_id": "_admin"}
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — UserRole admin-escalation guard, create path
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAdminEscalationBlocked:
+    def test_admin_can_grant_admin(self, handler):
+        # Sanity: admins can grant any role, including ``_admin``.
+        assert handler.can_perform_action(
+            _admin(), "create", context={"role_id": "_admin"}
+        ) is True
+
+    def test_user_manager_can_grant_non_admin(self, handler):
+        # The legitimate use case: a non-admin user_manager promotes
+        # someone to ``_user_manager`` themselves.
+        assert handler.can_perform_action(
+            _user_manager(), "create", context={"role_id": "_user_manager"}
+        ) is True
+
+    def test_user_manager_cannot_grant_admin(self, handler):
+        # The vulnerability the report flagged.
+        assert handler.can_perform_action(
+            _user_manager(), "create", context={"role_id": "_admin"}
+        ) is False
+
+    def test_outsider_cannot_grant_anything(self, handler):
+        # Regression: a non-admin without the claim still gets nothing.
+        assert handler.can_perform_action(
+            _outsider(), "create", context={"role_id": "_user_manager"}
+        ) is False
+
+    def test_user_manager_create_without_context_allowed(self, handler):
+        # Defensive: if a caller forgets to pass context (shouldn't
+        # happen via the normal CRUD path), don't false-positive a
+        # block. The build_query filter still keeps non-admins away
+        # from existing admin rows on update/delete.
+        assert handler.can_perform_action(
+            _user_manager(), "create", context=None
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — UserRole admin-escalation guard, read / update / delete paths
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQueryFiltersAdminRows:
+    def test_admin_sees_all_rows_on_write(self, handler):
+        # Admin gets the unfiltered table back for update/delete.
+        db = MagicMock()
+        result = handler.build_query(_admin(), "delete", db)
+        # Admin path returns ``db.query(self.entity)`` directly;
+        # the filter chain is never invoked.
+        db.query.return_value.filter.assert_not_called()
+        assert result is db.query.return_value
+
+    def test_user_manager_delete_query_excludes_admin(self, handler):
+        # Non-admin write paths get a query that filters out admin
+        # rows. The endpoint then resolves an admin-targeted URL to
+        # NotFound rather than letting the delete succeed silently.
+        db = MagicMock()
+        handler.build_query(_user_manager(), "delete", db)
+        db.query.return_value.filter.assert_called_once()
+
+    def test_user_manager_update_query_excludes_admin(self, handler):
+        db = MagicMock()
+        handler.build_query(_user_manager(), "update", db)
+        db.query.return_value.filter.assert_called_once()
+
+    def test_reads_unfiltered_for_user_manager(self, handler):
+        # Reads (list / get) are open by design — needed so a user
+        # manager can SEE who is admin even though they can't change it.
+        db = MagicMock()
+        handler.build_query(_user_manager(), "list", db)
+        db.query.return_value.filter.assert_not_called()
+
+    def test_outsider_write_raises_forbidden(self, handler):
+        from computor_backend.api.exceptions import ForbiddenException
+        with pytest.raises(ForbiddenException):
+            handler.build_query(_outsider(), "delete", MagicMock())


### PR DESCRIPTION
Two bugs landed in one stack — the visible 500 was masking a privilege-escalation hole.

## Bugs

**1. \`POST /user-roles\` always 500'd** with \`TypeError: ReadOnlyPermissionHandler.can_perform_action() got an unexpected keyword argument 'context'\`. The CRUD layer at [crud.py:84](computor-backend/src/computor_backend/business_logic/crud.py#L84) passes \`context=context\` (payload-derived \`*_id\` dict for handler use), but \`ReadOnlyPermissionHandler.can_perform_action\` was never updated to accept it.

**2. Privilege escalation hole hidden behind that 500.** \`UserRole\` was registered with \`ReadOnlyPermissionHandler\` ([core.py:110](computor-backend/src/computor_backend/permissions/core.py#L110)). For \`create\`, that handler returns "yes if you have the \`user_role:create\` claim." \`_user_manager\` holds that claim. So once Bug 1 was fixed, **anyone with \`_user_manager\` could POST \`{user_id: <victim>, role_id: '_admin'}\` and grant themselves or anyone else the system \`_admin\` role.**

## Fix

1. **\`ReadOnlyPermissionHandler.can_perform_action\` now accepts \`context\`** (ignored for genuinely read-only entities — Role, CourseRole, etc. — but the call site no longer crashes).

2. **\`UserRole\` is now registered with a dedicated \`UserRolePermissionHandler\`** mirroring the \`_manager\`-can't-promote-to-\`_owner\` pattern from #112:
   - Reads (list / get) stay open
   - Writes require the standard \`user_role:<action>\` claim
   - **Even with the claim, non-admins can never touch a row whose \`role_id == "_admin"\`** — enforced on \`create\` via \`can_perform_action\` (inspects payload \`role_id\` from context) AND on \`update\`/\`delete\` via \`build_query\` filtering out admin rows so the URL lookup resolves to 404

## Behaviour matrix

| who | action | result |
|---|---|---|
| admin | grants \`_admin\` | ✓ 201 |
| \`_user_manager\` | grants \`_user_manager\` | ✓ 201 |
| \`_user_manager\` | grants \`_admin\` | **403** (was: would-be 201 if not for the TypeError) |
| \`_user_manager\` | deletes a non-admin row | ✓ |
| \`_user_manager\` | deletes an \`_admin\` row | **404** (filtered out before query) |
| anyone | reads | open as before |

## Verification

- 11 new pytest cases in \`tests/test_user_role_admin_escalation.py\` — pure unit, mock DB.
- Manual: as a non-admin holding \`_user_manager\`, POST \`/user-roles\` with \`role_id='_admin'\` now returns 403 instead of crashing or (worse) succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)