### PR TITLE
fix: accept uuid.UUID instances on UUID-column INSERT

### DIFF
--- a/computor-backend/src/computor_backend/custom_types/__init__.py
+++ b/computor-backend/src/computor_backend/custom_types/__init__.py
@@ -3,5 +3,6 @@ Custom types for the Computor backend.
 """
 
 from .ltree import Ltree, LtreeType
+from .uuid import UUID
 
-__all__ = ['Ltree', 'LtreeType']
+__all__ = ['Ltree', 'LtreeType', 'UUID']

--- a/computor-backend/src/computor_backend/custom_types/uuid.py
+++ b/computor-backend/src/computor_backend/custom_types/uuid.py
@@ -1,0 +1,50 @@
+"""UUID column type that tolerates ``uuid.UUID`` instances on INSERT.
+
+SQLAlchemy 1.4's psycopg2 dialect ships ``_PGUUID`` whose
+``bind_processor`` unconditionally wraps every value with
+``uuid.UUID(value)``. The stdlib constructor does
+``hex.replace('urn:', '')`` on its first positional argument, so when
+the value is already a ``uuid.UUID`` instance — as it is whenever a
+FastAPI ``UUID`` path parameter reaches the ORM as a foreign key on
+INSERT — the call raises ``AttributeError: 'UUID' object has no
+attribute 'replace'`` (psycopg2 surfaces it as
+``sqlalchemy.exc.StatementError``).
+
+Wrapping the dialect type in a ``TypeDecorator`` and pre-stringifying
+``uuid.UUID`` instances in ``process_bind_param`` keeps the underlying
+processor seeing only strings, which it handles correctly. Loaded
+values still come back as strings because the inherited
+``_PGUUID.result_processor`` (with ``as_uuid=False``) stringifies
+them, matching the project's existing convention.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID as _StdlibUUID
+
+from sqlalchemy.dialects.postgresql import UUID as _PGUUID
+from sqlalchemy.types import TypeDecorator
+
+
+class UUID(TypeDecorator):
+    """Drop-in replacement for ``postgresql.UUID``.
+
+    Use exactly like the stock postgres ``UUID`` column type. Accepts
+    ``uuid.UUID`` instances, plain strings, or ``None`` as bind
+    parameters.
+    """
+
+    impl = _PGUUID
+    cache_ok = True
+
+    def __init__(self, as_uuid: bool = False) -> None:
+        super().__init__()
+        self.as_uuid = as_uuid
+
+    def load_dialect_impl(self, dialect):
+        return dialect.type_descriptor(_PGUUID(as_uuid=self.as_uuid))
+
+    def process_bind_param(self, value, dialect):
+        if isinstance(value, _StdlibUUID):
+            return str(value)
+        return value

--- a/computor-backend/src/computor_backend/model/artifact.py
+++ b/computor-backend/src/computor_backend/model/artifact.py
@@ -2,9 +2,15 @@ from sqlalchemy import (
     BigInteger, Boolean, Column, DateTime, Float,
     ForeignKey, Index, Integer, String, text, LargeBinary, UniqueConstraint, func
 )
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, Mapped
 from typing import TYPE_CHECKING, List
+
+try:
+    from ..custom_types import UUID
+except ImportError:
+    # Fallback for Alembic context
+    from computor_backend.custom_types import UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/auth.py
+++ b/computor-backend/src/computor_backend/model/auth.py
@@ -2,8 +2,14 @@ from sqlalchemy import (
     BigInteger, Boolean, CheckConstraint, Column, DateTime,
     Enum, ForeignKey, Index, Integer, LargeBinary, String, text
 , func)
-from sqlalchemy.dialects.postgresql import INET, JSONB, UUID
+from sqlalchemy.dialects.postgresql import INET, JSONB
 from sqlalchemy.orm import relationship
+
+try:
+    from ..custom_types import UUID
+except ImportError:
+    # Fallback for Alembic context
+    from computor_backend.custom_types import UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/course.py
+++ b/computor-backend/src/computor_backend/model/course.py
@@ -5,14 +5,14 @@ from sqlalchemy import (
     Float, ForeignKey, ForeignKeyConstraint, Index, 
     Integer, String, text, select
 , func)
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, column_property, Mapped
 from sqlalchemy.ext.hybrid import hybrid_property
 try:
-    from ..custom_types import LtreeType
+    from ..custom_types import LtreeType, UUID
 except ImportError:
     # Fallback for Alembic context
-    from computor_backend.custom_types import LtreeType
+    from computor_backend.custom_types import LtreeType, UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/deployment.py
+++ b/computor-backend/src/computor_backend/model/deployment.py
@@ -11,13 +11,13 @@ from sqlalchemy import (
     Column, String, Text, DateTime, ForeignKey, 
     UniqueConstraint, Index, text, JSON, Integer
 )
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 try:
-    from ..custom_types import LtreeType
+    from ..custom_types import LtreeType, UUID
 except ImportError:
     # Fallback for Alembic context
