### PR TITLE
fix: UUID-instance INSERTs and submission-group course_id derivation

### DIFF
--- a/computor-backend/src/computor_backend/database.py
+++ b/computor-backend/src/computor_backend/database.py
@@ -1,7 +1,10 @@
 import os
 from contextlib import contextmanager
 from typing import Generator, Callable, TYPE_CHECKING
+from uuid import UUID as _UUID
+
 from sqlalchemy import create_engine, text
+from sqlalchemy.dialects.postgresql import psycopg2 as _pg_psycopg2
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.pool import QueuePool
 import sqlalchemy.exc as sa_exc
@@ -9,6 +12,30 @@ from fastapi import Depends
 
 if TYPE_CHECKING:
     from computor_backend.permissions.principal import Principal
+
+
+# Patch SQLAlchemy 1.4's psycopg2 _PGUUID bind processor so it does not crash
+# when a Python ``uuid.UUID`` instance is passed for a UUID column.
+#
+# The stock processor unconditionally calls ``uuid.UUID(value)``; the stdlib
+# constructor in turn does ``hex.replace('urn:', '')`` on its first argument
+# which fails with ``AttributeError: 'UUID' object has no attribute 'replace'``
+# whenever ``value`` is already a ``uuid.UUID``. That happens any time the
+# caller hands the ORM a UUID object on INSERT (e.g. a FastAPI ``UUID`` path
+# parameter being stored as a foreign key) — see issue #244 path 4.
+def _patched_pguuid_bind_processor(self, dialect):
+    if not self.as_uuid and dialect.use_native_uuid:
+
+        def process(value):
+            if value is None or isinstance(value, _UUID):
+                return value
+            return _pg_psycopg2._python_UUID(value)
+
+        return process
+    return None
+
+
+_pg_psycopg2._PGUUID.bind_processor = _patched_pguuid_bind_processor
 
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "localhost")
 POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")

--- a/computor-backend/src/computor_backend/model/course.py
+++ b/computor-backend/src/computor_backend/model/course.py
@@ -633,3 +633,21 @@ def _course_content_before_update(mapper, connection, target):
     if kind_id is not None:
         target.course_content_kind_id = kind_id
         target.is_submittable = submittable
+
+
+@_sa_event.listens_for(SubmissionGroup, "before_insert")
+def _submission_group_before_insert(mapper, connection, target):
+    # ``course_id`` is NOT NULL in the database but a SubmissionGroup is
+    # always scoped to a single CourseContent which already pins the
+    # course. Deriving it here lets ``POST /submission-groups`` accept
+    # the documented schema (``SubmissionGroupCreate`` does not list
+    # ``course_id``) instead of raising an opaque NOT-NULL violation.
+    if target.course_id is not None or target.course_content_id is None:
+        return
+    course_id = connection.execute(
+        _sa_select(CourseContent.course_id).where(
+            CourseContent.id == target.course_content_id
+        )
+    ).scalar()
+    if course_id is not None:
+        target.course_id = course_id

