### PR TITLE
fix: scope Result JOIN to the target member in tutor/student course-content list

### DIFF
--- a/computor-backend/src/computor_backend/repositories/course_content.py
+++ b/computor-backend/src/computor_backend/repositories/course_content.py
@@ -494,7 +494,14 @@ def user_course_content_query(user_id: UUID | str, course_content_id: UUID | str
         ).outerjoin(
             Result,
             (Result.course_content_id == latest_result_sub.c.course_content_id) &
-            (Result.created_at == latest_result_sub.c.latest_result_date)
+            (Result.created_at == latest_result_sub.c.latest_result_date) &
+            # Member-scope filter — without it, multiple ``result`` rows that
+            # share the exact ``created_at`` (bulk-inserted bench data, or two
+            # test runs that finish in the same microsecond) all match,
+            # producing a ~600× row blow-up that hangs SQLAlchemy ORM
+            # materialisation. Real users rarely tie timestamps so they don't
+            # hit this; bench-loaded test users do.
+            (Result.course_member_id == CourseMember.id)
         ) \
         .outerjoin(
             results_count_sub,
@@ -631,7 +638,14 @@ def user_course_content_list_query(user_id: UUID | str, db: Session):
         ).outerjoin(
             Result,
             (Result.course_content_id == latest_result_sub.c.course_content_id) &
-            (Result.created_at == latest_result_sub.c.latest_result_date)
+            (Result.created_at == latest_result_sub.c.latest_result_date) &
+            # Member-scope filter — without it, multiple ``result`` rows that
+            # share the exact ``created_at`` (bulk-inserted bench data, or two
+            # test runs that finish in the same microsecond) all match,
+            # producing a ~600× row blow-up that hangs SQLAlchemy ORM
+            # materialisation. Real users rarely tie timestamps so they don't
+            # hit this; bench-loaded test users do.
+            (Result.course_member_id == CourseMember.id)
         ) \
         .outerjoin(
             results_count_sub,
@@ -741,7 +755,14 @@ def course_member_course_content_query(
         ).outerjoin(
             Result,
             (Result.course_content_id == latest_result_sub.c.course_content_id) &
-            (Result.created_at == latest_result_sub.c.latest_result_date)
+            (Result.created_at == latest_result_sub.c.latest_result_date) &
+            # Member-scope filter — without it, multiple ``result`` rows that
+            # share the exact ``created_at`` (bulk-inserted bench data, or two
+            # test runs that finish in the same microsecond) all match,
+            # producing a ~600× row blow-up that hangs SQLAlchemy ORM
+            # materialisation. Real users rarely tie timestamps so they don't
+            # hit this; bench-loaded test users do.
+            (Result.course_member_id == CourseMember.id)
         ) \
         .outerjoin(
             results_count_sub,
@@ -866,7 +887,14 @@ def course_member_course_content_list_query(
         ).outerjoin(
             Result,
             (Result.course_content_id == latest_result_sub.c.course_content_id) &
-            (Result.created_at == latest_result_sub.c.latest_result_date)
+            (Result.created_at == latest_result_sub.c.latest_result_date) &
+            # Member-scope filter — without it, multiple ``result`` rows that
+            # share the exact ``created_at`` (bulk-inserted bench data, or two
+            # test runs that finish in the same microsecond) all match,
+            # producing a ~600× row blow-up that hangs SQLAlchemy ORM
+            # materialisation. Real users rarely tie timestamps so they don't
+            # hit this; bench-loaded test users do.
+            (Result.course_member_id == CourseMember.id)
         ) \
         .outerjoin(
             results_count_sub,


### PR DESCRIPTION
## Symptom

\`GET /tutors/course-members/{cm_id}/course-contents\` (and the analogous student endpoint) hangs forever for **bench-loaded test users**, while real users complete normally. The VSCode extension's 5 s HTTP timeout fires repeatedly; uvicorn's single worker sits at high CPU + multi-GiB RAM with the Postgres connection in \`idle in transaction\`/\`ClientRead\` — Postgres has finished, the *Python ORM materialisation* never returns. \`api.sh\` becomes effectively stuck because of the single-worker config.

## Root cause

The four course-content query builders in [\`repositories/course_content.py\`](computor-backend/src/computor_backend/repositories/course_content.py) join \`Result\` with this predicate:

\`\`\`python
.outerjoin(
    Result,
    (Result.course_content_id == latest_result_sub.c.course_content_id) &
    (Result.created_at == latest_result_sub.c.latest_result_date)
)
\`\`\`

The JOIN matches every \`result\` row whose \`(course_content_id, created_at)\` equals the target member's *latest result timestamp* — but it does **not** restrict the match to the target member. When multiple \`result\` rows for the same course content share the exact \`created_at\` (bulk-inserted bench fixtures, or two test runs that finish in the same microsecond), every tied row matches, producing one inner-query row per (target-content × tied-result) combination across the entire course.

Concrete reproduction (dev DB, course \`python.sc\`):

| | value |
|---|---|
| Target course_member \`271a80a9-...\` — submission_groups | 20 |
| Target course_member — artifacts | 40 |
| Target course_member — grades | 12 |
| Single course_content with **600** \`result\` rows all at \`created_at = 2026-04-21 17:24:06.168271+00\` | bench bulk insert |
| **Inner-query rows for ONE target member** | **12 067** (≈ 87 contents × ~138 ties) |

The inner query then drives \`subqueryload\` / \`joinedload\` of \`submission_groups\`, \`submission_artifacts\`, \`grades\`, \`graded_by\`, \`user\`, etc. — each materialised against a 12 067-row stream, which is what eats the GiB of RAM and never returns.

Real users rarely tie timestamps because their results arrive at different real-time ticks, so the JOIN matches 1:1 and the bug is invisible. Test data created with \`bulk_insert_mappings\` / \`COPY\` / parallel inserts in one transaction commonly all share \`created_at\`.

## Fix

Add \`Result.course_member_id == CourseMember.id\` to the JOIN predicate in all four query builders. \`CourseMember\` is the already-joined *target member* in every variant — filtered by \`CourseMember.user_id == user_id\` in the student variants and by \`CourseMember.id == course_member_id\` in the tutor variants — so the same one-line condition works everywhere.

## Verification

Re-tested on the dev DB after the fix (with the same bench data still in place):

| | before | after |
|---|---|---|
| Inner query row count for target member | **12 067** | **107** |
| \`GET /tutors/course-members/.../course-contents\` (\`course_manager\`) | hangs → 60 s timeout, 0 bytes | **HTTP 200, ~8 s, 193 KB** |
| Worker RSS during the call | 7.7 GiB and growing | normal |
| Postgres conn state | \`idle in transaction\` / \`ClientRead\` for 60+ s | clean |

The remaining ~5 s of the 8 s response is in \`_aggregate_unit_statuses\` (which fires a fallback recursive lookup); that's a separate optimisation opportunity, not a hang.

## Test plan

- [x] Reproduce the hang on dev DB with \`course_manager\` -> bench course_member; confirm 60 s timeout / 0 bytes.
- [x] Apply the fix; rerun the same call; confirm 200 OK in seconds.
- [x] Inner-query row-count drops from 12 067 to 107 (Postgres-side count).
- [ ] Spot-check the four call sites in production-shape data: a real student's \`/students/course-contents\`, a tutor opening a real student's grading page, and the single-content variants \`get_course_content\`.
- [ ] If any tutor view ever accidentally calls these query builders for a course_member that's not the principal's, the new condition still holds because \`CourseMember\` in every builder is the *target* (joined and filtered before the \`Result\` outerjoin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)