-    from computor_backend.custom_types import LtreeType
+    from computor_backend.custom_types import LtreeType, UUID
 from sqlalchemy.sql import func
 
 from .base import Base

--- a/computor-backend/src/computor_backend/model/example.py
+++ b/computor-backend/src/computor_backend/model/example.py
@@ -6,15 +6,14 @@ Each example is stored in its own directory with a flat structure.
 """
 
 from sqlalchemy import Column, String, Text, Boolean, DateTime, ARRAY, ForeignKey, text, Integer
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from sqlalchemy import CheckConstraint, UniqueConstraint
 try:
-    from ..custom_types import LtreeType
+    from ..custom_types import LtreeType, UUID
 except ImportError:
     # Fallback for Alembic context
-    from computor_backend.custom_types import LtreeType
+    from computor_backend.custom_types import LtreeType, UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/extension.py
+++ b/computor-backend/src/computor_backend/model/extension.py
@@ -12,9 +12,14 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+
+try:
+    from ..custom_types import UUID
+except ImportError:
+    # Fallback for Alembic context
+    from computor_backend.custom_types import UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/group.py
+++ b/computor-backend/src/computor_backend/model/group.py
@@ -2,8 +2,14 @@ from sqlalchemy import (
     BigInteger, Boolean, CheckConstraint, Column, DateTime, 
     Enum, ForeignKey, String, text
 , func)
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
+
+try:
+    from ..custom_types import UUID
+except ImportError:
+    # Fallback for Alembic context
+    from computor_backend.custom_types import UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/message.py
+++ b/computor-backend/src/computor_backend/model/message.py
@@ -2,8 +2,14 @@ from sqlalchemy import (
     BigInteger, Column, DateTime, ForeignKey,
     Index, String, text, Integer
 , func)
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
+
+try:
+    from ..custom_types import UUID
+except ImportError:
+    # Fallback for Alembic context
+    from computor_backend.custom_types import UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/message_audit.py
+++ b/computor-backend/src/computor_backend/model/message_audit.py
@@ -2,9 +2,14 @@ from sqlalchemy import (
     BigInteger, Column, DateTime, ForeignKey,
     Index, String, text, Enum as SQLEnum
 )
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 import enum
+
+try:
+    from ..custom_types import UUID
+except ImportError:
+    # Fallback for Alembic context
+    from computor_backend.custom_types import UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/organization.py
+++ b/computor-backend/src/computor_backend/model/organization.py
@@ -2,13 +2,13 @@ from sqlalchemy import (
     BigInteger, Boolean, CheckConstraint, Column, DateTime,
     Enum, ForeignKey, Index, String, text, Computed
 , func)
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 try:
-    from ..custom_types import LtreeType
+    from ..custom_types import LtreeType, UUID
 except ImportError:
     # Fallback for Alembic context
-    from computor_backend.custom_types import LtreeType
+    from computor_backend.custom_types import LtreeType, UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/result.py
+++ b/computor-backend/src/computor_backend/model/result.py
@@ -2,9 +2,15 @@ from sqlalchemy import (
     BigInteger, Boolean, Column, DateTime, Float,
     ForeignKey, Index, Integer, String, text
 , func)
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, Mapped
 from typing import TYPE_CHECKING
+
+try:
+    from ..custom_types import UUID
+except ImportError:
+    # Fallback for Alembic context
+    from computor_backend.custom_types import UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/role.py
+++ b/computor-backend/src/computor_backend/model/role.py
@@ -2,8 +2,14 @@ from sqlalchemy import (
     BigInteger, Boolean, CheckConstraint, Column, DateTime, 
     ForeignKey, String, text
 , func)
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
+
+try:
+    from ..custom_types import UUID
+except ImportError:
+    # Fallback for Alembic context
+    from computor_backend.custom_types import UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/model/service.py
+++ b/computor-backend/src/computor_backend/model/service.py
@@ -17,13 +17,13 @@ from sqlalchemy import (
     BigInteger, Boolean, CheckConstraint, Column, DateTime,
     ForeignKey, Index, LargeBinary, String, Text, func, text
 )
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
 try:
-    from ..custom_types import LtreeType
+    from ..custom_types import LtreeType, UUID
 except ImportError:
-    from computor_backend.custom_types import LtreeType
+    from computor_backend.custom_types import LtreeType, UUID
 
 from .base import Base
 

--- a/computor-backend/src/computor_backend/tests/test_uuid_column_type.py
+++ b/computor-backend/src/computor_backend/tests/test_uuid_column_type.py
@@ -1,0 +1,67 @@
+"""Regression test for the UUID column type.
+
+SQLAlchemy 1.4's psycopg2 dialect ships ``_PGUUID`` whose
+``bind_processor`` calls ``uuid.UUID(value)`` on every INSERT
+parameter. The stdlib constructor does ``hex.replace('urn:', '')``
+which raises ``AttributeError: 'UUID' object has no attribute
+'replace'`` whenever the value is already a ``uuid.UUID`` instance —
+e.g. a FastAPI ``UUID`` path parameter handed to the ORM as a foreign
+key on INSERT. ``custom_types.UUID`` wraps the dialect type in a
+``TypeDecorator`` that pre-stringifies UUID instances so the
+underlying processor only ever sees a string.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from computor_backend.custom_types import Ltree
+from computor_backend.model.organization import Organization
+
+
+def _pg_url() -> str:
+    user = os.environ.get("POSTGRES_USER")
+    password = os.environ.get("POSTGRES_PASSWORD")
+    db = os.environ.get("POSTGRES_DB")
+    if not (user and password and db):
+        pytest.skip("postgres test environment not configured")
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    port = os.environ.get("POSTGRES_PORT", "5432")
+    return f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{db}"
+
+
+@pytest.fixture
+def pg_session():
+    engine = create_engine(_pg_url(), future=True)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+        engine.dispose()
+
+
+@pytest.mark.integration
+def test_uuid_column_accepts_uuid_instance_on_insert(pg_session):
+    # FastAPI path parameters declared as ``UUID`` arrive at the ORM as
+    # ``uuid.UUID`` objects. Without the TypeDecorator the flush below
+    # raises ``StatementError: 'UUID' object has no attribute
+    # 'replace'`` from inside SQLAlchemy's psycopg2 bind processor.
+    suffix = uuid.uuid4().hex[:8]
+    org = Organization(
+        id=uuid.uuid4(),
+        path=Ltree(f"itest_{suffix}"),
+        title=f"Issue-244 Org {suffix}",
+        organization_type="community",
+        properties={},
+    )
+    pg_session.add(org)
+    pg_session.flush()


