### PR TITLE
feat(testing): richer assertion messages for variable comparisons

### DIFF
--- a/computor-testing/testers/tests/test_base.py
+++ b/computor-testing/testers/tests/test_base.py
@@ -78,6 +78,255 @@ def check_file_exists(directory: str, pattern: str) -> Tuple[bool, List[str]]:
     return False, []
 
 
+# =============================================================================
+# Diff message formatters
+# -----------------------------------------------------------------------------
+# These produce the multi-line strings carried in AssertionError messages and
+# (via the pytest hook) into ``ComputorReportSub.statusMessage``. They are
+# string-only — no schema change — so any improvement here flows straight
+# through to the student's testSummary.json regardless of language tester.
+# =============================================================================
+
+
+# Cap on how many mismatching elements / characters we show in a single
+# message — beyond this we show "... and N more" to keep the output readable
+# without truncating the *truly* small mismatches.
+_MAX_DIFF_SAMPLES = 5
+_MAX_STR_LEN = 200
+
+
+def _format_scalar(value) -> str:
+    """Compact scalar formatter that handles NaN / inf cleanly."""
+    if isinstance(value, float):
+        if np.isnan(value):
+            return "NaN"
+        if np.isposinf(value):
+            return "+inf"
+        if np.isneginf(value):
+            return "-inf"
+        # Use g-format with enough digits to expose subtle off-by-eps issues.
+        return f"{value:.6g}"
+    return repr(value)
+
+
+def _shape_hint(actual_shape, expected_shape) -> str:
+    """Return a one-line hint when shapes look related but mismatched."""
+    if actual_shape == expected_shape:
+        return ""
+    a, e = tuple(actual_shape), tuple(expected_shape)
+    # Transposed 2D
+    if len(a) == 2 and len(e) == 2 and a == e[::-1]:
+        return "  hint: shapes look transposed — did you forget `.T` or transpose?"
+    # Reversed in any rank
+    if len(a) == len(e) and a == e[::-1] and len(a) > 1:
+        return "  hint: shapes are reversed — check axis order."
+    # Same total size: maybe needs reshape
+    try:
+        if int(np.prod(a)) == int(np.prod(e)):
+            return "  hint: total element count matches — try `.reshape({})`.".format(
+                tuple(e)
+            )
+    except Exception:  # noqa: BLE001 — defensive, formatting must never raise
+        pass
+    return ""
+
+
+def _format_array_diff(
+    actual: np.ndarray,
+    expected: np.ndarray,
+    name: str,
+    rel_tol: Optional[float],
+    abs_tol: Optional[float],
+) -> str:
+    """Build a multi-line diff message for two arrays known to differ.
+
+    Caller has already verified that ``np.allclose`` (numeric) or
+    ``np.array_equal`` (non-numeric) returned False — this only formats.
+    """
+    lines = [f"Variable `{name}` differs from expected:"]
+
+    # Shape / dtype
+    if actual.shape == expected.shape:
+        lines.append(f"  shape: {actual.shape}")
+    else:
+        lines.append(f"  shape: actual={actual.shape}  expected={expected.shape}")
+    if actual.dtype == expected.dtype:
+        lines.append(f"  dtype: {actual.dtype}")
+    else:
+        lines.append(f"  dtype: actual={actual.dtype}  expected={expected.dtype}")
+
+    if rel_tol is not None or abs_tol is not None:
+        lines.append(f"  tolerances: rel={rel_tol!r}  abs={abs_tol!r}")
+
+    # Only compute element-wise diff when shapes match — otherwise indices
+    # are not comparable.
+    if actual.shape != expected.shape:
+        hint = _shape_hint(actual.shape, expected.shape)
+        if hint:
+            lines.append(hint)
+        return "\n".join(lines)
+
+    is_numeric = np.issubdtype(actual.dtype, np.number) and np.issubdtype(
+        expected.dtype, np.number
+    )
+
+    if is_numeric:
+        with np.errstate(invalid="ignore", divide="ignore"):
+            actual_f = actual.astype(np.float64, copy=False)
+            expected_f = expected.astype(np.float64, copy=False)
+            abs_diff = np.abs(actual_f - expected_f)
+
+            # NaN positions that disagree
+            actual_nan = np.isnan(actual_f)
+            expected_nan = np.isnan(expected_f)
+            nan_disagree = actual_nan ^ expected_nan
+            if np.any(nan_disagree):
+                idxs = list(zip(*np.where(nan_disagree)))[:_MAX_DIFF_SAMPLES]
+                lines.append(f"  NaN disagreement at {len(idxs)}+ positions:")
+                for idx in idxs:
+                    a_val = "NaN" if actual_nan[idx] else _format_scalar(actual_f[idx])
+                    e_val = "NaN" if expected_nan[idx] else _format_scalar(expected_f[idx])
+                    lines.append(f"    {idx}: actual={a_val:<14} expected={e_val}")
+
+            # Where both are finite, compute diffs. If finite values
+            # already agree (max diff is 0) we omit these lines —
+            # otherwise NaN-only mismatches are followed by an
+            # uninformative "max abs diff: 0" that just adds noise.
+            both_finite = np.isfinite(actual_f) & np.isfinite(expected_f)
+            if np.any(both_finite):
+                finite_abs = np.where(both_finite, abs_diff, 0.0)
+                max_abs = float(finite_abs.max())
+                if max_abs > 0:
+                    max_abs_idx = np.unravel_index(
+                        int(finite_abs.argmax()), finite_abs.shape
+                    )
+                    lines.append(
+                        f"  max abs diff: {max_abs:.6g} at index {max_abs_idx}"
+                    )
+
+                    # Relative diff is only meaningful where expected is non-zero.
+                    with np.errstate(divide="ignore", invalid="ignore"):
+                        rel = np.where(
+                            both_finite & (expected_f != 0),
+                            abs_diff / np.abs(expected_f),
+                            0.0,
+                        )
+                    if np.any(rel > 0):
+                        max_rel = float(rel.max())
+                        max_rel_idx = np.unravel_index(int(rel.argmax()), rel.shape)
+                        lines.append(
+                            f"  max rel diff: {max_rel:.6g} at index {max_rel_idx}"
+                        )
+
+            # Mismatching positions sample (numeric closeness)
+            close = np.isclose(
+                actual_f,
+                expected_f,
+                rtol=rel_tol if rel_tol is not None else 1e-9,
+                atol=abs_tol if abs_tol is not None else 1e-12,
+                equal_nan=True,
+            )
+            mismatch_mask = ~close & both_finite
+            mismatch_idxs = list(zip(*np.where(mismatch_mask)))
+            if mismatch_idxs:
+                shown = mismatch_idxs[:_MAX_DIFF_SAMPLES]
+                lines.append(f"  mismatching elements ({len(mismatch_idxs)} total):")
+                for idx in shown:
+                    a_val = _format_scalar(actual_f[idx])
+                    e_val = _format_scalar(expected_f[idx])
+                    lines.append(f"    {idx}: actual={a_val:<14} expected={e_val}")
+                if len(mismatch_idxs) > len(shown):
+                    lines.append(
+                        f"    ... and {len(mismatch_idxs) - len(shown)} more"
+                    )
+    else:
+        # Non-numeric: show first few unequal element pairs.
+        ne_mask = actual != expected
+        ne_idxs = list(zip(*np.where(np.asarray(ne_mask))))
+        shown = ne_idxs[:_MAX_DIFF_SAMPLES]
+        if shown:
+            lines.append(
+                f"  unequal elements ({len(ne_idxs)} total):"
+            )
+            for idx in shown:
+                lines.append(
+                    f"    {idx}: actual={actual[idx]!r:<20} expected={expected[idx]!r}"
+                )
+            if len(ne_idxs) > len(shown):
+                lines.append(f"    ... and {len(ne_idxs) - len(shown)} more")
+
+    return "\n".join(lines)
+
+
+def _format_scalar_diff(
+    actual,
+    expected,
+    name: str,
+    rel_tol: Optional[float],
+    abs_tol: Optional[float],
+) -> str:
+    """Build a multi-line diff message for two scalars known to differ."""
+    lines = [f"Variable `{name}` differs from expected:"]
+    lines.append(f"  expected: {_format_scalar(expected)}")
+    lines.append(f"  actual:   {_format_scalar(actual)}")
+    try:
+        abs_diff = abs(actual - expected)
+        lines.append(f"  abs diff: {_format_scalar(float(abs_diff))}")
+        if expected != 0:
+            rel_diff = abs_diff / abs(expected)
+            lines.append(f"  rel diff: {_format_scalar(float(rel_diff))}")
+        if rel_tol is not None or abs_tol is not None:
+            lines.append(f"  tolerances: rel={rel_tol!r}  abs={abs_tol!r}")
+    except Exception:  # noqa: BLE001 — never let formatting raise
+        pass
+    return "\n".join(lines)
+
+
+def _clip(s: str, max_len: int = _MAX_STR_LEN) -> str:
+    """Clip a string for inclusion in an error message."""
+    s = str(s)
+    if len(s) <= max_len:
+        return s
+    head = max_len - 16  # leave room for the "... <N more chars>" tail
+    return s[:head] + f"...<{len(s) - head} more chars>"
+
+
+def _first_diff_index(a: str, b: str) -> Optional[int]:
+    """Return the first index where two strings differ, or None if equal."""
+    n = min(len(a), len(b))
+    for i in range(n):
+        if a[i] != b[i]:
+            return i
+    if len(a) != len(b):
+        return n
+    return None
+
+
+def _format_pattern_diff(
+    actual_str: str,
+    pattern: str,
+    qualification: str,
+    name: str,
+) -> str:
+    """Build a multi-line diff message for the matches/contains/regex paths."""
+    lines = [f"Variable `{name}` failed `{qualification}` check:"]
+    lines.append(f"  pattern: {_clip(pattern)!r}")
+    lines.append(f"  actual:  {_clip(actual_str)!r}")
+    lines.append(f"  lengths: actual={len(actual_str)}  pattern={len(pattern)}")
+    if qualification == "matches":
+        idx = _first_diff_index(actual_str, pattern)
+        if idx is not None:
+            ctx_start = max(idx - 8, 0)
+            ctx_end_a = min(idx + 8, len(actual_str))
+            ctx_end_p = min(idx + 8, len(pattern))
+            lines.append(
+                f"  first diff at index {idx}: "
+                f"actual={actual_str[ctx_start:ctx_end_a]!r:<24} "
+                f"pattern={pattern[ctx_start:ctx_end_p]!r}"
+            )
+    return "\n".join(lines)
+
+
 def compare_values(actual, expected, rel_tol=None, abs_tol=None, name="value"):
     """
     Compare two values with tolerance. Raises AssertionError on mismatch.
@@ -105,16 +354,26 @@ def compare_values(actual, expected, rel_tol=None, abs_tol=None, name="value"):
         expected = np.asarray(expected)
 
         if actual.shape != expected.shape:
-            raise AssertionError(
-                f"Shape mismatch for '{name}': {actual.shape} vs {expected.shape}"
+            msg = (
+                f"Variable `{name}` has wrong shape:\n"
+                f"  expected: {expected.shape}\n"
+                f"  actual:   {actual.shape}"
             )
+            hint = _shape_hint(actual.shape, expected.shape)
+            if hint:
+                msg += "\n" + hint
+            raise AssertionError(msg)
 
         if np.issubdtype(expected.dtype, np.number):
             if not np.allclose(actual, expected, rtol=rel_tol, atol=abs_tol, equal_nan=True):
-                raise AssertionError(f"Array values differ for '{name}'")
+                raise AssertionError(
+                    _format_array_diff(actual, expected, name, rel_tol, abs_tol)
+                )
         else:
             if not np.array_equal(actual, expected):
-                raise AssertionError(f"Array values differ for '{name}'")
+                raise AssertionError(
+                    _format_array_diff(actual, expected, name, rel_tol, abs_tol)
+                )
         return
 
     # Handle numeric scalars
@@ -145,7 +404,9 @@ def compare_values(actual, expected, rel_tol=None, abs_tol=None, name="value"):
         if abs_diff <= abs_tol:
             return
 
-        raise AssertionError(f"Value mismatch for '{name}': {actual} vs {expected}")
+        raise AssertionError(
+            _format_scalar_diff(actual, expected, name, rel_tol, abs_tol)
+        )
 
     # Handle complex numbers
     if isinstance(expected, complex):
@@ -155,23 +416,48 @@ def compare_values(actual, expected, rel_tol=None, abs_tol=None, name="value"):
             )
         if not (abs(actual.real - expected.real) <= abs_tol and
                 abs(actual.imag - expected.imag) <= abs_tol):
-            raise AssertionError(f"Value mismatch for '{name}': {actual} vs {expected}")
+            raise AssertionError(
+                _format_scalar_diff(actual, expected, name, rel_tol, abs_tol)
+            )
         return
 
     # Handle strings
     if isinstance(expected, str):
-        assert actual == expected, \
-            f"String mismatch for '{name}': '{actual}' vs '{expected}'"
+        if actual != expected:
+            actual_str = str(actual)
+            idx = _first_diff_index(actual_str, expected)
+            msg = (
+                f"Variable `{name}` differs from expected:\n"
+                f"  expected: {_clip(expected)!r}\n"
+                f"  actual:   {_clip(actual_str)!r}\n"
+                f"  lengths:  actual={len(actual_str)}  expected={len(expected)}"
+            )
+            if idx is not None:
+                ctx_start = max(idx - 8, 0)
+                ctx_end_a = min(idx + 8, len(actual_str))
+                ctx_end_e = min(idx + 8, len(expected))
+                msg += (
+                    f"\n  first diff at index {idx}: "
+                    f"actual={actual_str[ctx_start:ctx_end_a]!r}  "
+                    f"expected={expected[ctx_start:ctx_end_e]!r}"
+                )
+            raise AssertionError(msg)
         return
 
     # Handle lists/tuples
     if isinstance(expected, (list, tuple)):
         if not isinstance(actual, (list, tuple)):
-            raise AssertionError(f"Type mismatch for '{name}': expected list/tuple")
+            raise AssertionError(
+                f"Variable `{name}` has wrong type:\n"
+                f"  expected: {type(expected).__name__} (list/tuple)\n"
+                f"  actual:   {type(actual).__name__}"
+            )
 
         if len(actual) != len(expected):
             raise AssertionError(
-                f"Length mismatch for '{name}': {len(actual)} vs {len(expected)}"
+                f"Variable `{name}` has wrong length:\n"
+                f"  expected: {len(expected)}\n"
+                f"  actual:   {len(actual)}"
             )
 
         for i, (a, e) in enumerate(zip(actual, expected)):
@@ -181,19 +467,33 @@ def compare_values(actual, expected, rel_tol=None, abs_tol=None, name="value"):
     # Handle dicts
     if isinstance(expected, dict):
         if not isinstance(actual, dict):
-            raise AssertionError(f"Type mismatch for '{name}': expected dict")
-
-        if set(actual.keys()) != set(expected.keys()):
             raise AssertionError(
-                f"Key mismatch for '{name}': {set(actual.keys())} vs {set(expected.keys())}"
+                f"Variable `{name}` has wrong type:\n"
+                f"  expected: dict\n"
+                f"  actual:   {type(actual).__name__}"
             )
+
+        actual_keys = set(actual.keys())
+        expected_keys = set(expected.keys())
+        if actual_keys != expected_keys:
+            missing = expected_keys - actual_keys
+            extra = actual_keys - expected_keys
+            msg = [f"Variable `{name}` has wrong keys:"]
+            if missing:
+                msg.append(f"  missing: {sorted(missing)!r}")
+            if extra:
+                msg.append(f"  extra:   {sorted(extra)!r}")
+            raise AssertionError("\n".join(msg))
 
         for key in expected:
             compare_values(actual[key], expected[key], rel_tol, abs_tol, f"{name}[{key!r}]")
         return
 
     # Default comparison
-    assert actual == expected, f"Value mismatch for '{name}': {actual} vs {expected}"
+    if actual != expected:
+        raise AssertionError(
+            _format_scalar_diff(actual, expected, name, rel_tol, abs_tol)
+        )
 
 
 # =============================================================================
@@ -494,31 +794,55 @@ def compare_variable_by_qualification(
         compare_values(val_student, ref, relative_tolerance, absolute_tolerance, name)
 
     elif qualification == QualificationEnum.matches:
-        assert str(val_student) == pattern, \
-            f"Variable `{name}` does not match pattern `{pattern}`"
+        actual_str = str(val_student)
+        if actual_str != pattern:
+            raise AssertionError(
+                _format_pattern_diff(actual_str, pattern, "matches", name)
+            )
 
     elif qualification == QualificationEnum.contains:
-        assert pattern in str(val_student), \
-            f"Variable `{name}` does not contain `{pattern}`"
+        actual_str = str(val_student)
+        if pattern not in actual_str:
+            raise AssertionError(
+                _format_pattern_diff(actual_str, pattern, "contains", name)
+            )
 
     elif qualification == QualificationEnum.startsWith:
-        assert str(val_student).startswith(pattern), \
-            f"Variable `{name}` does not start with `{pattern}`"
+        actual_str = str(val_student)
+        if not actual_str.startswith(pattern):
+            raise AssertionError(
+                _format_pattern_diff(actual_str, pattern, "startsWith", name)
+            )
 
     elif qualification == QualificationEnum.endsWith:
-        assert str(val_student).endswith(pattern), \
-            f"Variable `{name}` does not end with `{pattern}`"
+        actual_str = str(val_student)
+        if not actual_str.endswith(pattern):
+            raise AssertionError(
+                _format_pattern_diff(actual_str, pattern, "endsWith", name)
+            )
 
     elif qualification == QualificationEnum.regexp:
+        actual_str = str(val_student)
         try:
-            match = safe_regex_search(pattern, str(val_student))
+            match = safe_regex_search(pattern, actual_str)
         except RegexTimeoutError:
             pytest.fail(f"Pattern `{pattern}` timed out (possible ReDoS)")
-        assert match, f"Variable `{name}` does not match regex `{pattern}`"
+        if not match:
+            raise AssertionError(
+                _format_pattern_diff(actual_str, pattern, "regexp", name)
+            )
 
     elif qualification == QualificationEnum.count:
-        assert str(val_student).count(pattern) == count_requirement, \
-            f"Variable `{name}` does not contain pattern `{pattern}` {count_requirement} times"
+        actual_str = str(val_student)
+        actual_count = actual_str.count(pattern)
+        if actual_count != count_requirement:
+            raise AssertionError(
+                f"Variable `{name}` failed `count` check:\n"
+                f"  pattern:  {_clip(pattern)!r}\n"
+                f"  expected: {count_requirement} occurrence(s)\n"
+                f"  actual:   {actual_count} occurrence(s)\n"
+                f"  in:       {_clip(actual_str)!r}"
+            )
 
     else:
         pytest.skip(f"Unsupported qualification: {qualification}")
@@ -549,15 +873,21 @@ def _check_shape_common(actual, expected, name: str):
         else:
             shape_expected = ()
         if shape_actual != shape_expected:
-            pytest.fail(
-                f"Variable `{name}` has incorrect shape: "
-                f"{shape_actual} vs {shape_expected}"
+            msg = (
+                f"Variable `{name}` has wrong shape:\n"
+                f"  expected: {shape_expected}\n"
+                f"  actual:   {shape_actual}"
             )
+            hint = _shape_hint(shape_actual, shape_expected)
+            if hint:
+                msg += "\n" + hint
+            pytest.fail(msg)
     elif hasattr(actual, '__len__') and hasattr(expected, '__len__'):
         if len(actual) != len(expected):
             pytest.fail(
-                f"Variable `{name}` has incorrect length: "
-                f"{len(actual)} vs {len(expected)}"
+                f"Variable `{name}` has wrong length:\n"
+                f"  expected: {len(expected)}\n"
+                f"  actual:   {len(actual)}"
             )
 
 

--- a/computor-testing/tests/test_diff_formatters.py
+++ b/computor-testing/tests/test_diff_formatters.py
@@ -1,0 +1,303 @@
+"""Unit tests for the assertion diff formatters in ``testers.tests.test_base``.
+
+These cover the string-only enrichment introduced in #117: helpers that
+build the multi-line ``AssertionError`` messages surfaced as
+``ComputorReportSub.statusMessage`` for every failing variable test
+across all language testers.
+
+The point of the tests is **not** to pin the exact message text (so we
+can keep iterating on wording) but to guarantee the salient pieces of
+information actually appear:
+
+- variable name in backticks
+- both shapes / dtypes when they differ
+- a max abs diff number with a coordinate
+- mismatching-element samples with actual/expected pairs
+- transpose hint when shapes are 2D-reversed
+- expected vs. actual scalar values + abs/rel diff
+- pattern + actual + a length / first-diff hint for matches/regex/contains
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from testers.tests.test_base import (  # type: ignore
+    _clip,
+    _first_diff_index,
+    _format_array_diff,
+    _format_pattern_diff,
+    _format_scalar,
+    _format_scalar_diff,
+    _shape_hint,
+    compare_values,
+)
+
+
+# ---------------------------------------------------------------------------
+# _format_scalar
+# ---------------------------------------------------------------------------
+
+
+class TestFormatScalar:
+    def test_plain_float(self):
+        assert _format_scalar(3.14) == "3.14"
+
+    def test_nan(self):
+        assert _format_scalar(float("nan")) == "NaN"
+
+    def test_pos_inf(self):
+        assert _format_scalar(float("inf")) == "+inf"
+
+    def test_neg_inf(self):
+        assert _format_scalar(float("-inf")) == "-inf"
+
+    def test_int(self):
+        assert _format_scalar(42) == "42"
+
+    def test_string_uses_repr(self):
+        assert _format_scalar("hello") == "'hello'"
+
+
+# ---------------------------------------------------------------------------
+# _shape_hint
+# ---------------------------------------------------------------------------
+
+
+class TestShapeHint:
+    def test_same_shape_no_hint(self):
+        assert _shape_hint((3, 4), (3, 4)) == ""
+
+    def test_2d_transposed_hint(self):
+        hint = _shape_hint((4, 3), (3, 4))
+        assert "transpose" in hint.lower()
+
+    def test_higher_rank_reversed_hint(self):
+        hint = _shape_hint((2, 3, 4), (4, 3, 2))
+        assert "axis order" in hint.lower() or "reversed" in hint.lower()
+
+    def test_same_total_elements_reshape_hint(self):
+        hint = _shape_hint((6,), (2, 3))
+        assert "reshape" in hint.lower()
+
+    def test_no_relation_no_hint(self):
+        # Total element count differs, no transpose pattern.
+        assert _shape_hint((2, 2), (3, 3)) == ""
+
+
+# ---------------------------------------------------------------------------
+# _format_array_diff
+# ---------------------------------------------------------------------------
+
+
+class TestFormatArrayDiff:
+    def test_includes_name_and_shape(self):
+        a = np.array([[1.0, 2.0]])
+        e = np.array([[1.0, 3.0]])
+        msg = _format_array_diff(a, e, "r2", 1e-9, 1e-12)
+        assert "`r2`" in msg
+        assert "shape: (1, 2)" in msg
+
+    def test_includes_max_abs_diff_and_index(self):
+        a = np.array([1.0, 2.0, 3.0])
+        e = np.array([1.0, 2.0, 5.5])
+        msg = _format_array_diff(a, e, "x", 1e-9, 1e-12)
+        assert "max abs diff" in msg
+        # Diff is 2.5 at index 2.
+        assert "2.5" in msg
+        assert "(2,)" in msg
+
+    def test_includes_mismatch_samples(self):
+        a = np.array([1.0, 2.0, 3.0])
+        e = np.array([9.0, 2.0, 9.0])
+        msg = _format_array_diff(a, e, "x", 1e-9, 1e-12)
+        assert "mismatching elements" in msg
+        # Both mismatching positions referenced
+        assert "actual=1" in msg.replace(" ", "")
+        assert "actual=3" in msg.replace(" ", "")
+        assert "expected=9" in msg.replace(" ", "")
+
+    def test_caps_mismatch_sample_count(self):
+        a = np.zeros(20)
+        e = np.arange(1, 21).astype(float)
+        msg = _format_array_diff(a, e, "x", 1e-9, 1e-12)
+        # Should mention there are more, capped at the configured max.
+        assert "more" in msg
+        # Should still report total count.
+        assert "20" in msg
+
+    def test_dtype_mismatch_shows_both(self):
+        a = np.array([1, 2], dtype=np.int32)
+        e = np.array([1.0, 2.0], dtype=np.float64)
+        msg = _format_array_diff(a, e, "x", None, None)
+        assert "int32" in msg
+        assert "float64" in msg
+
+    def test_shape_mismatch_skips_index_diff(self):
+        # When shapes differ, we cannot report indices — make sure we don't
+        # crash and do return *something* useful.
+        a = np.array([1.0, 2.0])
+        e = np.array([[1.0], [2.0]])
+        msg = _format_array_diff(a, e, "x", None, None)
+        assert "shape" in msg.lower()
+        # No max-abs-diff line because shapes differ.
+        assert "max abs diff" not in msg
+
+    def test_nan_disagreement(self):
+        a = np.array([1.0, float("nan"), 3.0])
+        e = np.array([1.0, 2.0, 3.0])
+        msg = _format_array_diff(a, e, "x", None, None)
+        assert "NaN" in msg
+
+    def test_non_numeric_arrays(self):
+        a = np.array(["a", "b", "c"])
+        e = np.array(["a", "x", "c"])
+        msg = _format_array_diff(a, e, "labels", None, None)
+        assert "unequal elements" in msg
+        assert "'b'" in msg
+        assert "'x'" in msg
+
+
+# ---------------------------------------------------------------------------
+# _format_scalar_diff
+# ---------------------------------------------------------------------------
+
+
+class TestFormatScalarDiff:
+    def test_basic_mismatch(self):
+        msg = _format_scalar_diff(3.14, 3.0, "pi", 1e-9, 1e-12)
+        assert "`pi`" in msg
+        assert "3.14" in msg
+        assert "3" in msg  # expected
+        assert "abs diff" in msg
+        assert "rel diff" in msg
+
+    def test_zero_expected_skips_rel_diff(self):
+        msg = _format_scalar_diff(0.5, 0.0, "x", 1e-9, 1e-12)
+        # No rel diff line because expected is zero.
+        assert "rel diff" not in msg
+        assert "abs diff" in msg
+
+    def test_includes_tolerances_when_given(self):
+        msg = _format_scalar_diff(1.0, 2.0, "x", 1e-9, 1e-12)
+        assert "tolerances" in msg
+
+    def test_no_tolerances_no_line(self):
+        msg = _format_scalar_diff(1.0, 2.0, "x", None, None)
+        assert "tolerances" not in msg
+
+
+# ---------------------------------------------------------------------------
+# _format_pattern_diff
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPatternDiff:
+    def test_includes_pattern_actual_lengths(self):
+        msg = _format_pattern_diff("hello world", "hella world", "matches", "out")
+        assert "`out`" in msg
+        assert "matches" in msg
+        assert "hello world" in msg
+        assert "hella world" in msg
+        assert "lengths" in msg
+
+    def test_matches_shows_first_diff(self):
+        # Difference at index 4 ('o' vs 'a').
+        msg = _format_pattern_diff("hello", "hella", "matches", "x")
+        assert "first diff at index 4" in msg
+
+    def test_clips_long_strings(self):
+        long_actual = "a" * 1000
+        long_pattern = "b" * 1000
+        msg = _format_pattern_diff(long_actual, long_pattern, "matches", "x")
+        # Clipped marker present, total length bound is sane.
+        assert "more chars" in msg
+        assert len(msg) < 2_000
+
+
+# ---------------------------------------------------------------------------
+# _first_diff_index
+# ---------------------------------------------------------------------------
+
+
+class TestFirstDiffIndex:
+    def test_equal_strings(self):
+        assert _first_diff_index("foo", "foo") is None
+
+    def test_different_at_index_0(self):
+        assert _first_diff_index("xfoo", "foo") == 0
+
+    def test_different_in_middle(self):
+        assert _first_diff_index("foo", "fxo") == 1
+
+    def test_one_is_prefix(self):
+        assert _first_diff_index("foo", "foobar") == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration through compare_values — ensure the message is *raised*
+# ---------------------------------------------------------------------------
+
+
+class TestCompareValuesIntegration:
+    def test_array_mismatch_produces_rich_message(self):
+        a = np.array([1.0, 2.0, 9.0])
+        e = np.array([1.0, 2.0, 3.0])
+        with pytest.raises(AssertionError) as exc:
+            compare_values(a, e, name="r2")
+        msg = str(exc.value)
+        assert "`r2`" in msg
+        assert "max abs diff" in msg
+        # Sanity check: the element pair is referenced.
+        assert "actual=9" in msg.replace(" ", "")
+
+    def test_scalar_mismatch_produces_rich_message(self):
+        with pytest.raises(AssertionError) as exc:
+            compare_values(1.5, 1.0, name="x")
+        msg = str(exc.value)
+        assert "`x`" in msg
+        assert "abs diff" in msg
+
+    def test_shape_mismatch_includes_transpose_hint(self):
+        a = np.zeros((4, 3))
+        e = np.zeros((3, 4))
+        with pytest.raises(AssertionError) as exc:
+            compare_values(a, e, name="m")
+        msg = str(exc.value)
+        assert "wrong shape" in msg
+        assert "transpose" in msg.lower()
+
+    def test_dict_key_mismatch_lists_missing_and_extra(self):
+        with pytest.raises(AssertionError) as exc:
+            compare_values({"a": 1, "x": 2}, {"a": 1, "b": 2}, name="d")
+        msg = str(exc.value)
+        assert "`d`" in msg
+        assert "wrong keys" in msg
+        assert "missing" in msg
+        assert "'b'" in msg
+        assert "extra" in msg
+        assert "'x'" in msg
+
+    def test_string_mismatch_includes_first_diff(self):
+        with pytest.raises(AssertionError) as exc:
+            compare_values("hello", "hella", name="s")
+        msg = str(exc.value)
+        assert "`s`" in msg
+        assert "first diff at index 4" in msg
+
+
+# ---------------------------------------------------------------------------
+# _clip
+# ---------------------------------------------------------------------------
+
+
+class TestClip:
+    def test_short_string_unchanged(self):
+        assert _clip("hello", max_len=200) == "hello"
+
+    def test_long_string_clipped(self):
+        s = "x" * 500
+        clipped = _clip(s, max_len=200)
+        assert len(clipped) <= 220  # tail "<N more chars>" extra
+        assert "more chars" in clipped


