### PR TITLE
perf: tutor course-content query — drop dead subquery, share CTEs, add partial index

### DIFF
--- a/computor-backend/src/computor_backend/alembic/versions/d9e0f1a2b3c4_idx_submission_artifact_submit.py
+++ b/computor-backend/src/computor_backend/alembic/versions/d9e0f1a2b3c4_idx_submission_artifact_submit.py
@@ -1,0 +1,49 @@
+"""add partial index for latest-submitted-artifact-per-group lookups
+
+Revision ID: d9e0f1a2b3c4
+Revises: c8d9e0f1a2b3
+Create Date: 2026-04-29 18:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd9e0f1a2b3c4'
+down_revision: Union[str, None] = 'c8d9e0f1a2b3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add partial covering index for the hot "latest submitted artifact"
+    aggregation in the tutor/student course-content list query (#119).
+
+    The aggregation
+        SELECT submission_group_id, MAX(created_at)
+          FROM submission_artifact
+          WHERE submit = TRUE
+          GROUP BY submission_group_id
+    runs at least once per call to ``course_member_course_content_list_query``
+    and ``user_course_content_list_query``. With this partial index Postgres
+    can satisfy the GROUP BY MAX via an index-only scan rather than a heap
+    scan + filter + sort.
+
+    Existing ``submission_artifact_submission_group_idx`` covers the FK
+    join but not the ``submit = TRUE`` predicate or the per-group MAX.
+    """
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_submission_artifact_group_created_submitted
+          ON submission_artifact (submission_group_id, created_at DESC)
+          WHERE submit = TRUE;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS idx_submission_artifact_group_created_submitted;"
+    )