### PR DESCRIPTION
## Summary

`POST /course-contents/{id}/submission-groups/my-team` (and any other code path that hands a `uuid.UUID` instance to the ORM as a foreign key on INSERT) crashes with

```
sqlalchemy.exc.StatementError: (builtins.AttributeError) 'UUID' object has no attribute 'replace'
```

Cause: SQLAlchemy 1.4's psycopg2 dialect type `_PGUUID` declares

```python
def bind_processor(self, dialect):
    if not self.as_uuid and dialect.use_native_uuid:
        def process(value):
            if value is not None:
                value = _python_UUID(value)
            return value
        return process
```

`_python_UUID` is `uuid.UUID`. The stdlib constructor does `hex.replace('urn:', '').replace('uuid:', '')` on its first positional argument, so passing it an existing `uuid.UUID` instance raises `AttributeError`. FastAPI parses path parameters declared as `UUID` into `uuid.UUID` objects and the affected handlers store those values directly as foreign keys, hitting the bug. (Reported in computor-org/issues#244 path 4.)

Fix: wrap the dialect type in a `TypeDecorator` (`custom_types.UUID`) that pre-stringifies `uuid.UUID` instances in `process_bind_param` so the underlying processor only ever sees a string. Strings and `None` pass through unchanged. Generated SQL column type, default `as_uuid` behaviour, and result-side stringification (which the rest of the codebase already relies on) are all preserved. All 13 model files switch to importing `UUID` from `computor_backend.custom_types`.

This is the bug #1 split out of #127 (closed). Bug #2 (`POST /submission-groups` `course_id` derivation) ships as a separate PR.

## Verification

Local docker harness (`postgres:16` from `ops/docker/docker-compose.base.yaml`), Python 3.14, sqlalchemy 1.4.54, psycopg2-binary 2.9.12.

### Test fails on main

```
test_uuid_column_accepts_uuid_instance_on_insert FAILED
E   AttributeError: 'UUID' object has no attribute 'replace'
E   sqlalchemy.exc.StatementError: (builtins.AttributeError) 'UUID' object has no attribute 'replace'
======================== 1 failed, 10 warnings in 0.47s =========================
```

### Test passes after fix

```
test_uuid_column_accepts_uuid_instance_on_insert PASSED
======================== 1 passed, 10 warnings in 0.23s =========================
```

Run with:

```
POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=postgres \
POSTGRES_PASSWORD=$PW POSTGRES_DB=computor \
  pytest computor-backend/src/computor_backend/tests/test_uuid_column_type.py -v
```

The 11 failures in `test_password_hashing.py` are present on `main` unchanged by this PR.

Refs computor-org/issues#244 (bug #1 only).

## Test plan

- [x] Reproduce the original `'UUID' object has no attribute 'replace'` error against fresh local postgres without changes.
- [x] Apply the TypeDecorator, confirm the regression test passes.
- [x] Confirm string and `None` bind values still flow through unchanged.
- [x] Confirm no model imports of `postgresql.UUID` remain.
- [x] Confirm pre-existing test pass/fail counts unchanged on the rest of the suite.