### PR TITLE
fix: derive SubmissionGroup.course_id from course_content on insert

### DIFF
--- a/computor-backend/src/computor_backend/model/course.py
+++ b/computor-backend/src/computor_backend/model/course.py
@@ -633,3 +633,22 @@ def _course_content_before_update(mapper, connection, target):
     if kind_id is not None:
         target.course_content_kind_id = kind_id
         target.is_submittable = submittable
+
+
+@_sa_event.listens_for(SubmissionGroup, "before_insert")
+def _submission_group_before_insert(mapper, connection, target):
+    # ``course_id`` is NOT NULL in the database but a SubmissionGroup
+    # is always scoped to a single CourseContent which already pins
+    # the course. Deriving it here lets ``POST /submission-groups``
+    # accept the documented schema (``SubmissionGroupCreate`` does
+    # not list ``course_id``) instead of raising an opaque NOT-NULL
+    # violation. See computor-org/issues#244 path 5.
+    if target.course_id is not None or target.course_content_id is None:
+        return
+    course_id = connection.execute(
+        _sa_select(CourseContent.course_id).where(
+            CourseContent.id == target.course_content_id
+        )
+    ).scalar()
+    if course_id is not None:
+        target.course_id = course_id

--- a/computor-backend/src/computor_backend/tests/test_submission_group_course_id.py
+++ b/computor-backend/src/computor_backend/tests/test_submission_group_course_id.py
@@ -1,0 +1,126 @@
+"""Regression test for SubmissionGroup ``course_id`` derivation.
+
+``SubmissionGroupCreate`` does not list ``course_id`` because the
+column is fully derivable from ``course_content.course_id``. The
+database, however, declares ``course_id`` NOT NULL — so callers
+that POST the documented payload tripped a NOT-NULL violation
+(computor-org/issues#244 path 5). The model layer now fills
+``course_id`` from the linked ``CourseContent`` in a
+``before_insert`` listener.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from computor_backend.custom_types import Ltree
+from computor_backend.model.course import (
+    Course,
+    CourseContent,
+    CourseContentKind,
+    CourseContentType,
+    CourseFamily,
+    SubmissionGroup,
+)
+from computor_backend.model.organization import Organization
+
+
+def _pg_url() -> str:
+    user = os.environ.get("POSTGRES_USER")
+    password = os.environ.get("POSTGRES_PASSWORD")
+    db = os.environ.get("POSTGRES_DB")
+    if not (user and password and db):
+        pytest.skip("postgres test environment not configured")
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    port = os.environ.get("POSTGRES_PORT", "5432")
+    return f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{db}"
+
+
+@pytest.fixture
+def pg_session():
+    engine = create_engine(_pg_url(), future=True)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def course_content(pg_session):
+    suffix = uuid.uuid4().hex[:8]
+    org = Organization(
+        path=Ltree(f"itest_{suffix}"),
+        title=f"Issue-244 Org {suffix}",
+        organization_type="community",
+        properties={},
+    )
+    cf = CourseFamily(
+        path=Ltree(f"itest_{suffix}.fam"),
+        title="Family",
+        organization=org,
+        properties={},
+    )
+    course = Course(
+        path=Ltree(f"itest_{suffix}.fam.course"),
+        title="Course",
+        course_family=cf,
+        organization=org,
+        properties={},
+    )
+    pg_session.add(course)
+    pg_session.flush()
+
+    kind = pg_session.query(CourseContentKind).filter_by(id="assignment").first()
+    if kind is None:
+        kind = CourseContentKind(
+            id="assignment",
+            title="Assignment",
+            has_ascendants=False,
+            has_descendants=False,
+            submittable=True,
+        )
+        pg_session.add(kind)
+        pg_session.flush()
+
+    cct = CourseContentType(
+        slug="task",
+        title="Task",
+        course_id=course.id,
+        course_content_kind_id=kind.id,
+        properties={},
+    )
+    pg_session.add(cct)
+    pg_session.flush()
+
+    cc = CourseContent(
+        path=Ltree("week1"),
+        title="Assignment",
+        course_id=course.id,
+        course_content_type_id=cct.id,
+        position=1.0,
+        max_group_size=1,
+        properties={},
+    )
+    pg_session.add(cc)
+    pg_session.flush()
+    return cc
+
+
+@pytest.mark.integration
+def test_submission_group_course_id_is_derived_from_course_content(
+    pg_session, course_content
+):
+    sg = SubmissionGroup(course_content_id=course_content.id, max_group_size=1)
+    pg_session.add(sg)
+    pg_session.flush()
+    assert sg.course_id == course_content.course_id


### PR DESCRIPTION
## Summary

`POST /submission-groups` rejected the documented payload with

```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.NotNullViolation)
null value in column "course_id" of relation "submission_group"
violates not-null constraint
```

`SubmissionGroupCreate` does not list `course_id` (the column is fully derivable from `course_content.course_id`); the database declares it NOT NULL; nothing in between bridges the gap. Adding `course_id` to the request body trips the validator with a generic `VAL_001`, so callers had no working path. (Reported in computor-org/issues#244 path 5.)

Fix: a `before_insert` listener on `SubmissionGroup` that fills `course_id` from the linked `CourseContent` when the caller did not set it. Explicitly-set values are left alone. The change matches the existing `_course_content_before_insert` denormalisation pattern in the same module.

This is bug #2 split out of #127 (closed). Bug #1 (UUID-instance INSERT) ships as #128.

## Verification

Local docker harness (`postgres:16` from `ops/docker/docker-compose.base.yaml`), Python 3.14, sqlalchemy 1.4.54, psycopg2-binary 2.9.12.

### Test fails on main

```
test_submission_group_course_id_is_derived_from_course_content FAILED
E   psycopg2.errors.NotNullViolation: null value in column "course_id" of relation "submission_group" violates not-null constraint
E   sqlalchemy.exc.IntegrityError: (psycopg2.errors.NotNullViolation) null value in column "course_id" of relation "submission_group" violates not-null constraint
======================== 1 failed, 10 warnings in 0.40s =========================
```

### Test passes after fix

```
test_submission_group_course_id_is_derived_from_course_content PASSED
======================== 1 passed, 10 warnings in 0.19s =========================
```

Run with:

```
POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=postgres \
POSTGRES_PASSWORD=$PW POSTGRES_DB=computor \
  pytest computor-backend/src/computor_backend/tests/test_submission_group_course_id.py -v
```

Refs computor-org/issues#244 (bug #2 only).

## Test plan

- [x] Reproduce the original NOT-NULL violation against fresh local postgres without changes.
- [x] Apply the listener, confirm the regression test passes.
- [x] Confirm an explicitly-set `course_id` is preserved (covered by the early-return path; explicit construct without payload omission is the existing test_team_management.py pattern).