### PR DESCRIPTION
Closes #117

## Summary

The single chokepoint for almost every variable mismatch in the test runner — \`compare_values\` and \`compare_variable_by_qualification\` in \`computor-testing/testers/tests/test_base.py\` — was raising one-line AssertionErrors that gave students nothing to work with. Since the pytest hook at \`conftest_base.py:913\` writes \`str(exc.value)\` straight into \`ComputorReportSub.statusMessage\`, those one-liners were what students saw in the web UI / report.

This PR replaces the messages with multi-line diagnostics. **String-only — no DTO change, no UI dependency.** Every language tester (Python / Octave / R / Julia / C / Fortran / Document) benefits, since they all funnel through these helpers.

## What's new

Helpers in \`test_base.py\`:

| helper | does |
|---|---|
| \`_format_scalar(v)\` | NaN / inf-aware compact formatter |
| \`_shape_hint(actual, expected)\` | transpose / reshape suggestions when shapes mismatch |
| \`_format_array_diff(...)\` | shape, dtype, max abs/rel diff (+ coordinates), NaN disagreement, up to 5 mismatching element pairs, "+ N more" tail |
| \`_format_scalar_diff(...)\` | expected, actual, abs diff, rel diff (when meaningful), tolerances applied |
| \`_format_pattern_diff(...)\` | for matches/contains/startsWith/endsWith/regexp/count: pattern, actual (clipped), lengths, first-differing-character index for \`matches\` |
| \`_clip\` / \`_first_diff_index\` | string-handling utilities |

Wired into:

- \`compare_values\` for numpy arrays, scalars, complex, strings, lists/tuples, dicts.
- \`compare_variable_by_qualification\` for matches / contains / startsWith / endsWith / regexp / count.
- \`_check_shape_common\` (uses \`_shape_hint\`).

## Before vs. after

| | before | after |
|---|---|---|
| array mismatch | \`Array values differ for 'r2'\` | shape, dtype, max abs/rel diff with index, sample mismatching pairs |
| transposed shape | \`Shape mismatch for 'M': (4,3) vs (3,4)\` | same + \`hint: shapes look transposed — did you forget .T?\` |
| scalar off by epsilon | \`Value mismatch for 'pi': 3.140000001 vs 3.14\` | expected/actual/abs/rel/tolerances |
| dict key drift | \`Key mismatch for 'd': {'a','x'} vs {'a','b'}\` | clean missing/extra split |
| string mismatch | \`String mismatch for 's': 'hello' vs 'hella'\` | clipped values + lengths + \`first diff at index 4\` |

Sample real output (commit body and tests have more):

\`\`\`
Variable \`r2\` differs from expected:
  shape: (2, 3)
  dtype: float64
  tolerances: rel=1e-09  abs=1e-12
  max abs diff: 4 at index (1, 0)
  max rel diff: 1 at index (1, 0)
  mismatching elements (2 total):
    (0, 2): actual=3.5            expected=3
    (1, 0): actual=-8.88178e-16   expected=4
\`\`\`

\`\`\`
Variable \`M\` has wrong shape:
  expected: (3, 4)
  actual:   (4, 3)
  hint: shapes look transposed — did you forget \`.T\` or transpose?
\`\`\`

## Out of scope (next PR — Option B)

Attaching a structured \`detail\` dict to the exception so the pytest hook can also populate \`ComputorReportSub.debug\` and \`details\`. Schema fields are already there in \`testing_report.py\`; we just don't fill them yet. Once landed, the web UI can render the diff as a real table and the AI tutor agent can read \`max_abs_diff\` / mismatch indices directly. Tracked separately.

## Test plan

- [x] \`pytest computor-testing/tests/test_diff_formatters.py\` — 37 cases, all green.
- [ ] Run a real submission against an example test (e.g. \`computor-testing/examples/itpcp.pgph.py\`) and confirm the new \`statusMessage\` shape in the resulting \`testSummary.json\`.
- [ ] Spot-check that a passing test still produces no diff message (formatter not invoked).
- [ ] Confirm the AI-tutor agent's debug-prompt path still receives a useful string in \`statusMessage\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)