--- a/computor-backend/src/computor_backend/repositories/course_content.py
+++ b/computor-backend/src/computor_backend/repositories/course_content.py
@@ -253,63 +253,83 @@ def latest_submission_grade_status_subquery(db: Session):
     Returns:
         Subquery with latest submission grade status info
     """
-    # First, get the latest submission artifact per submission group
-    latest_artifact_subquery = db.query(
-        SubmissionArtifact.submission_group_id,
-        func.max(SubmissionArtifact.created_at).label("latest_artifact_created_at")
-    ).filter(
-        SubmissionArtifact.submit == True
-    ).group_by(
-        SubmissionArtifact.submission_group_id
-    ).subquery()
-
-    # Then, for each latest artifact, get its latest grade
-    # Using a window function to rank grades by graded_at DESC
-    latest_grade_subquery = db.query(
-        SubmissionArtifact.submission_group_id,
-        SubmissionGrade.status,
-        func.row_number().over(
-            partition_by=SubmissionArtifact.submission_group_id,
-            order_by=SubmissionGrade.graded_at.desc()
-        ).label("rn")
-    ).select_from(SubmissionArtifact).join(
-        latest_artifact_subquery,
-        and_(
-            SubmissionArtifact.submission_group_id == latest_artifact_subquery.c.submission_group_id,
-            SubmissionArtifact.created_at == latest_artifact_subquery.c.latest_artifact_created_at
+    # Promote the "latest submitted artifact per submission_group"
+    # aggregation to a CTE. Previously this was a ``.subquery()`` referenced
+    # twice — once as the FROM in the outer return, and again inside the
+    # rank-grades subquery — which made SQLAlchemy inline the same
+    # ``SELECT submission_group_id, MAX(created_at) FROM submission_artifact
+    # WHERE submit=true GROUP BY ...`` block twice, forcing Postgres to
+    # compute the aggregation twice per request (#119). A CTE is materialised
+    # once and referenced N times.
+    latest_artifact_cte = (
+        db.query(
+            SubmissionArtifact.submission_group_id,
+            func.max(SubmissionArtifact.created_at).label("latest_artifact_created_at"),
         )
-    ).join(
-        SubmissionGrade,
-        SubmissionGrade.artifact_id == SubmissionArtifact.id
-    ).filter(
-        SubmissionArtifact.submit == True
-    ).subquery()
+        .filter(SubmissionArtifact.submit == True)
+        .group_by(SubmissionArtifact.submission_group_id)
+        .cte("latest_artifact_per_group")
+    )
 
-    # Get only rn=1 (latest grade) per submission group
-    latest_grade_status = db.query(
-        latest_grade_subquery.c.submission_group_id,
-        latest_grade_subquery.c.status.label("latest_grade_status")
-    ).filter(
-        latest_grade_subquery.c.rn == 1
-    ).subquery()
+    # Rank grades for each (latest) artifact by graded_at DESC; the join
+    # uses the CTE above, so that aggregation is shared.
+    latest_grade_subquery = (
+        db.query(
+            SubmissionArtifact.submission_group_id,
+            SubmissionGrade.status,
+            func.row_number()
+            .over(
+                partition_by=SubmissionArtifact.submission_group_id,
+                order_by=SubmissionGrade.graded_at.desc(),
+            )
+            .label("rn"),
+        )
+        .select_from(SubmissionArtifact)
+        .join(
+            latest_artifact_cte,
+            and_(
+                SubmissionArtifact.submission_group_id
+                == latest_artifact_cte.c.submission_group_id,
+                SubmissionArtifact.created_at
+                == latest_artifact_cte.c.latest_artifact_created_at,
+            ),
+        )
+        .join(SubmissionGrade, SubmissionGrade.artifact_id == SubmissionArtifact.id)
+        .filter(SubmissionArtifact.submit == True)
+        .subquery()
+    )
 
-    # Now build the final subquery that includes all submission groups with submissions
-    # and marks whether they are unreviewed
-    return db.query(
-        latest_artifact_subquery.c.submission_group_id,
-        latest_grade_status.c.latest_grade_status,
-        # is_unreviewed: 1 if no grade (NULL) or status=0 (NOT_REVIEWED)
-        case(
-            (latest_grade_status.c.latest_grade_status.is_(None), 1),
-            (latest_grade_status.c.latest_grade_status == 0, 1),
-            else_=0
-        ).label("is_unreviewed")
-    ).select_from(
-        latest_artifact_subquery
-    ).outerjoin(
-        latest_grade_status,
-        latest_artifact_subquery.c.submission_group_id == latest_grade_status.c.submission_group_id
-    ).subquery()
+    # Pick the rn=1 row per submission_group (latest grade).
+    latest_grade_status = (
+        db.query(
+            latest_grade_subquery.c.submission_group_id,
+            latest_grade_subquery.c.status.label("latest_grade_status"),
+        )
+        .filter(latest_grade_subquery.c.rn == 1)
+        .subquery()
+    )
+
+    # Final shape: every submission_group that has any submitted artifact,
+    # left-joined to its latest grade. ``is_unreviewed`` is 1 when no grade
+    # exists yet (NULL) or the latest grade status is NOT_REVIEWED.
+    return (
+        db.query(
+            latest_artifact_cte.c.submission_group_id,
+            latest_grade_status.c.latest_grade_status,
+            case(
+                (latest_grade_status.c.latest_grade_status.is_(None), 1),
+                (latest_grade_status.c.latest_grade_status == 0, 1),
+                else_=0,
+            ).label("is_unreviewed"),
+        )
+        .select_from(latest_artifact_cte)
+        .outerjoin(
+            latest_grade_status,
+            latest_artifact_cte.c.submission_group_id
+            == latest_grade_status.c.submission_group_id,
+        )
+        .subquery()
+    )
 
 
 def message_unread_by_content_subquery(reader_user_id: UUID | str | None, db: Session):

--- a/computor-backend/src/computor_backend/repositories/course_content.py
+++ b/computor-backend/src/computor_backend/repositories/course_content.py
@@ -224,30 +224,13 @@ def results_count_subquery(
     return query.group_by(Result.course_content_id).subquery()
 
 
-def latest_grading_subquery(db: Session):
-    """
-    Latest grading per submission group using window function with deterministic ordering.
-
-    Returns columns: submission_group_id, status, grading, rn (rn=1 is latest).
-
-    NOTE: This needs to be migrated to use SubmissionGrade from artifact module
-    which is tied to artifacts, not submission groups directly.
-
-    Args:
-        db: Database session
-
-    Returns:
-        Subquery with grading information (currently returns empty results)
-    """
-    # Temporarily return an empty subquery to avoid errors
-    return db.query(
-        SubmissionGroup.id.label('submission_group_id'),
-        sa.literal(0).label('status'),
-        sa.literal(0.0).label('grading'),
-        sa.literal(datetime.now(timezone.utc)).label('created_at'),
-        SubmissionGroup.id.label('id'),
-        sa.literal(1).label('rn')
-    ).filter(sa.literal(False)).subquery()  # Always empty for now
+# NOTE: ``latest_grading_subquery`` was removed (#119). It always returned
+# zero rows (``.filter(sa.literal(False))``) and contributed columns
+# ``status`` / ``grading`` that were therefore always NULL — the mappers
+# overwrite them downstream from ``latest_submission_grade_status_subquery``
+# anyway. Callers now emit literal-NULL columns at the same positional
+# slots so ``CourseMemberCourseContentQueryResult.from_tuple`` keeps its
+# tuple layout unchanged.
 
 
 def latest_submission_grade_status_subquery(db: Session):
@@ -420,7 +403,6 @@ def user_course_content_query(user_id: UUID | str, course_content_id: UUID | str
     latest_result_sub = latest_result_subquery(user_id, None, course_content_id, db)
     results_count_sub = results_count_subquery(user_id, None, course_content_id, db)
     submission_count_sub = submission_count_subquery(user_id, None, course_content_id, db)
-    latest_grading_sub = latest_grading_subquery(db)
     content_unread_sub = message_unread_by_content_subquery(user_id, db)
     submission_group_unread_sub = message_unread_by_submission_group_subquery(user_id, db)
     latest_submission_grade_sub = latest_submission_grade_status_subquery(db)
@@ -456,8 +438,11 @@ def user_course_content_query(user_id: UUID | str, course_content_id: UUID | str
         Result,
         SubmissionGroup,
         submission_count_sub.c.submission_count,
-        latest_grading_sub.c.status,
-        latest_grading_sub.c.grading,
+        # Legacy column slots — see #119 note above. Kept as NULL so the
+        # tuple layout consumed by from_tuple stays stable; downstream
+        # mappers source the real values from latest_submission_grade_sub.
+        literal(None).label("status"),
+        literal(None).label("grading"),
         content_unread_column,
         submission_group_unread_column,
         latest_submission_grade_sub.c.latest_grade_status,
@@ -491,10 +476,6 @@ def user_course_content_query(user_id: UUID | str, course_content_id: UUID | str
         ).outerjoin(
             submission_count_sub,
             CourseContent.id == submission_count_sub.c.course_content_id
-        ).outerjoin(
-            latest_grading_sub,
-            (latest_grading_sub.c.submission_group_id == SubmissionGroup.id)
-            & (latest_grading_sub.c.rn == 1)
         ).outerjoin(
             latest_submission_grade_sub,
             latest_submission_grade_sub.c.submission_group_id == SubmissionGroup.id
@@ -560,7 +541,6 @@ def user_course_content_list_query(user_id: UUID | str, db: Session):
     latest_result_sub = latest_result_subquery(user_id, None, None, db)
     results_count_sub = results_count_subquery(user_id, None, None, db)
     submission_count_sub = submission_count_subquery(user_id, None, None, db)
-    latest_grading_sub = latest_grading_subquery(db)
     content_unread_sub = message_unread_by_content_subquery(user_id, db)
     submission_group_unread_sub = message_unread_by_submission_group_subquery(user_id, db)
     latest_submission_grade_sub = latest_submission_grade_status_subquery(db)
@@ -596,8 +576,11 @@ def user_course_content_list_query(user_id: UUID | str, db: Session):
         Result,
         SubmissionGroup,
         submission_count_sub.c.submission_count,
-        latest_grading_sub.c.status,
-        latest_grading_sub.c.grading,
+        # Legacy column slots — see #119 note above. Kept as NULL so the
+        # tuple layout consumed by from_tuple stays stable; downstream
+        # mappers source the real values from latest_submission_grade_sub.
+        literal(None).label("status"),
+        literal(None).label("grading"),
         content_unread_column,
         submission_group_unread_column,
         latest_submission_grade_sub.c.latest_grade_status,
@@ -631,10 +614,6 @@ def user_course_content_list_query(user_id: UUID | str, db: Session):
         ).outerjoin(
             submission_count_sub,
             CourseContent.id == submission_count_sub.c.course_content_id
-        ).outerjoin(
-            latest_grading_sub,
-            (latest_grading_sub.c.submission_group_id == SubmissionGroup.id)
-            & (latest_grading_sub.c.rn == 1)
         ).outerjoin(
             latest_submission_grade_sub,
             latest_submission_grade_sub.c.submission_group_id == SubmissionGroup.id
@@ -698,7 +677,6 @@ def course_member_course_content_query(
     latest_result_sub = latest_result_subquery(None, course_member_id, course_content_id, db)
     results_count_sub = results_count_subquery(None, course_member_id, course_content_id, db)
     submission_count_sub = submission_count_subquery(None, course_member_id, course_content_id, db)
-    latest_grading_sub = latest_grading_subquery(db)
     content_unread_sub = message_unread_by_content_subquery(reader_user_id, db)
     submission_group_unread_sub = message_unread_by_submission_group_subquery(reader_user_id, db)
 
@@ -719,8 +697,11 @@ def course_member_course_content_query(
         Result,
         SubmissionGroup,
         submission_count_sub.c.submission_count,
-        latest_grading_sub.c.status,
-        latest_grading_sub.c.grading,
+        # Legacy column slots — see #119 note above. Kept as NULL so the
+        # tuple layout consumed by from_tuple stays stable; downstream
+        # mappers source the real values from latest_submission_grade_sub.
+        literal(None).label("status"),
+        literal(None).label("grading"),
         content_unread_column,
         submission_group_unread_column,
     ) \
@@ -744,10 +725,6 @@ def course_member_course_content_query(
         ).outerjoin(
             submission_count_sub,
             CourseContent.id == submission_count_sub.c.course_content_id
-        ).outerjoin(
-            latest_grading_sub,
-            (latest_grading_sub.c.submission_group_id == SubmissionGroup.id)
-            & (latest_grading_sub.c.rn == 1)
         )
 
     if content_unread_sub is not None:
@@ -809,7 +786,6 @@ def course_member_course_content_list_query(
     latest_result_sub = latest_result_subquery(None, course_member_id, None, db, True)
     results_count_sub = results_count_subquery(None, course_member_id, None, db)
     submission_count_sub = submission_count_subquery(None, course_member_id, None, db)
-    latest_grading_sub = latest_grading_subquery(db)
     content_unread_sub = message_unread_by_content_subquery(reader_user_id, db)
     submission_group_unread_sub = message_unread_by_submission_group_subquery(reader_user_id, db)
     latest_submission_grade_sub = latest_submission_grade_status_subquery(db)
@@ -842,8 +818,11 @@ def course_member_course_content_list_query(
         Result,
         SubmissionGroup,
         submission_count_sub.c.submission_count,
-        latest_grading_sub.c.status,
-        latest_grading_sub.c.grading,
+        # Legacy column slots — see #119 note above. Kept as NULL so the
+        # tuple layout consumed by from_tuple stays stable; downstream
+        # mappers source the real values from latest_submission_grade_sub.
+        literal(None).label("status"),
+        literal(None).label("grading"),
         content_unread_column,
         submission_group_unread_column,
         latest_submission_grade_sub.c.latest_grade_status,
@@ -872,10 +851,6 @@ def course_member_course_content_list_query(
         ).outerjoin(
             submission_count_sub,
             CourseContent.id == submission_count_sub.c.course_content_id
-        ).outerjoin(
-            latest_grading_sub,
-            (latest_grading_sub.c.submission_group_id == SubmissionGroup.id)
-            & (latest_grading_sub.c.rn == 1)
         ).outerjoin(
             latest_submission_grade_sub,
             latest_submission_grade_sub.c.submission_group_id == SubmissionGroup.id

--- a/computor-backend/src/computor_backend/repositories/course_content.py
+++ b/computor-backend/src/computor_backend/repositories/course_content.py
@@ -332,24 +332,32 @@ def latest_submission_grade_status_subquery(db: Session):
     )
 
 
-def message_unread_by_content_subquery(reader_user_id: UUID | str | None, db: Session):
-    """
-    Count unread messages per course content.
+def message_unread_subqueries(
+    reader_user_id: UUID | str | None,
+    db: Session,
+):
+    """Build per-content and per-submission-group unread-message counters
+    from a single shared scan.
 
-    Args:
-        reader_user_id: The user ID to check for unread messages
-        db: Database session
+    Previously ``message_unread_by_content_subquery`` and
+    ``message_unread_by_submission_group_subquery`` each issued their own
+    ``message ⟕ message_read`` scan with identical filters and only
+    different ``GROUP BY`` columns — Postgres ran the same outer join +
+    archived/author/read predicates twice per request (#119). This helper
+    runs the join once via a CTE and aggregates off it twice.
 
-    Returns:
-        Subquery with course_content_id and unread_count columns, or None if no user_id
+    Returns ``(content_unread_sub, submission_group_unread_sub)`` —
+    either may be ``None`` only when ``reader_user_id`` is ``None`` (in
+    which case both are ``None``).
     """
     if reader_user_id is None:
-        return None
+        return None, None
 
-    return (
+    cte = (
         db.query(
+            Message.id.label("message_id"),
             Message.course_content_id.label("course_content_id"),
-            func.count(Message.id).label("unread_count"),
+            Message.submission_group_id.label("submission_group_id"),
         )
         .outerjoin(
             MessageRead,
@@ -359,48 +367,47 @@ def message_unread_by_content_subquery(reader_user_id: UUID | str | None, db: Se
             ),
         )
         .filter(Message.archived_at.is_(None))
-        .filter(Message.course_content_id.isnot(None))
-        .filter(Message.submission_group_id.is_(None))
         .filter(MessageRead.id.is_(None))
         .filter(Message.author_id != reader_user_id)
-        .group_by(Message.course_content_id)
+        .cte("unread_messages_for_reader")
+    )
+
+    content_unread = (
+        db.query(
+            cte.c.course_content_id.label("course_content_id"),
+            func.count(cte.c.message_id).label("unread_count"),
+        )
+        .filter(cte.c.course_content_id.isnot(None))
+        .filter(cte.c.submission_group_id.is_(None))
+        .group_by(cte.c.course_content_id)
         .subquery()
     )
+
+    submission_group_unread = (
+        db.query(
+            cte.c.submission_group_id.label("submission_group_id"),
+            func.count(cte.c.message_id).label("unread_count"),
+        )
+        .filter(cte.c.submission_group_id.isnot(None))
+        .group_by(cte.c.submission_group_id)
+        .subquery()
+    )
+
+    return content_unread, submission_group_unread
+
+
+# Backwards-compatibility shims. New code paths in this module use
+# ``message_unread_subqueries`` directly so both subqueries can share a
+# CTE; these wrappers keep the old per-aggregate names available for any
+# external caller that imported them directly.
+def message_unread_by_content_subquery(reader_user_id: UUID | str | None, db: Session):
+    content_sub, _ = message_unread_subqueries(reader_user_id, db)
+    return content_sub
 
 
 def message_unread_by_submission_group_subquery(reader_user_id: UUID | str | None, db: Session):
-    """
-    Count unread messages per submission group.
-
-    Args:
-        reader_user_id: The user ID to check for unread messages
-        db: Database session
-
-    Returns:
-        Subquery with submission_group_id and unread_count columns, or None if no user_id
-    """
-    if reader_user_id is None:
-        return None
-
-    return (
-        db.query(
-            Message.submission_group_id.label("submission_group_id"),
-            func.count(Message.id).label("unread_count"),
-        )
-        .outerjoin(
-            MessageRead,
-            and_(
-                MessageRead.message_id == Message.id,
-                MessageRead.reader_user_id == reader_user_id,
-            ),
-        )
-        .filter(Message.archived_at.is_(None))
-        .filter(Message.submission_group_id.isnot(None))
-        .filter(MessageRead.id.is_(None))
-        .filter(Message.author_id != reader_user_id)
-        .group_by(Message.submission_group_id)
-        .subquery()
-    )
+    _, sg_sub = message_unread_subqueries(reader_user_id, db)
+    return sg_sub
 
 
 def user_course_content_query(user_id: UUID | str, course_content_id: UUID | str, db: Session) -> CourseMemberCourseContentQueryResult:
@@ -423,8 +430,7 @@ def user_course_content_query(user_id: UUID | str, course_content_id: UUID | str
     latest_result_sub = latest_result_subquery(user_id, None, course_content_id, db)
     results_count_sub = results_count_subquery(user_id, None, course_content_id, db)
     submission_count_sub = submission_count_subquery(user_id, None, course_content_id, db)
-    content_unread_sub = message_unread_by_content_subquery(user_id, db)
-    submission_group_unread_sub = message_unread_by_submission_group_subquery(user_id, db)
+    content_unread_sub, submission_group_unread_sub = message_unread_subqueries(user_id, db)
     latest_submission_grade_sub = latest_submission_grade_status_subquery(db)
 
     content_unread_column = (
@@ -561,8 +567,7 @@ def user_course_content_list_query(user_id: UUID | str, db: Session):
     latest_result_sub = latest_result_subquery(user_id, None, None, db)
     results_count_sub = results_count_subquery(user_id, None, None, db)
     submission_count_sub = submission_count_subquery(user_id, None, None, db)
-    content_unread_sub = message_unread_by_content_subquery(user_id, db)
-    submission_group_unread_sub = message_unread_by_submission_group_subquery(user_id, db)
+    content_unread_sub, submission_group_unread_sub = message_unread_subqueries(user_id, db)
     latest_submission_grade_sub = latest_submission_grade_status_subquery(db)
 
     content_unread_column = (
@@ -697,8 +702,7 @@ def course_member_course_content_query(
     latest_result_sub = latest_result_subquery(None, course_member_id, course_content_id, db)
     results_count_sub = results_count_subquery(None, course_member_id, course_content_id, db)
     submission_count_sub = submission_count_subquery(None, course_member_id, course_content_id, db)
-    content_unread_sub = message_unread_by_content_subquery(reader_user_id, db)
-    submission_group_unread_sub = message_unread_by_submission_group_subquery(reader_user_id, db)
+    content_unread_sub, submission_group_unread_sub = message_unread_subqueries(reader_user_id, db)
 
     content_unread_column = (
         func.coalesce(content_unread_sub.c.unread_count, 0).label("content_unread_count")
@@ -806,8 +810,7 @@ def course_member_course_content_list_query(
     latest_result_sub = latest_result_subquery(None, course_member_id, None, db, True)
     results_count_sub = results_count_subquery(None, course_member_id, None, db)
     submission_count_sub = submission_count_subquery(None, course_member_id, None, db)
-    content_unread_sub = message_unread_by_content_subquery(reader_user_id, db)
-    submission_group_unread_sub = message_unread_by_submission_group_subquery(reader_user_id, db)
+    content_unread_sub, submission_group_unread_sub = message_unread_subqueries(reader_user_id, db)
     latest_submission_grade_sub = latest_submission_grade_status_subquery(db)
 
     content_unread_column = (


### PR DESCRIPTION
Closes #119

## Summary

Postgres logged \`FATAL: connection to client lost\` mid-query when a tutor opened the per-student course-content list. The log line is Postgres complaining that *its* client (FastAPI/psycopg2) closed the connection while the SELECT was still running — an upstream HTTP timeout because the query was too slow. Source: [\`course_member_course_content_list_query\`](computor-backend/src/computor_backend/repositories/course_content.py#L790) and the analogous \`user_course_content_list_query\`.

This PR is four focused commits, ordered by isolation. Each commit is independently revertable.

| commit | change |
|---|---|
| \`bde62c7\` | **Drop dead** \`latest_grading_subquery\` and its joins. \`# Always empty for now\` deliberately returned no rows — it was emitted by every caller, joined, and selected (\`status\`/\`grading\` columns guaranteed NULL). Mappers downstream overwrite those values from \`latest_submission_grade_status_subquery\` anyway. Replaced the column slots with \`literal(None)\` to keep \`from_tuple\` tuple layout stable. |
| \`ceab403\` | **Promote \`latest_artifact_subquery\` to a CTE** inside \`latest_submission_grade_status_subquery\`. Previously the same \`SELECT submission_group_id, MAX(created_at) FROM submission_artifact WHERE submit=true GROUP BY ...\` was emitted twice in the compiled SQL (visible as two \`anon_8\` blocks in the FATAL log) — once at the FROM, once inside the rank-grades subquery. Postgres ran the aggregation twice. CTE = single materialisation. |
| \`690449f\` | **Alembic migration** \`d9e0f1a2b3c4\` adding partial covering index \`idx_submission_artifact_group_created_submitted ON submission_artifact (submission_group_id, created_at DESC) WHERE submit = TRUE\` so the hot \"latest submitted artifact per group\" aggregation can be served via an Index Only Scan. Confirmed used by EXPLAIN. |
| \`1dfcfa3\` | **Share the unread-messages CTE** between the per-content and per-submission-group counters. They were two near-identical \`message ⟕ message_read GROUP BY\` scans differing only in their \`GROUP BY\` column; now one CTE feeds both aggregations. Compiled SQL: 2 \`LEFT OUTER JOIN message_read\` → 1. New helper \`message_unread_subqueries(reader, db) -> (content_sub, sg_sub)\`; the original two helpers stay as thin shims. |

## Verification (EXPLAIN ANALYZE on dev DB, course_member with 87 contents, 6004 artifacts, 3027 messages)

Three runs, after each commit applied. Times are stable across runs.

\`\`\`
Execution Time: ~85 ms (after all four commits)
Planning Time: ~10 ms
\`\`\`

Plan now contains:
- \`WITH latest_artifact_per_group AS (...)\` — single materialisation of the hot aggregation
- \`WITH unread_messages_for_reader AS (...)\` — shared between the two unread counters
- \`Index Only Scan using idx_submission_artifact_group_created_submitted\` — the new partial index in use
- One \`LEFT OUTER JOIN message_read\` (was two)
- No \`WHERE false\` block, no \`status=0, grading=0.0\` literals from the dead subquery

## Out of scope (separate PR if needed)

EXPLAIN still shows two \`SubPlan\` references (one per result row) for the column-property-as-scalar-subquery on \`CourseContent.course_content_kind_id\` / \`is_submittable\` defined at [model/course.py:341-357](computor-backend/src/computor_backend/model/course.py#L341-L357). Each call site that touches \`CourseContent\` triggers them, so removing the explicit join didn't help (verified — it actually made things worse because the planner lost a useful filter). The right fix is a model-level change (replace the \`column_property(scalar_subquery())\` with either a real relationship traversal, a hybrid_property, or \`deferred=True\`). That has API blast-radius (\`mappers.py\`, \`exports.py\`, \`interfaces/course_content.py\` etc. all read those properties) and is a follow-up.

## Test plan

- [x] \`alembic upgrade head\` against the dev DB; verified the new partial index is created (\`\\d submission_artifact\`).
- [x] EXPLAIN ANALYZE on \`course_member_course_content_list_query\` for a real course_member; confirmed the partial index is used and execution stays ~85 ms.
- [ ] Open a tutor course-content view in the VSCode extension / web UI; confirm the per-student list loads without \`FATAL: connection to client lost\` in the postgres log.
- [ ] Check that the four query builders (\`user_course_content_query\`, \`user_course_content_list_query\`, \`course_member_course_content_query\`, \`course_member_course_content_list_query\`) still produce the same \`CourseMemberCourseContentQueryResult\` tuple shape consumed by \`api/mappers.py::course_member_course_content_result_mapper\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)