--- a/computor-backend/src/computor_backend/tests/test_submission_group_creation.py
+++ b/computor-backend/src/computor_backend/tests/test_submission_group_creation.py
@@ -1,0 +1,198 @@
+"""Regression tests for issue #244 SubmissionGroup creation.
+
+Two bugs were filed against the synthetic-test-student lifecycle:
+
+1. ``UUID has no attribute 'replace'`` when a Python ``uuid.UUID`` is
+   bound to a UUID column on INSERT. SQLAlchemy 1.4's
+   ``_PGUUID.bind_processor`` calls ``uuid.UUID(value)`` which trips
+   the stdlib constructor's ``hex.replace('urn:', '')`` whenever the
+   value is already a UUID instance. ``database.py`` patches the bind
+   processor to short-circuit on UUID instances.
+
+2. ``POST /submission-groups`` rejected payloads that did not carry
+   ``course_id`` even though ``SubmissionGroupCreate`` doesn't list
+   it. ``model.course`` now auto-derives ``course_id`` from
+   ``course_content.course_id`` in a ``before_insert`` listener.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+# Importing this module installs the SA UUID bind-processor patch.
+import computor_backend.database  # noqa: F401
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from computor_backend.custom_types import Ltree
+from computor_backend.model.auth import User
+from computor_backend.model.course import (
+    Course,
+    CourseContent,
+    CourseContentKind,
+    CourseContentType,
+    CourseFamily,
+    CourseGroup,
+    CourseMember,
+    SubmissionGroup,
+    SubmissionGroupMember,
+)
+from computor_backend.model.organization import Organization
+
+
+def _pg_url() -> str:
+    user = os.environ.get("POSTGRES_USER")
+    password = os.environ.get("POSTGRES_PASSWORD")
+    db = os.environ.get("POSTGRES_DB")
+    if not (user and password and db):
+        pytest.skip("postgres test environment not configured")
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    port = os.environ.get("POSTGRES_PORT", "5432")
+    return f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{db}"
+
+
+@pytest.fixture
+def pg_session():
+    engine = create_engine(_pg_url(), future=True)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def course_content(pg_session):
+    """Build a minimal course + team-content fixture."""
+    suffix = uuid.uuid4().hex[:8]
+
+    # ``organization_type='community'`` avoids the ``user`` check
+    # constraint that requires a back-reference into ``user``.
+    org = Organization(
+        path=Ltree(f"itest_{suffix}"),
+        title=f"Issue-244 Org {suffix}",
+        organization_type="community",
+        properties={},
+    )
+    cf = CourseFamily(
+        path=Ltree(f"itest_{suffix}.fam"),
+        title="Family",
+        organization=org,
+        properties={},
+    )
+    course = Course(
+        path=Ltree(f"itest_{suffix}.fam.course"),
+        title="Course",
+        course_family=cf,
+        organization=org,
+        properties={},
+    )
+    pg_session.add(course)
+    pg_session.flush()
+
+    kind = pg_session.query(CourseContentKind).filter_by(id="assignment").first()
+    if kind is None:
+        kind = CourseContentKind(
+            id="assignment",
+            title="Assignment",
+            has_ascendants=False,
+            has_descendants=False,
+            submittable=True,
+        )
+        pg_session.add(kind)
+        pg_session.flush()
+
+    cct = CourseContentType(
+        slug="task",
+        title="Task",
+        course_id=course.id,
+        course_content_kind_id=kind.id,
+        properties={},
+    )
+    pg_session.add(cct)
+    pg_session.flush()
+
+    cc = CourseContent(
+        path=Ltree("week1"),
+        title="Team Assignment",
+        course_id=course.id,
+        course_content_type_id=cct.id,
+        position=1.0,
+        max_group_size=4,
+        properties={},
+    )
+    pg_session.add(cc)
+    pg_session.flush()
+    return cc
+
+
+@pytest.fixture
+def course_member(pg_session, course_content):
+    """A student in ``course_content``'s course with no ``Account``."""
+    suffix = uuid.uuid4().hex[:8]
+    user = User(
+        username=f"mcstudent_{suffix}",
+        email=f"mcstudent_{suffix}@example.com",
+        given_name="Student",
+        family_name="McStudentface",
+    )
+    cg = CourseGroup(title="A1", course_id=course_content.course_id, properties={})
+    pg_session.add_all([user, cg])
+    pg_session.flush()
+    cm = CourseMember(
+        user_id=user.id,
+        course_id=course_content.course_id,
+        course_group_id=cg.id,
+        course_role_id="_student",
+        properties={},
+    )
+    pg_session.add(cm)
+    pg_session.flush()
+    return cm
+
+
+@pytest.mark.integration
+def test_submission_group_insert_accepts_uuid_instance_fks(
+    pg_session, course_content, course_member
+):
+    # Bug #1: feed UUID instances (not strings) the way FastAPI hands
+    # parsed path parameters to the ORM. Without the bind-processor
+    # patch the flush below dies with
+    # ``StatementError: 'UUID' object has no attribute 'replace'``.
+    cc_id = uuid.UUID(str(course_content.id))
+    course_id = uuid.UUID(str(course_content.course_id))
+    cm_id = uuid.UUID(str(course_member.id))
+
+    sg = SubmissionGroup(
+        course_content_id=cc_id, course_id=course_id, max_group_size=4
+    )
+    pg_session.add(sg)
+    pg_session.flush()
+    pg_session.add(
+        SubmissionGroupMember(
+            submission_group_id=uuid.UUID(str(sg.id)),
+            course_member_id=cm_id,
+            course_id=course_id,
+        )
+    )
+    pg_session.flush()
+
+
+@pytest.mark.integration
+def test_submission_group_derives_course_id_from_course_content(
+    pg_session, course_content
+):
+    # Bug #2: ``SubmissionGroupCreate`` doesn't list ``course_id``;
+    # the ``before_insert`` listener fills it from ``course_content``
+    # so the documented payload no longer trips the NOT-NULL constraint.
+    sg = SubmissionGroup(course_content_id=course_content.id, max_group_size=1)
+    pg_session.add(sg)
+    pg_session.flush()
+    assert sg.course_id == course_content.course_id


