### PR TITLE
fix(submissions): guard NULL artifact.properties on download_submission_as_zip

### DIFF
--- a/computor-backend/src/computor_backend/business_logic/submissions.py
+++ b/computor-backend/src/computor_backend/business_logic/submissions.py
@@ -467,8 +467,12 @@ async def download_submission_as_zip(
     # Check access permissions
     artifact = check_artifact_access(artifact_id, permissions, db)
 
-    # Get list of files from properties
-    files_included = artifact.properties.get("files_included", [])
+    # ``properties`` is nullable on submission_artifact and is sometimes
+    # absent for benchmark / test fixtures that didn't go through the full
+    # upload flow. Treat NULL the same as "no files" — raise a clean 404
+    # instead of letting an AttributeError become a 500 stack trace.
+    artifact_props = artifact.properties or {}
+    files_included = artifact_props.get("files_included", [])
     if not files_included:
         raise NotFoundException(detail="No files found in this submission")
 


### PR DESCRIPTION
## Symptom

\`GET /submissions/artifacts/{artifact_id}/download\` returns \`HTTP 500\` with a noisy stack trace in the api log:

\`\`\`
AttributeError: 'NoneType' object has no attribute 'get'
  File "business_logic/submissions.py", line 471, in download_submission_as_zip
    files_included = artifact.properties.get("files_included", [])
\`\`\`

## Cause

\`submission_artifact.properties\` is nullable. Artifacts that didn't go through the full upload flow — bench / test fixtures inserted directly via SQL or scripts — leave \`properties\` as \`NULL\`. The download path called \`.get()\` on it without guarding.

## Fix

One-liner: coalesce to \`{}\` before \`.get()\` and treat the missing-data case the same as the existing "no files" path:

\`\`\`python
artifact_props = artifact.properties or {}
files_included = artifact_props.get("files_included", [])
if not files_included:
    raise NotFoundException(detail="No files found in this submission")
\`\`\`

Outward behaviour for a real download: identical (a 404 with the existing message). For the broken case: a clean 404 instead of a 500 + traceback.

## Test plan

- [ ] Hit \`GET /submissions/artifacts/{id}/download\` for a bench artifact (\`properties IS NULL\`) → expect \`HTTP 404\` with \`"No files found in this submission"\` and **no stack trace** in the api log.
- [ ] Hit the same endpoint for a real artifact with populated \`properties.files_included\` → expect the ZIP download to still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)