### PR TITLE
fix: let service accounts download tutor test input

### DIFF
--- a/computor-backend/src/computor_backend/api/tutor.py
+++ b/computor-backend/src/computor_backend/api/tutor.py
@@ -976,13 +976,17 @@ async def download_tutor_test_input(
     permissions: Annotated[Principal, Depends(get_current_principal)],
     redis = Depends(get_redis_client),
 ):
-    """
-    Download tutor test input files as a ZIP.
+    """Download tutor test input files as a ZIP.
 
-    Used by the testing worker to fetch the tutor's uploaded code
-    for test execution.
+    Called by the testing worker (service account, ``X-API-Token``)
+    to fetch the tutor's uploaded code for test execution. Service
+    accounts bypass the per-user ownership check because the worker
+    is never the same user as the tutor who created the test —
+    rejecting it here breaks the whole testing pipeline (workflow
+    can't fetch input → no artifacts → user later sees a confusing
+    404 on artifacts/download).
 
-    **Permissions**: Only the test owner or admin can download input.
+    **Permissions**: test owner, admin, or service account.
     """
     from computor_backend.services.tutor_test_state import get_tutor_test_metadata
     from computor_backend.services.tutor_test_storage import download_tutor_test_input_as_zip
@@ -995,7 +999,7 @@ async def download_tutor_test_input(
 
     user_id = permissions.get_user_id()
     if metadata.get("user_id") and str(user_id) != metadata.get("user_id"):
-        if not permissions.is_admin:
+        if not (permissions.is_admin or permissions.is_service):
             raise ForbiddenException(detail="You don't have access to this test")
 
     zip_data = await download_tutor_test_input_as_zip(test_id)

--- a/computor-backend/src/computor_backend/permissions/auth.py
+++ b/computor-backend/src/computor_backend/permissions/auth.py
@@ -334,11 +334,23 @@ class PrincipalBuilder:
         # Build structured claims
         claims = build_claims(claim_values)
 
+        # Surface ``User.is_service`` on the principal so endpoints can
+        # distinguish a worker / system account from a regular user
+        # without re-querying the DB. Used by worker-facing endpoints
+        # (e.g. tutor test ``input/download``) to bypass per-user
+        # ownership checks for the test-runner service account.
+        is_service = bool(
+            db.query(User.is_service)
+            .filter(User.id == auth_result.user_id)
+            .scalar()
+        )
+
         # Create Principal
         return Principal(
             user_id=auth_result.user_id,
             roles=auth_result.role_ids,
-            claims=claims
+            claims=claims,
+            is_service=is_service,
         )
     
     @staticmethod

--- a/computor-backend/src/computor_backend/permissions/principal.py
+++ b/computor-backend/src/computor_backend/permissions/principal.py
@@ -180,8 +180,9 @@ class Principal(BaseModel):
     """Enhanced Principal class with improved permission evaluation"""
     
     is_admin: bool = False
+    is_service: bool = False  # User.is_service (system / worker accounts)
     user_id: Optional[str] = None
-    
+
     roles: List[str] = Field(default_factory=list)
     claims: Claims = Field(default_factory=Claims)
     

--- a/computor-backend/src/computor_backend/tests/test_tutor_test_input_auth.py
+++ b/computor-backend/src/computor_backend/tests/test_tutor_test_input_auth.py
@@ -1,0 +1,124 @@
+"""Regression tests for the tutor-test ``input/download`` auth check.
+
+PR #101 added a per-user ownership check to ``download_tutor_test_input``
+to close a "any authenticated user can read any tutor's input" hole.
+That check was correct in spirit but broke the Temporal worker, which
+calls the same endpoint with an API-token-backed service account
+whose ``user_id`` is the worker's, not the tutor's. Result: every
+tutor-testing workflow died at the input-fetch step → no artifacts
+produced → users later saw a confusing 404 on
+``/tutors/tests/{id}/artifacts/download``.
+
+The fix wires ``is_service`` (from ``User.is_service``) onto the
+``Principal``, and the input-download endpoint now bypasses the
+ownership check for service accounts in addition to admins.
+
+Tests below cover both layers:
+
+1. ``Principal.is_service`` exists, defaults to False, round-trips
+   through Pydantic serialisation (used by the auth cache).
+2. The ``is_admin or is_service`` predicate behaves correctly across
+   the four relevant cases (owner / admin / service / outsider).
+
+The endpoint itself isn't directly callable in a unit test (FastAPI
+dependency injection, Redis), so we exercise the predicate the
+endpoint uses — same shape, no infra.
+"""
+
+import pytest
+
+from computor_backend.permissions.principal import Principal
+
+
+# ---------------------------------------------------------------------------
+# Principal.is_service plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestPrincipalIsService:
+    def test_default_false(self):
+        # Existing call sites that don't set is_service must still get
+        # a non-service principal — backward compat.
+        p = Principal(user_id="u-1")
+        assert p.is_service is False
+
+    def test_explicit_true(self):
+        p = Principal(user_id="u-svc", is_service=True)
+        assert p.is_service is True
+
+    def test_round_trips_through_serialisation(self):
+        # ``PrincipalBuilder.build_with_cache`` writes the Principal
+        # to Redis as ``model_dump_json`` and rehydrates with
+        # ``model_validate``. is_service must survive that round-trip
+        # so cached service principals don't lose their service flag.
+        original = Principal(user_id="u-svc", is_service=True, is_admin=False)
+        rehydrated = Principal.model_validate(original.model_dump())
+        assert rehydrated.is_service is True
+        assert rehydrated.is_admin is False
+
+    def test_is_admin_and_is_service_are_independent(self):
+        # The two flags don't imply each other. Admins aren't
+        # automatically service accounts; service accounts aren't
+        # automatically admins.
+        admin = Principal(user_id="u-a", is_admin=True)
+        service = Principal(user_id="u-s", is_service=True)
+        assert admin.is_service is False
+        assert service.is_admin is False
+
+
+# ---------------------------------------------------------------------------
+# The ownership-bypass predicate the endpoint uses.
+# ---------------------------------------------------------------------------
+
+
+def _input_download_authorised(principal: Principal, owner_user_id: str) -> bool:
+    """Mirror of the predicate in ``download_tutor_test_input``.
+
+    Kept as a free function in the test so the test stays decoupled
+    from the FastAPI endpoint — what we're guarding against is the
+    LOGIC, not the routing.
+    """
+    if not owner_user_id:
+        return True  # legacy entries without a user_id slot through
+    if str(principal.user_id) == owner_user_id:
+        return True
+    return bool(principal.is_admin or principal.is_service)
+
+
+class TestInputDownloadAuthorisation:
+    OWNER_ID = "u-tutor"
+
+    def test_owner_allowed(self):
+        owner = Principal(user_id=self.OWNER_ID)
+        assert _input_download_authorised(owner, self.OWNER_ID) is True
+
+    def test_admin_allowed(self):
+        admin = Principal(user_id="u-admin", is_admin=True)
+        assert _input_download_authorised(admin, self.OWNER_ID) is True
+
+    def test_service_account_allowed(self):
+        # The whole point of the fix — the worker, authenticating as
+        # a service account, can fetch the tutor's input even though
+        # it isn't the tutor.
+        worker = Principal(user_id="u-worker", is_service=True)
+        assert _input_download_authorised(worker, self.OWNER_ID) is True
+
+    def test_outsider_denied(self):
+        # Regression: another regular user must STILL get rejected.
+        # PR #101's intent was to close exactly this case.
+        snoop = Principal(user_id="u-snoop")
+        assert _input_download_authorised(snoop, self.OWNER_ID) is False
+
+    def test_outsider_with_neither_flag_denied(self):
+        # Defensive: explicit False on both flags is the same as default.
+        snoop = Principal(user_id="u-snoop", is_admin=False, is_service=False)
+        assert _input_download_authorised(snoop, self.OWNER_ID) is False
+
+    def test_legacy_entry_without_owner_user_id_allowed(self):
+        # Defensive: if Redis ever returns an entry without a
+        # ``user_id`` field (pre-PR-#101 metadata that's still
+        # within TTL during a deploy), we don't want to lock it down
+        # surprisingly. The endpoint guards with ``if metadata.get(...)``
+        # already; this just documents the behaviour.
+        anybody = Principal(user_id="u-x")
+        assert _input_download_authorised(anybody, "") is True


### PR DESCRIPTION
## Bug

PR #101 (\`9c201f0\`, Apr 17) added a per-user ownership check to \`download_tutor_test_input\` to close a "any authenticated user can read any tutor's input" hole. The check was correct in spirit but broke the **Temporal worker**, which calls the same endpoint with an \`X-API-Token\`-backed service account whose \`user_id\` is the worker's, not the tutor's.

End-to-end consequence:

- Worker fetches input → **403** (rejected as "not the test owner")
- Workflow dies before producing artifacts
- 1 hour later the Redis metadata expires
- User hits \`GET /tests/{id}/artifacts/download\` → **404 \`NF_001\`** ("not found or expired")
- vscode extension surfaces a misleading "[AUTHZ_001] You don't have access to this test (HTTP 403)" message for that 404

So the symptom was a 404 in the backend log + a 403-shaped message in the UI; both traced back to the worker being silently rejected on the input-fetch step.

## Fix

Smallest viable: surface \`User.is_service\` on the \`Principal\` and let it bypass the ownership check alongside \`is_admin\`.

- New \`Principal.is_service: bool = False\`. Default keeps every existing call site unchanged.
- \`PrincipalBuilder.build\` looks up \`User.is_service\` once when constructing the principal. Survives the auth-cache round-trip (Pydantic field).
- \`download_tutor_test_input\` ownership check now reads \`if not (permissions.is_admin or permissions.is_service)\` instead of \`if not permissions.is_admin\`.

## What's now true

| caller | hits \`GET /tutors/tests/{id}/input/download\` | result |
|---|---|---|
| the tutor (test owner) | their session | ✓ 200 (unchanged) |
| admin | session or token | ✓ 200 (unchanged) |
| **Temporal worker** | \`X-API-Token\` for service account | **✓ 200** — was 403, **fix is here** |
| any other authenticated user | session/token | ✗ 403 (unchanged — closes the same hole #101 was guarding) |

User-facing result endpoints (\`/tests/{id}\`, \`/tests/{id}/artifacts\`, \`/tests/{id}/artifacts/download\`) still restrict to owner + admin — no widening of result visibility.

## Verification

- 10 new pytest cases in \`tests/test_tutor_test_input_auth.py\` covering \`Principal.is_service\` plumbing (defaults, serialization round-trip, independence from \`is_admin\`) and the four-way authorisation matrix (owner / admin / service / outsider).
- Manual: as a service-token-backed worker, calling \`/input/download\` for a tutor's test now returns 200; as an unrelated regular user, still 403.

## Follow-ups (not in this PR)

- The two POST worker-write endpoints (\`/tests/{id}/results\` and \`/tests/{id}/artifacts/upload\`) have no permission gate at all — anyone authenticated can submit. Same shape #101 noticed; worth a follow-up to lock them down with the same \`owner / admin / service\` predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)