### PR DESCRIPTION
## Summary

Two independent bugs in computor-org/issues#244 blocked the synthetic-test-student lifecycle from reaching `POST /my-team`:

- **Bug #1 — `'UUID' object has no attribute 'replace'`**: SQLAlchemy 1.4's psycopg2 `_PGUUID.bind_processor` calls `uuid.UUID(value)` on every UUID column on INSERT. The stdlib constructor does `hex.replace('urn:', '')`, which fails when `value` is already a `uuid.UUID` instance (e.g. a FastAPI-parsed path parameter being stored as a foreign key). Patch the bind processor in `database.py` to short-circuit on UUID instances.

- **Bug #2 — `POST /submission-groups` NOT-NULL on `course_id`**: `SubmissionGroupCreate` doesn't list `course_id` (the column is fully derivable from `course_content.course_id`) but the database enforces NOT NULL, so the documented payload failed. Add a `before_insert` listener on `SubmissionGroup` that fills `course_id` from the linked `CourseContent` when omitted.

The lifecycle gaps and lecturer-scope endpoint requests in computor-org/issues#244 remain open for separate work; this PR is scoped to the two backend bugs the issue asks to track.

## Verification

Local docker-compose harness (`postgres:16` from `ops/docker/docker-compose.base.yaml`), Python 3.14, sqlalchemy 1.4.54, psycopg2-binary 2.9.12, alembic upgraded to head before each run.

### Test fails on main

```
test_submission_group_insert_accepts_uuid_instance_fks                 FAILED
test_submission_group_derives_course_id_from_course_content            FAILED
E   AttributeError: 'UUID' object has no attribute 'replace'
E   sqlalchemy.exc.StatementError: (builtins.AttributeError) 'UUID' object has no attribute 'replace'
E   psycopg2.errors.NotNullViolation: null value in column "course_id" of relation "submission_group" violates not-null constraint
E   sqlalchemy.exc.IntegrityError: (psycopg2.errors.NotNullViolation) null value in column "course_id" of relation "submission_group" violates not-null constraint
```

### Test passes after fix

```
test_submission_group_insert_accepts_uuid_instance_fks                 PASSED
test_submission_group_derives_course_id_from_course_content            PASSED
======================== 2 passed, 10 warnings in 0.25s ========================
```

Run with:
```
POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=postgres POSTGRES_PASSWORD=$PW POSTGRES_DB=computor \
  pytest computor-backend/src/computor_backend/tests/test_submission_group_creation.py -v
```

Closes computor-org/issues#244 (the two backend bugs documented in the issue body).

## Test plan

- [x] Reproduce both errors against fresh local postgres without changes.
- [x] Apply patch, confirm both regression tests pass.
- [x] Confirm UUID bind processor still wraps strings into `uuid.UUID` and still passes `None` through.
- [x] Confirm `before_insert` listener leaves an explicitly-set `course_id` untouched.