### PR TITLE
Typed example_version metadata + testing-service hardening

### DIFF
--- a/computor-backend/src/computor_backend/alembic/versions/c4d5e6f7a8b9_add_typed_meta_columns_to_example_version.py
+++ b/computor-backend/src/computor_backend/alembic/versions/c4d5e6f7a8b9_add_typed_meta_columns_to_example_version.py
@@ -1,0 +1,277 @@
+"""add typed meta columns to example_version, drop meta_yaml
+
+Revision ID: c4d5e6f7a8b9
+Revises: f1c2d3e4a5b6
+Create Date: 2026-05-05 13:00:00.000000
+
+Replace the single ``meta_yaml TEXT`` blob on ``example_version`` with a
+typed schema:
+
+- ``meta`` (JSONB)            — full parsed meta.yaml (round-trip storage)
+- ``title``, ``description``, ``language``, ``license`` — promoted scalars
+- ``execution_backend`` (JSONB) — full ``properties.executionBackend`` dict
+                                  (slug + version + settings)
+- ``student_submission_files``, ``additional_files``, ``student_templates``,
+  ``test_files`` (TEXT[])    — promoted file lists used by the student-
+                                template / tutor flows
+
+The ``testing_service_id`` FK added in the previous migration stays put;
+it remains the resolved Service.id derived from
+``properties.executionBackend.slug``. The new ``execution_backend`` JSONB
+preserves the original meta.yaml block verbatim (slug + version +
+settings), so a future Service rename doesn't lose the historical
+declaration.
+
+Strategy:
+  1. Add new columns (nullable).
+  2. Backfill in Python: parse each row's ``meta_yaml``, populate.
+  3. ``meta`` becomes NOT NULL — unparseable rows store a structured
+     fallback so the constraint holds and the bad input is recoverable.
+  4. Drop ``meta_yaml``.
+"""
+from typing import Sequence, Union
+
+import yaml
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4d5e6f7a8b9'
+down_revision: Union[str, None] = 'f1c2d3e4a5b6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _split_promoted(parsed: dict | None, raw_yaml: str | None) -> dict:
+    """Pull promoted fields out of a parsed meta.yaml dict.
+
+    Returns a flat dict ready to feed UPDATE bind parameters. If the
+    YAML couldn't be parsed (or wasn't a dict), we still produce a row:
+    ``meta`` gets a structured fallback containing the parse error and
+    a truncated raw payload so an admin can fix the source later.
+    """
+    if not isinstance(parsed, dict):
+        return {
+            "meta": {
+                "_parse_error": "meta.yaml did not parse to a dict",
+                "_raw": (raw_yaml or "")[:2000],
+            },
+            "title": None,
+            "description": None,
+            "language": None,
+            "license": None,
+            "execution_backend": None,
+            "student_submission_files": [],
+            "additional_files": [],
+            "student_templates": [],
+            "test_files": [],
+        }
+
+    properties = parsed.get("properties")
+    if not isinstance(properties, dict):
+        properties = {}
+
+    def _str_list(value) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return [str(item) for item in value if item is not None]
+
+    return {
+        "meta": parsed,
+        "title": parsed.get("title"),
+        "description": parsed.get("description"),
+        "language": parsed.get("language"),
+        "license": parsed.get("license"),
+        "execution_backend": (
+            properties.get("executionBackend")
+            if isinstance(properties.get("executionBackend"), dict)
+            else None
+        ),
+        "student_submission_files": _str_list(properties.get("studentSubmissionFiles")),
+        "additional_files": _str_list(properties.get("additionalFiles")),
+        "student_templates": _str_list(properties.get("studentTemplates")),
+        "test_files": _str_list(properties.get("testFiles")),
+    }
+
+
+def upgrade() -> None:
+    # 1. Add columns nullable.
+    op.add_column('example_version', sa.Column('meta', postgresql.JSONB(), nullable=True))
+    op.add_column('example_version', sa.Column('title', sa.String(length=255), nullable=True))
+    op.add_column('example_version', sa.Column('description', sa.Text(), nullable=True))
+    op.add_column('example_version', sa.Column('language', sa.String(length=16), nullable=True))
+    op.add_column('example_version', sa.Column('license', sa.String(length=255), nullable=True))
+    op.add_column(
+        'example_version',
+        sa.Column('execution_backend', postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        'example_version',
+        sa.Column(
+            'student_submission_files',
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+    op.add_column(
+        'example_version',
+        sa.Column(
+            'additional_files',
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+    op.add_column(
+        'example_version',
+        sa.Column(
+            'student_templates',
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+    op.add_column(
+        'example_version',
+        sa.Column(
+            'test_files',
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+
+    # 2. Backfill from existing meta_yaml.
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT id, meta_yaml FROM example_version")
+    ).fetchall()
+
+    update_stmt = sa.text(
+        """
+        UPDATE example_version
+           SET meta = CAST(:meta AS JSONB),
+               title = :title,
+               description = :description,
+               language = :language,
+               license = :license,
+               execution_backend = CAST(:execution_backend AS JSONB),
+               student_submission_files = :student_submission_files,
+               additional_files = :additional_files,
+               student_templates = :student_templates,
+               test_files = :test_files
+         WHERE id = :id
+        """
+    )
+
+    import json as _json
+
+    parsed_ok = 0
+    parse_errors = 0
+    for row in rows:
+        raw = row.meta_yaml
+        try:
+            parsed = yaml.safe_load(raw) if raw else None
+        except yaml.YAMLError:
+            parsed = None
+            parse_errors += 1
+
+        promoted = _split_promoted(parsed, raw)
+
+        bind.execute(
+            update_stmt,
+            {
+                "id": row.id,
+                "meta": _json.dumps(promoted["meta"]),
+                "title": promoted["title"],
+                "description": promoted["description"],
+                "language": promoted["language"],
+                "license": promoted["license"],
+                "execution_backend": (
+                    _json.dumps(promoted["execution_backend"])
+                    if promoted["execution_backend"] is not None
+                    else None
+                ),
+                "student_submission_files": promoted["student_submission_files"],
+                "additional_files": promoted["additional_files"],
+                "student_templates": promoted["student_templates"],
+                "test_files": promoted["test_files"],
+            },
+        )
+
+        if isinstance(parsed, dict):
+            parsed_ok += 1
+
+    op.execute(
+        sa.text(
+            "DO $$ BEGIN "
+            f"RAISE NOTICE 'example_version meta backfill: parsed_ok={parsed_ok}, "
+            f"yaml_errors={parse_errors}, total={len(rows)}'; "
+            "END $$;"
+        )
+    )
+
+    # 3. Tighten ``meta`` — backfill guarantees every row has a value.
+    op.alter_column(
+        'example_version',
+        'meta',
+        existing_type=postgresql.JSONB(),
+        nullable=False,
+    )
+
+    # Server defaults on the array columns served the migration; drop
+    # them so the application is the only writer going forward and we
+    # don't accumulate empty arrays on rows that genuinely didn't
+    # declare files.
+    op.alter_column('example_version', 'student_submission_files', server_default=None)
+    op.alter_column('example_version', 'additional_files', server_default=None)
+    op.alter_column('example_version', 'student_templates', server_default=None)
+    op.alter_column('example_version', 'test_files', server_default=None)
+
+    # 4. Drop the old text blob.
+    op.drop_column('example_version', 'meta_yaml')
+
+
+def downgrade() -> None:
+    """Re-create ``meta_yaml`` and rehydrate it from JSONB.
+
+    The downgrade path is best-effort — it dumps the JSONB back to
+    YAML so the column has a usable value, but exact whitespace /
+    comments from the original meta.yaml file are lost (that
+    information was already lost on the upgrade backfill).
+    """
+    op.add_column(
+        'example_version',
+        sa.Column('meta_yaml', sa.Text(), nullable=True),
+    )
+
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT id, meta FROM example_version WHERE meta IS NOT NULL")
+    ).fetchall()
+
+    for row in rows:
+        try:
+            rendered = yaml.safe_dump(row.meta, default_flow_style=False, sort_keys=False)
+        except Exception:
+            rendered = ""
+        bind.execute(
+            sa.text("UPDATE example_version SET meta_yaml = :y WHERE id = :id"),
+            {"y": rendered, "id": row.id},
+        )
+
+    op.alter_column('example_version', 'meta_yaml', nullable=False)
+
+    op.drop_column('example_version', 'test_files')
+    op.drop_column('example_version', 'student_templates')
+    op.drop_column('example_version', 'additional_files')
+    op.drop_column('example_version', 'student_submission_files')
+    op.drop_column('example_version', 'execution_backend')
+    op.drop_column('example_version', 'license')
+    op.drop_column('example_version', 'language')
+    op.drop_column('example_version', 'description')
+    op.drop_column('example_version', 'title')
+    op.drop_column('example_version', 'meta')

--- a/computor-backend/src/computor_backend/alembic/versions/d5e6f7a8b9c0_drop_meta_and_test_yaml_blobs.py
+++ b/computor-backend/src/computor_backend/alembic/versions/d5e6f7a8b9c0_drop_meta_and_test_yaml_blobs.py
@@ -1,0 +1,53 @@
+"""drop meta JSONB and test_yaml text from example_version
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-05-05 14:00:00.000000
+
+The previous refactor (c4d5e6f7a8b9) replaced the legacy ``meta_yaml``
+text column with a ``meta`` JSONB plus promoted scalar/array columns.
+After review we decided ``meta`` JSONB and ``test_yaml`` text are
+redundant: every example file (including ``meta.yaml`` and
+``test.yaml``) is already persisted to MinIO at
+``{storage_path}/{filename}``. The promoted columns
+(``title``, ``description``, ``language``, ``license``,
+``execution_backend``, ``student_submission_files``,
+``additional_files``, ``student_templates``, ``test_files``,
+``testing_service_id``) cover every hot-path read; the download
+endpoint reads the original yaml documents from MinIO with a Redis
+cache in front for the cold path.
+
+Drops only — no data migration. The yaml documents themselves still
+exist in MinIO.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd5e6f7a8b9c0'
+down_revision: Union[str, None] = 'c4d5e6f7a8b9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column('example_version', 'meta')
+    op.drop_column('example_version', 'test_yaml')
+
+
+def downgrade() -> None:
+    """Re-create the columns as nullable. No backfill — yaml documents
+    live in MinIO and would have to be re-fetched. Downgrade is for
+    schema rollback only."""
+    op.add_column(
+        'example_version',
+        sa.Column('test_yaml', sa.Text(), nullable=True),
+    )
+    op.add_column(
+        'example_version',
+        sa.Column('meta', postgresql.JSONB(), nullable=True),
+    )

--- a/computor-backend/src/computor_backend/alembic/versions/f1c2d3e4a5b6_add_testing_service_id_to_example_version.py
+++ b/computor-backend/src/computor_backend/alembic/versions/f1c2d3e4a5b6_add_testing_service_id_to_example_version.py
@@ -1,0 +1,165 @@
+"""add testing_service_id to example_version
+
+Revision ID: f1c2d3e4a5b6
+Revises: e0f1a2b3c4d5
+Create Date: 2026-05-05 12:00:00.000000
+
+Move the canonical "which service runs tests for this example" link from a
+runtime YAML lookup at assignment time onto a real foreign-key column on
+``example_version``. Resolving the slug→service mapping happens once, at
+upload, and is then stable for every assignment that follows.
+
+Pre-existing rows are backfilled in Python (we need yaml parsing). Rows
+whose meta.yaml lacks ``properties.executionBackend.slug`` or whose slug
+no longer resolves to an enabled, non-archived ``service`` are left with
+``testing_service_id = NULL`` — the application will surface those when
+someone tries to assign them.
+
+After ``example_version.testing_service_id`` is populated, the migration
+also backfills ``course_content.testing_service_id`` for any submittable
+content that already has a deployment but never got the previous
+best-effort auto-link to fire (rows assigned before commit e1712c9).
+"""
+from typing import Sequence, Union
+
+import yaml
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1c2d3e4a5b6'
+down_revision: Union[str, None] = 'e0f1a2b3c4d5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _extract_execution_backend_slug(meta_yaml: str) -> str | None:
+    """Mirror of ExampleVersion.get_execution_backend_slug — kept inline
+    so this migration is self-contained and survives future refactors of
+    the model.
+    """
+    if not meta_yaml:
+        return None
+    try:
+        data = yaml.safe_load(meta_yaml)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    properties = data.get('properties')
+    if not isinstance(properties, dict):
+        return None
+    execution_backend = properties.get('executionBackend')
+    if not isinstance(execution_backend, dict):
+        return None
+    return execution_backend.get('slug')
+
+
+def upgrade() -> None:
+    # 1. Add nullable column + supporting index. Stays nullable: pre-
+    #    existing rows whose slug we can't resolve must be allowed to
+    #    persist; we don't want the migration to wedge on legacy bad data.
+    op.add_column(
+        'example_version',
+        sa.Column('testing_service_id', postgresql.UUID(), nullable=True),
+    )
+    op.create_index(
+        'ix_example_version_testing_service_id',
+        'example_version',
+        ['testing_service_id'],
+    )
+    op.create_foreign_key(
+        'example_version_testing_service_id_fkey',
+        'example_version', 'service',
+        ['testing_service_id'], ['id'],
+        ondelete='RESTRICT',
+    )
+
+    # 2. Backfill example_version.testing_service_id by parsing meta.yaml
+    #    and resolving the slug against the service table. Iterate in
+    #    Python since Postgres doesn't speak YAML.
+    bind = op.get_bind()
+
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, meta_yaml FROM example_version "
+            "WHERE meta_yaml IS NOT NULL AND testing_service_id IS NULL"
+        )
+    ).fetchall()
+
+    # Build slug → service.id once. Only enabled, non-archived services
+    # qualify — same predicate used by the runtime resolver, so the
+    # migration matches the application's view of "live" services.
+    service_rows = bind.execute(
+        sa.text(
+            "SELECT id, slug FROM service "
+            "WHERE enabled = TRUE AND archived_at IS NULL"
+        )
+    ).fetchall()
+    slug_to_service_id = {r.slug: r.id for r in service_rows}
+
+    update_stmt = sa.text(
+        "UPDATE example_version SET testing_service_id = :sid WHERE id = :vid"
+    )
+
+    matched = 0
+    no_slug = 0
+    no_service = 0
+    for row in rows:
+        slug = _extract_execution_backend_slug(row.meta_yaml)
+        if not slug:
+            no_slug += 1
+            continue
+        service_id = slug_to_service_id.get(slug)
+        if not service_id:
+            no_service += 1
+            continue
+        bind.execute(update_stmt, {"sid": service_id, "vid": row.id})
+        matched += 1
+
+    # Surface the backfill outcome in the migration log so an operator
+    # running ``alembic upgrade`` can immediately see how many legacy
+    # versions are still orphaned and need follow-up.
+    op.execute(
+        sa.text(
+            "DO $$ BEGIN "
+            "RAISE NOTICE 'example_version.testing_service_id backfill: "
+            f"matched={matched}, no_executionBackend_slug={no_slug}, "
+            f"unresolved_slug={no_service}'; "
+            "END $$;"
+        )
+    )
+
+    # 3. Backfill course_content.testing_service_id from the now-populated
+    #    example_version FK, but only for content that currently has a
+    #    live deployment and no testing service yet. This covers content
+    #    assigned before the runtime auto-link existed (commit e1712c9,
+    #    2026-03-16) as well as anything where the auto-link silently
+    #    no-op'd.
+    op.execute(
+        """
+        UPDATE course_content cc
+           SET testing_service_id = ev.testing_service_id
+          FROM course_content_deployment d
+          JOIN example_version ev ON ev.id = d.example_version_id
+         WHERE d.course_content_id = cc.id
+           AND d.deployment_status <> 'unassigned'
+           AND ev.testing_service_id IS NOT NULL
+           AND cc.testing_service_id IS NULL;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'example_version_testing_service_id_fkey',
+        'example_version',
+        type_='foreignkey',
+    )
+    op.drop_index(
+        'ix_example_version_testing_service_id',
+        table_name='example_version',
+    )
+    op.drop_column('example_version', 'testing_service_id')

--- a/computor-backend/src/computor_backend/api/course_contents.py
+++ b/computor-backend/src/computor_backend/api/course_contents.py
@@ -215,6 +215,14 @@ async def unassign_example_from_content(
     deployment.deployment_message = "Example unassigned"
     deployment.updated_by = permissions.user_id if hasattr(permissions, 'user_id') else None
 
+    # Clear the cached testing_service_id on the course content too — it
+    # only made sense as a denormalisation of the now-unassigned example
+    # version. Leaving it set would falsely advertise that this content
+    # has a testing backend.
+    if content.testing_service_id is not None:
+        content.testing_service_id = None
+        content.updated_by = permissions.user_id if hasattr(permissions, 'user_id') else None
+
     # Update via repository
     deployment = deployment_repo.update(deployment)
 

--- a/computor-backend/src/computor_backend/api/examples.py
+++ b/computor-backend/src/computor_backend/api/examples.py
@@ -41,6 +41,7 @@ from computor_types.cascade_deletion import (
 )
 from computor_backend.interfaces.example import ExampleInterface
 from ..model.example import ExampleRepository, Example, ExampleVersion, ExampleDependency
+from ..model.service import Service
 from ..permissions.auth import get_current_principal
 from computor_backend.api._pagination import paginated_list
 from computor_backend.business_logic.crud import (
@@ -74,6 +75,160 @@ CACHE_TTL_GET = 600   # 10 minutes
 # ------------------------------------------------------------------------------
 # Helpers
 # ------------------------------------------------------------------------------
+
+def _resolve_testing_service_id(db: Session, meta: dict) -> str:
+    """Resolve ``example_version.testing_service_id`` from parsed meta.
+
+    The slug at ``properties.executionBackend.slug`` is the contract
+    between an example and the platform's testing infrastructure. We
+    resolve it once at upload — every later assignment just copies the
+    FK — so a missing or stale slug must fail loudly here instead of
+    silently producing assignable-but-untestable content downstream.
+
+    Raises BadRequestException if meta lacks the field, or if the
+    declared slug doesn't resolve to an enabled, non-archived Service.
+    """
+    eb = ExampleVersion.extract_execution_backend(meta)
+    slug = eb.get('slug') if eb else None
+    if not slug:
+        raise BadRequestException(
+            error_code="EXAMPLE_VERSION_NO_BACKEND",
+            detail=(
+                "meta.yaml is missing properties.executionBackend.slug. "
+                "Add an executionBackend declaration so the platform "
+                "knows which service should run tests for this example."
+            ),
+        )
+    service = db.query(Service).filter(
+        Service.slug == slug,
+        Service.enabled == True,  # noqa: E712 — SQLAlchemy column comparison
+        Service.archived_at.is_(None),
+    ).first()
+    if not service:
+        raise BadRequestException(
+            error_code="EXAMPLE_VERSION_UNKNOWN_BACKEND",
+            detail=(
+                f"meta.yaml references execution backend slug '{slug}', "
+                "which does not match any enabled, non-archived service. "
+                "Register the service or fix the slug in meta.yaml."
+            ),
+            context={"slug": slug},
+        )
+    return service.id
+
+
+def _split_promoted_meta(meta: dict) -> dict:
+    """Pull promoted columns out of a parsed meta.yaml dict.
+
+    Returns a kwargs dict ready to spread onto ExampleVersion(...).
+    The full meta.yaml document itself is **not** stored in the DB —
+    it's persisted to MinIO at ``{storage_path}/meta.yaml`` along
+    with the rest of the example files. Only the promoted scalars,
+    file lists, and the executionBackend block survive in Postgres.
+    """
+    if not isinstance(meta, dict):
+        meta = {}
+    properties = meta.get("properties") if isinstance(meta.get("properties"), dict) else {}
+
+    def _str_list(value) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return [str(item) for item in value if item is not None]
+
+    eb = properties.get("executionBackend") if isinstance(properties.get("executionBackend"), dict) else None
+
+    return {
+        "title": meta.get("title"),
+        "description": meta.get("description"),
+        "language": meta.get("language"),
+        "license": meta.get("license"),
+        "execution_backend": eb,
+        "student_submission_files": _str_list(properties.get("studentSubmissionFiles")),
+        "additional_files": _str_list(properties.get("additionalFiles")),
+        "student_templates": _str_list(properties.get("studentTemplates")),
+        "test_files": _str_list(properties.get("testFiles")),
+    }
+
+
+# Redis-backed cache for yaml documents fetched from MinIO. Example
+# versions are immutable (a new upload creates a new version), so we
+# can cache for a long time. Keys are namespaced per (kind, version_id).
+_YAML_CACHE_TTL = 7 * 24 * 60 * 60  # 7 days
+
+
+async def _get_version_yaml_dict(
+    version: ExampleVersion,
+    kind: str,  # "meta" | "test"
+    storage_service,
+) -> dict | None:
+    """Fetch and parse meta.yaml or test.yaml for a version from MinIO,
+    returning a dict (or None for ``test`` when the file is absent).
+
+    Goes through the shared cache: first checks Redis, falls back to
+    MinIO on miss, populates the cache on success. Git-source examples
+    don't have files in MinIO — for those, return a synthetic minimal
+    dict for ``meta`` and ``None`` for ``test``.
+    """
+    if kind not in ("meta", "test"):
+        raise ValueError(f"Unsupported yaml kind: {kind}")
+
+    repository = version.example.repository
+
+    if repository.source_type == "git":
+        # Synthetic meta for git-sourced examples; no test.yaml available.
+        if kind == "meta":
+            return {
+                "slug": str(version.example.identifier),
+                "title": version.example.title,
+                "description": version.example.description or "",
+            }
+        return None
+
+    if repository.source_type not in ("minio", "s3"):
+        return None
+
+    cache = get_cache()
+    cache_key = cache.k("example_version_yaml", kind, str(version.id))
+
+    cached = cache.get_by_key(cache_key)
+    if cached is not None:
+        return cached if cached != {"_absent": True} else None
+
+    bucket_name = repository.source_url.split('/')[0]
+    object_key = f"{version.storage_path}/{kind}.yaml"
+
+    try:
+        raw = await storage_service.download_file(
+            bucket_name=bucket_name,
+            object_key=object_key,
+        )
+    except NotFoundException:
+        if kind == "test":
+            cache.set_with_tags(
+                cache_key,
+                {"_absent": True},
+                tags=[f"example_version:{version.id}"],
+                ttl=_YAML_CACHE_TTL,
+            )
+            return None
+        # meta.yaml is required — re-raise so the caller surfaces it.
+        raise
+
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8", errors="replace")
+
+    parsed = yaml.safe_load(raw) or {}
+    if not isinstance(parsed, dict):
+        parsed = {"_parse_error": "yaml did not parse to a dict", "_raw": raw[:2000]}
+
+    cache.set_with_tags(
+        cache_key,
+        parsed,
+        tags=[f"example_version:{version.id}"],
+        ttl=_YAML_CACHE_TTL,
+    )
+    return parsed
+
 
 def _guess_content_type(filename: str, is_binary: bool) -> str:
     """Return a reasonable content-type for a given filename.
@@ -330,9 +485,21 @@ async def create_version(
     if version.example_id != example_id:
         raise BadRequestException("Example ID mismatch")
 
-    # Create version
+    # Resolve testing service before persisting — catches missing/unknown
+    # executionBackend at the doorstep instead of letting the broken row
+    # reach assignment.
+    testing_service_id = _resolve_testing_service_id(db, version.meta)
+
+    # Build the kwargs by combining the DTO scalars with the promoted
+    # columns extracted from ``meta``. The full meta dict itself is
+    # not stored — the meta.yaml file lives in MinIO under
+    # ``{storage_path}/meta.yaml``.
+    payload = version.model_dump(exclude={"meta"})
+    payload.update(_split_promoted_meta(version.meta))
+
     db_version = ExampleVersion(
-        **version.model_dump(),
+        **payload,
+        testing_service_id=testing_service_id,
         created_by=permissions.user_id,
     )
 
@@ -676,13 +843,11 @@ async def upload_example(
         version_number = version_repo.get_next_version_number(example.id)
         storage_path = f"examples/{repository.id}/{example.directory}/v{version_number}"
     
-    # Upload files to MinIO
+    # Upload files to MinIO. meta.yaml and test.yaml ride inside this
+    # loop alongside the rest — the DB no longer carries a separate
+    # copy of those documents; downloads fetch them from MinIO via
+    # ``_get_version_yaml_dict`` (Redis-cached).
     bucket_name = repository.source_url.split('/')[0]  # First part is bucket
-    
-    # Get test.yaml content if it exists
-    test_yaml_content = incoming_files.get('test.yaml')
-    if isinstance(test_yaml_content, (bytes, bytearray)):
-        test_yaml_content = test_yaml_content.decode('utf-8', errors='replace')
 
     for filename, content in incoming_files.items():
         if filename.lower().endswith('.zip'):
@@ -707,13 +872,30 @@ async def upload_example(
             content_type=content_type,
         )
     
-    # Create or update version record
+    # Resolve testing service from meta.yaml — applies to both create
+    # and update branches, since updating an existing version may swap
+    # the executionBackend declaration.
+    testing_service_id = _resolve_testing_service_id(db, meta_data)
+
+    # Pre-compute promoted column values from the parsed meta dict.
+    promoted = _split_promoted_meta(meta_data)
+
+    # Create or update version record. Re-uploads of an existing
+    # version invalidate the cached yaml — the file was overwritten
+    # in MinIO above, but the parsed dict in Redis would otherwise
+    # serve stale data until TTL.
+    cache = get_cache()
+
     if existing_version:
-        # Update existing version
-        existing_version.meta_yaml = meta_str
-        existing_version.test_yaml = test_yaml_content
+        # Update existing version — refresh every promoted column so
+        # we don't end up with a stale title / exec-backend / file
+        # list hanging off a re-uploaded version.
+        for field, value in promoted.items():
+            setattr(existing_version, field, value)
+        existing_version.testing_service_id = testing_service_id
         existing_version.updated_at = func.now()
         version = version_repo.update(existing_version)
+        cache.invalidate_tags(f"example_version:{version.id}")
     else:
         # Create new version
         version = ExampleVersion(
@@ -721,9 +903,9 @@ async def upload_example(
             version_tag=version_tag,
             version_number=version_number,
             storage_path=storage_path,
-            meta_yaml=meta_str,
-            test_yaml=test_yaml_content,
+            testing_service_id=testing_service_id,
             created_by=permissions.user_id,
+            **promoted,
         )
         version = version_repo.create(version)
     
@@ -788,17 +970,26 @@ async def download_example_latest(
         
         # For Git repositories, we can't download directly
         if repository.source_type == "git":
-            # Return basic structure for Git-based examples
+            # Return basic structure for Git-based examples. The
+            # ``meta`` field carries the fields we know from the
+            # ``Example`` row; clients that want the full meta.yaml
+            # should clone the git repository.
+            synthetic_meta = {
+                "slug": str(example.identifier),
+                "title": example.title,
+                "description": example.description or "",
+            }
             return ExampleDownloadResponse(
                 example_id=example.id,
                 version_id=None,
                 version_tag="latest",
+                identifier=str(example.identifier),
+                directory=example.directory,
                 files={
                     "README.md": f"# {example.title}\n\n{example.description or 'No description available'}\n\nThis example is stored in a Git repository.\nClone the repository to access the files.",
-                    "meta.yaml": f"slug: {example.identifier}\ntitle: {example.title}\ndescription: {example.description or ''}\n"
                 },
-                meta_yaml=f"slug: {example.identifier}\ntitle: {example.title}\n",
-                test_yaml=None,
+                meta=synthetic_meta,
+                test=None,
                 dependencies=None,
             )
         
@@ -943,6 +1134,8 @@ async def download_example_version(
             # Download dependency files
             dep_files = await download_example_files(dep_version)
             
+            dep_meta = await _get_version_yaml_dict(dep_version, "meta", storage_service)
+            dep_test = await _get_version_yaml_dict(dep_version, "test", storage_service)
             dependency_files.append({
                 "example_id": str(dep_example.id),
                 "version_id": str(dep_version.id),
@@ -951,10 +1144,12 @@ async def download_example_version(
                 "identifier": str(dep_example.identifier),
                 "title": dep_example.title,
                 "files": dep_files,
-                "meta_yaml": dep_version.meta_yaml,
-                "test_yaml": dep_version.test_yaml,
+                "meta": dep_meta or {},
+                "test": dep_test,
             })
-    
+
+    main_meta = await _get_version_yaml_dict(version, "meta", storage_service)
+    main_test = await _get_version_yaml_dict(version, "test", storage_service)
     return ExampleDownloadResponse(
         example_id=example.id,
         version_id=version.id,
@@ -962,8 +1157,8 @@ async def download_example_version(
         identifier=str(example.identifier),
         directory=example.directory,
         files=main_files,
-        meta_yaml=version.meta_yaml,
-        test_yaml=version.test_yaml,
+        meta=main_meta or {},
+        test=main_test,
         dependencies=dependency_files if with_dependencies else None,
     )
 

--- a/computor-backend/src/computor_backend/api/services.py
+++ b/computor-backend/src/computor_backend/api/services.py
@@ -7,7 +7,7 @@ Provides endpoints for service account management and self-identification.
 from typing import Annotated, List
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.orm import Session
 
 from computor_backend.database import get_db
@@ -155,9 +155,17 @@ def update_service_endpoint(
     service_data: ServiceUpdate,
     permissions: Annotated[Principal, Depends(get_current_principal)],
     db: Session = Depends(get_db),
+    force: bool = Query(
+        False,
+        description=(
+            "Override the dependents-check when disabling a service. "
+            "Without this, disabling a service that course contents or "
+            "example versions depend on returns 409."
+        ),
+    ),
 ):
     """Update service account details."""
-    return update_service_account(service_id, service_data, permissions, db)
+    return update_service_account(service_id, service_data, permissions, db, force=force)
 
 
 @services_router.put("/{service_id}/heartbeat", status_code=status.HTTP_204_NO_CONTENT)
@@ -175,6 +183,14 @@ def delete_service_endpoint(
     service_id: UUID | str,
     permissions: Annotated[Principal, Depends(get_current_principal)],
     db: Session = Depends(get_db),
+    force: bool = Query(
+        False,
+        description=(
+            "Override the dependents-check when archiving a service. "
+            "Without this, archiving a service that course contents or "
+            "example versions depend on returns 409."
+        ),
+    ),
 ):
     """Delete (archive) a service account."""
-    delete_service_account(service_id, permissions, db)
+    delete_service_account(service_id, permissions, db, force=force)

--- a/computor-backend/src/computor_backend/api/tutor.py
+++ b/computor-backend/src/computor_backend/api/tutor.py
@@ -295,19 +295,14 @@ async def download_course_content_reference(
     """
     import zipfile
     import io
-    import yaml
 
     course_content, version, repository = await _get_example_version_for_course_content(
         course_content_id, permissions, db, cache
     )
 
-    # Parse meta.yaml to get reference file paths
-    meta_data = yaml.safe_load(version.meta_yaml) if version.meta_yaml else {}
-    properties = meta_data.get('properties', {})
-
-    # Get the reference file patterns from meta.yaml
-    student_submission_files = properties.get('studentSubmissionFiles', []) or []
-    additional_files = properties.get('additionalFiles', []) or []
+    # File lists live on dedicated columns now — no YAML parsing needed.
+    student_submission_files = list(version.student_submission_files or [])
+    additional_files = list(version.additional_files or [])
     reference_paths = set(student_submission_files + additional_files)
 
     if not reference_paths:

--- a/computor-backend/src/computor_backend/business_logic/lecturer_deployment.py
+++ b/computor-backend/src/computor_backend/business_logic/lecturer_deployment.py
@@ -106,38 +106,83 @@ def validate_semantic_version(version_str: str) -> SemanticVersion:
         ) from e
 
 
-def _auto_link_testing_service(
+def _link_testing_service(
     course_content: CourseContent,
     example_version: ExampleVersion,
     permissions: Principal,
     db: Session
 ) -> None:
+    """Copy ``example_version.testing_service_id`` onto the course content.
+
+    The canonical resolution from meta.yaml's executionBackend slug to a
+    Service.id happens once at example-version upload (see
+    ``api.examples._resolve_testing_service_id``). At assignment time we
+    just propagate the already-validated FK — O(1) and cannot silently
+    fail.
+
+    Legacy fallback: rows uploaded before the FK existed (or whose
+    backfill couldn't resolve at migration time) still have
+    ``example_version.testing_service_id = NULL``. For those, we
+    attempt the slug→service lookup once and write the result back to
+    ``example_version`` so subsequent assignments take the fast path.
+    Truly unresolvable versions raise BadRequestException — the lecturer
+    sees the failure here instead of getting an assignment that can't
+    run tests.
     """
-    Auto-link testing service to course content based on example's execution backend slug.
-
-    Looks up the service by the slug extracted from the example version's meta.yaml
-    and sets course_content.testing_service_id if found.
-    """
-    execution_backend_slug = example_version.get_execution_backend_slug()
-    if not execution_backend_slug:
-        return
-
-    service = db.query(Service).filter(
-        Service.slug == execution_backend_slug,
-        Service.enabled == True,
-        Service.archived_at.is_(None)
-    ).first()
-
-    if service:
-        if course_content.testing_service_id != service.id:
-            course_content.testing_service_id = service.id
+    if example_version.testing_service_id is not None:
+        if course_content.testing_service_id != example_version.testing_service_id:
+            course_content.testing_service_id = example_version.testing_service_id
             course_content.updated_by = permissions.user_id
             course_content.updated_at = datetime.now(timezone.utc)
-            logger.info(
-                f"Linked testing service '{execution_backend_slug}' to course content {course_content.path}"
-            )
-    else:
-        logger.warning(f"Service not found for execution_backend slug: {execution_backend_slug}")
+        return
+
+    # Legacy fallback — only reached for example_versions predating the
+    # upload-time resolver, or where backfill couldn't match the slug.
+    slug = example_version.get_execution_backend_slug()
+    if not slug:
+        raise BadRequestException(
+            error_code="EXAMPLE_VERSION_NO_BACKEND",
+            detail=(
+                f"Example version {example_version.id} has no testing "
+                "service link and its meta.yaml declares no "
+                "executionBackend. Re-upload the example with a valid "
+                "executionBackend slug."
+            ),
+            context={"example_version_id": str(example_version.id)},
+        )
+
+    service = db.query(Service).filter(
+        Service.slug == slug,
+        Service.enabled == True,  # noqa: E712 — SQLAlchemy column comparison
+        Service.archived_at.is_(None),
+    ).first()
+
+    if not service:
+        raise BadRequestException(
+            error_code="EXAMPLE_VERSION_UNKNOWN_BACKEND",
+            detail=(
+                f"Example version {example_version.id} declares "
+                f"executionBackend slug '{slug}', which does not match "
+                "any enabled, non-archived service. Register the service "
+                "or fix the slug in meta.yaml."
+            ),
+            context={
+                "example_version_id": str(example_version.id),
+                "slug": slug,
+            },
+        )
+
+    # Self-heal: persist the resolved FK on the example version so we
+    # don't have to re-do this lookup on every future assignment.
+    example_version.testing_service_id = service.id
+    course_content.testing_service_id = service.id
+    course_content.updated_by = permissions.user_id
+    course_content.updated_at = datetime.now(timezone.utc)
+    logger.info(
+        "Backfilled testing service '%s' onto example_version %s "
+        "and course content %s",
+        slug, example_version.id, course_content.path,
+    )
 
 
 def assign_example_to_content(
@@ -346,8 +391,8 @@ def assign_example_to_content(
         )
         db.add(history)
 
-        # Auto-link testing service based on example's execution backend
-        _auto_link_testing_service(course_content, example_version, permissions, db)
+        # Propagate testing service from the (validated) example version FK
+        _link_testing_service(course_content, example_version, permissions, db)
 
         db.commit()
         db.refresh(existing_deployment)
@@ -386,8 +431,8 @@ def assign_example_to_content(
         )
         db.add(history)
 
-        # Auto-link testing service based on example's execution backend
-        _auto_link_testing_service(course_content, example_version, permissions, db)
+        # Propagate testing service from the (validated) example version FK
+        _link_testing_service(course_content, example_version, permissions, db)
 
         db.commit()
         db.refresh(deployment)
@@ -559,6 +604,12 @@ def unassign_example_from_content(
     deployment.example_version_id = None
     deployment.deployment_message = 'Unassigned by lecturer'
     deployment.updated_by = permissions.user_id
+
+    # Clear the cached testing_service_id on the course content too —
+    # it was a denormalisation of the now-unassigned example version.
+    if course_content.testing_service_id is not None:
+        course_content.testing_service_id = None
+        course_content.updated_by = permissions.user_id
 
     db.commit()
 

--- a/computor-backend/src/computor_backend/business_logic/service_accounts.py
+++ b/computor-backend/src/computor_backend/business_logic/service_accounts.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 
 from computor_backend.exceptions import (
     BadRequestException,
+    ConflictException,
     NotFoundException,
     ForbiddenException,
 )
@@ -16,6 +17,8 @@ from computor_backend.permissions.core import check_permissions
 from computor_backend.permissions.principal import Principal
 from computor_backend.model.service import Service
 from computor_backend.model.auth import User
+from computor_backend.model.course import CourseContent
+from computor_backend.model.example import ExampleVersion
 from computor_types.services import (
     ServiceCreate,
     ServiceGet,
@@ -183,13 +186,67 @@ def list_service_accounts(
     return [ServiceGet.model_validate(s, from_attributes=True) for s in services]
 
 
+def _get_service_dependents(db: Session, service_id) -> dict:
+    """Return a snapshot of resources that depend on a given service.
+
+    A service is considered "in use" if either:
+      - any course_content currently caches it as ``testing_service_id``
+        (i.e. the lecturer has assigned an example whose backend is this
+        service), or
+      - any example_version was uploaded with this service as its
+        resolved testing backend.
+
+    We cap the sampled lists at 10 IDs so the 409 response stays small;
+    the totals are accurate.
+    """
+    cc_total = (
+        db.query(CourseContent)
+        .filter(CourseContent.testing_service_id == service_id)
+        .count()
+    )
+    cc_sample = [
+        str(row.id)
+        for row in db.query(CourseContent.id)
+        .filter(CourseContent.testing_service_id == service_id)
+        .limit(10)
+        .all()
+    ]
+    ev_total = (
+        db.query(ExampleVersion)
+        .filter(ExampleVersion.testing_service_id == service_id)
+        .count()
+    )
+    ev_sample = [
+        str(row.id)
+        for row in db.query(ExampleVersion.id)
+        .filter(ExampleVersion.testing_service_id == service_id)
+        .limit(10)
+        .all()
+    ]
+    return {
+        "course_content_count": cc_total,
+        "course_content_sample": cc_sample,
+        "example_version_count": ev_total,
+        "example_version_sample": ev_sample,
+        "in_use": cc_total > 0 or ev_total > 0,
+    }
+
+
 def update_service_account(
     service_id: UUID | str,
     service_data: ServiceUpdate,
     permissions: Principal,
     db: Session,
+    *,
+    force: bool = False,
 ) -> ServiceGet:
-    """Update service account details."""
+    """Update service account details.
+
+    Refuses to disable (``enabled`` from True→False) a service that
+    course contents or example versions currently depend on, unless the
+    caller explicitly passes ``force=True``. Other field updates pass
+    through unchanged.
+    """
     query = check_permissions(permissions, Service, "update", db)
 
     service = query.filter(Service.id == service_id).first()
@@ -197,8 +254,38 @@ def update_service_account(
         raise NotFoundException(detail="Service not found")
 
     try:
-        # Update fields
         update_data = service_data.model_dump(exclude_unset=True)
+
+        # Guard: disabling a service in use breaks every course content
+        # and example version that points at it. Surface dependents so
+        # the admin can clean them up first (or pass force=true to
+        # override after acknowledging the impact).
+        will_disable = (
+            "enabled" in update_data
+            and update_data["enabled"] is False
+            and service.enabled is True
+        )
+        if will_disable and not force:
+            dependents = _get_service_dependents(db, service.id)
+            if dependents["in_use"]:
+                raise ConflictException(
+                    error_code="SERVICE_HAS_DEPENDENTS",
+                    detail=(
+                        f"Cannot disable service '{service.slug}': "
+                        f"{dependents['course_content_count']} course "
+                        "content(s) and "
+                        f"{dependents['example_version_count']} example "
+                        "version(s) depend on it. Reassign or unassign "
+                        "those before disabling, or retry with "
+                        "force=true to override."
+                    ),
+                    context={
+                        "service_id": str(service.id),
+                        "service_slug": service.slug,
+                        **dependents,
+                    },
+                )
+
         for field, value in update_data.items():
             if hasattr(service, field):
                 setattr(service, field, value)
@@ -212,6 +299,9 @@ def update_service_account(
 
         return ServiceGet.model_validate(service, from_attributes=True)
 
+    except ConflictException:
+        # ConflictException is intentional — don't swallow it as a 500.
+        raise
     except Exception as e:
         db.rollback()
         logger.error(f"Error updating service account: {e}")
@@ -247,18 +337,45 @@ def delete_service_account(
     service_id: UUID | str,
     permissions: Principal,
     db: Session,
+    *,
+    force: bool = False,
 ) -> None:
     """
     Delete (archive) a service account.
 
-    This soft-deletes the service by setting archived_at.
-    The user account is not deleted.
+    This soft-deletes the service by setting archived_at. The user
+    account is not deleted.
+
+    Refuses if any course_content or example_version currently depends
+    on the service (would render their assignments untestable). Pass
+    ``force=True`` to archive anyway after acknowledging the impact.
     """
     query = check_permissions(permissions, Service, "delete", db)
 
     service = query.filter(Service.id == service_id).first()
     if not service:
         raise NotFoundException(detail="Service not found")
+
+    if not force:
+        dependents = _get_service_dependents(db, service.id)
+        if dependents["in_use"]:
+            raise ConflictException(
+                error_code="SERVICE_HAS_DEPENDENTS",
+                detail=(
+                    f"Cannot archive service '{service.slug}': "
+                    f"{dependents['course_content_count']} course "
+                    "content(s) and "
+                    f"{dependents['example_version_count']} example "
+                    "version(s) depend on it. Reassign or unassign "
+                    "those before archiving, or retry with force=true "
+                    "to override."
+                ),
+                context={
+                    "service_id": str(service.id),
+                    "service_slug": service.slug,
+                    **dependents,
+                },
+            )
 
     try:
         service.archived_at = datetime.now(timezone.utc)

--- a/computor-backend/src/computor_backend/model/example.py
+++ b/computor-backend/src/computor_backend/model/example.py
@@ -6,7 +6,7 @@ Each example is stored in its own directory with a flat structure.
 """
 
 from sqlalchemy import Column, String, Text, Boolean, DateTime, ARRAY, ForeignKey, text, Integer
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from sqlalchemy import CheckConstraint, UniqueConstraint
@@ -212,63 +212,120 @@ class ExampleVersion(Base):
         comment="Path in storage system (MinIO path, S3 key, etc.)"
     )
     
-    # Content metadata
-    meta_yaml = Column(
-        Text,
-        nullable=False,
-        comment="Content of meta.yaml file for this version"
+    # Content metadata: only promoted columns live in the DB. The full
+    # meta.yaml / test.yaml documents are persisted to MinIO at
+    # ``{storage_path}/meta.yaml`` and ``{storage_path}/test.yaml``;
+    # download endpoints read them from there (with a Redis cache in
+    # front) instead of duplicating the raw documents in Postgres.
+    title = Column(
+        String(255),
+        nullable=True,
+        comment="meta.yaml: title (per-version)",
     )
-    test_yaml = Column(
+    description = Column(
         Text,
         nullable=True,
-        comment="Content of test.yaml file for this version (optional)"
+        comment="meta.yaml: description (per-version)",
+    )
+    language = Column(
+        String(16),
+        nullable=True,
+        comment="meta.yaml: language",
+    )
+    license = Column(
+        String(255),
+        nullable=True,
+        comment="meta.yaml: license",
+    )
+    execution_backend = Column(
+        JSONB,
+        nullable=True,
+        comment="meta.yaml: properties.executionBackend full dict (slug + version + settings)",
+    )
+    student_submission_files = Column(
+        ARRAY(Text),
+        nullable=False,
+        default=list,
+        comment="meta.yaml: properties.studentSubmissionFiles",
+    )
+    additional_files = Column(
+        ARRAY(Text),
+        nullable=False,
+        default=list,
+        comment="meta.yaml: properties.additionalFiles",
+    )
+    student_templates = Column(
+        ARRAY(Text),
+        nullable=False,
+        default=list,
+        comment="meta.yaml: properties.studentTemplates",
+    )
+    test_files = Column(
+        ARRAY(Text),
+        nullable=False,
+        default=list,
+        comment="meta.yaml: properties.testFiles",
     )
     
+    # Testing service: resolved at upload from
+    # ``properties.executionBackend.slug`` in meta.yaml against the
+    # ``service`` table. Stored as a real FK so assignment-time copies
+    # are O(1) and the resolution can't silently drift after upload.
+    testing_service_id = Column(
+        UUID,
+        ForeignKey('service.id', ondelete='RESTRICT'),
+        nullable=True,
+        index=True,
+        comment="Resolved Service.id for the executionBackend declared in meta.yaml",
+    )
+
     # Tracking
     created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
     created_by = Column(UUID, ForeignKey("user.id"), comment="User who created this version")
-    
+
     # Relationships
     example = relationship("Example", back_populates="versions")
     created_by_user = relationship("User", foreign_keys=[created_by])
-    
+    testing_service = relationship("Service", foreign_keys=[testing_service_id])
+
     # Deployment tracking
-    
+
     # Constraints
     __table_args__ = (
         UniqueConstraint("example_id", "version_tag", name="unique_example_version_tag"),
         UniqueConstraint("example_id", "version_number", name="unique_example_version_number"),
     )
-    
+
     def __repr__(self):
         return f"<ExampleVersion(id={self.id}, version_tag='{self.version_tag}')>"
-    
-    def get_execution_backend_slug(self) -> str:
+
+    @staticmethod
+    def extract_execution_backend(meta: dict | None) -> dict | None:
+        """Pull ``properties.executionBackend`` out of a parsed meta dict.
+
+        Returns the full block (slug + version + settings) or None.
+        Used by the upload path to populate ``execution_backend``.
         """
-        Extract the execution backend slug from the meta_yaml.
-        
-        Returns:
-            Execution backend slug if found, None otherwise
+        if not isinstance(meta, dict):
+            return None
+        properties = meta.get('properties')
+        if not isinstance(properties, dict):
+            return None
+        eb = properties.get('executionBackend')
+        return eb if isinstance(eb, dict) else None
+
+    def get_execution_backend_slug(self) -> str | None:
+        """Convenience accessor for the execution-backend slug.
+
+        Reads the dedicated ``execution_backend`` JSONB column — no YAML
+        parsing, no nested-dict walking. Prefer the resolved
+        ``testing_service_id`` FK for runtime decisions; this method is
+        for callers that genuinely need the original slug string (e.g.
+        legacy fallbacks where the FK wasn't backfilled).
         """
-        import yaml
-        
-        if not self.meta_yaml:
+        if not isinstance(self.execution_backend, dict):
             return None
-        
-        try:
-            # Parse the meta.yaml content
-            meta_data = yaml.safe_load(self.meta_yaml)
-            
-            # Navigate to properties.executionBackend.slug
-            properties = meta_data.get('properties', {})
-            if properties:
-                execution_backend = properties.get('executionBackend', {})
-                if execution_backend and isinstance(execution_backend, dict):
-                    return execution_backend.get('slug')
-            
-            return None
-        except (yaml.YAMLError, AttributeError, TypeError):
-            return None
+        return self.execution_backend.get('slug')
 
 
 class ExampleDependency(Base):

--- a/computor-backend/src/computor_backend/scripts/test_examples_api.py
+++ b/computor-backend/src/computor_backend/scripts/test_examples_api.py
@@ -94,17 +94,10 @@ class ExampleAPITester:
         print("\n🧪 Testing Upload/Download")
         print("=" * 40)
         
-        # Test upload
+        # Test upload — meta.yaml and test.yaml ride inside the ``files``
+        # dict (the upload endpoint extracts them from there).
         print("\n1. Testing upload...")
-        upload_data = {
-            "repository_id": repository_id,
-            "directory": "hello-world",
-            "version_tag": "1.0",
-            "files": {
-                "main.py": "print('Hello, World!')\n",
-                "README.md": "# Hello World Example\n\nA simple hello world program.\n"
-            },
-            "meta_yaml": """slug: api.test.hello.world
+        meta_yaml_str = """slug: api.test.hello.world
 version: '1.0'
 title: Hello World
 description: Simple hello world example
@@ -112,8 +105,11 @@ language: en
 properties:
   studentSubmissionFiles:
   - main.py
-""",
-            "test_yaml": """type: python
+  executionBackend:
+    slug: itpcp.exec.py
+    version: '3.13'
+"""
+        test_yaml_str = """type: python
 name: Hello World Test
 description: Test for hello world
 version: '1.0'
@@ -123,6 +119,16 @@ properties:
     name: hello_output
     expected: "Hello, World!"
 """
+        upload_data = {
+            "repository_id": repository_id,
+            "directory": "hello-world",
+            "version_tag": "1.0",
+            "files": {
+                "main.py": "print('Hello, World!')\n",
+                "README.md": "# Hello World Example\n\nA simple hello world program.\n",
+                "meta.yaml": meta_yaml_str,
+                "test.yaml": test_yaml_str,
+            },
         }
         
         response = self.session.post(f"{self.base_url}/examples/upload", json=upload_data)
@@ -140,8 +146,8 @@ properties:
                 print(f"   Downloaded {len(download_data['files'])} files:")
                 for filename in download_data['files'].keys():
                     print(f"   - {filename}")
-                print(f"   Has meta.yaml: {bool(download_data['meta_yaml'])}")
-                print(f"   Has test.yaml: {bool(download_data['test_yaml'])}")
+                print(f"   Has meta:      {bool(download_data.get('meta'))}")
+                print(f"   Has test:      {bool(download_data.get('test'))}")
                 return True
             else:
                 print(f"   Download Error: {response.text}")

--- a/computor-backend/src/computor_backend/scripts/upload_examples.py
+++ b/computor-backend/src/computor_backend/scripts/upload_examples.py
@@ -192,14 +192,15 @@ language: en
                 with open(file_path, 'w', encoding='utf-8') as f:
                     f.write(content)
             
-            # Write meta.yaml
+            # Write meta.yaml — server returns parsed dict, render back to YAML
+            import yaml as _yaml
             with open(example_dir / 'meta.yaml', 'w', encoding='utf-8') as f:
-                f.write(data['meta_yaml'])
-            
-            # Write test.yaml if present
-            if data['test_yaml']:
+                _yaml.safe_dump(data['meta'], f, default_flow_style=False, sort_keys=False)
+
+            # Write test.yaml if present — server returns parsed dict, render back
+            if data.get('test'):
                 with open(example_dir / 'test.yaml', 'w', encoding='utf-8') as f:
-                    f.write(data['test_yaml'])
+                    _yaml.safe_dump(data['test'], f, default_flow_style=False, sort_keys=False)
             
             print(f"✅ Downloaded to: {example_dir}")
             return True

--- a/computor-backend/src/computor_backend/tasks/temporal_student_template_v2.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_student_template_v2.py
@@ -23,23 +23,26 @@ async def process_example_for_student_template_v2(
 ) -> Dict[str, Any]:
     """
     Process example files for student template generation.
-    Uses meta.yaml to determine which files to include.
+    File lists come from the ExampleVersion DB row (typed columns), not
+    from re-parsing the workspace meta.yaml.
     """
-    import yaml
     from pathlib import Path
-    
+
     try:
         # Create target directory
         target_path.mkdir(parents=True, exist_ok=True)
-        
-        # Parse meta.yaml if it exists
-        meta_yaml = None
-        if 'meta.yaml' in example_files:
-            try:
-                meta_yaml = yaml.safe_load(example_files['meta.yaml'])
-            except Exception as e:
-                logger.error(f"Failed to parse meta.yaml: {e}")
-        
+
+        # File lists from typed columns on ExampleVersion. These were
+        # derived from meta.yaml at upload and are the source of truth
+        # for what files belong to this version.
+        additional_files = list(getattr(version, 'additional_files', None) or [])
+        submission_files = list(getattr(version, 'student_submission_files', None) or [])
+        student_templates = list(getattr(version, 'student_templates', None) or [])
+        has_meta = (
+            additional_files or submission_files or student_templates
+            or getattr(version, 'meta', None)
+        )
+
         # Process content directory files
         for filename, content in example_files.items():
             if filename.startswith('content/'):
@@ -63,23 +66,15 @@ async def process_example_for_student_template_v2(
                     file_path = target_path / relative_path
                     file_path.parent.mkdir(parents=True, exist_ok=True)
                     file_path.write_bytes(content)
-        
-        if meta_yaml:
-            properties = meta_yaml.get('properties', {})
-            
+
+        if has_meta:
             # Process additionalFiles - copy to assignment root
-            additional_files = properties.get('additionalFiles', [])
             for file_name in additional_files:
                 if file_name in example_files:
                     # Copy to root of assignment directory
                     file_path = target_path / Path(file_name).name  # Use only filename, not path
                     file_path.parent.mkdir(parents=True, exist_ok=True)
                     file_path.write_bytes(example_files[file_name])
-            
-            # Process studentSubmissionFiles - ensure all required files exist
-            # Use content from studentTemplates when available, otherwise create empty
-            submission_files = properties.get('studentSubmissionFiles', [])
-            student_templates = properties.get('studentTemplates', [])
             
             # Build a map of template filenames to their content
             template_content_map = {}
@@ -619,69 +614,72 @@ async def generate_student_template_activity_v2(
                         logger.warning(f"Failed to load files from example repository for {content.path}: {e}")
                         files = {}
 
-                    # Extract service type from meta.yaml and link to appropriate service
-                    if not content.testing_service_id and files:
+                    # Legacy fallback: link a testing service by language when
+                    # the slug→service.id resolution didn't fire. Reads from
+                    # the ExampleVersion's typed ``execution_backend`` column
+                    # first; falls back to parsing the meta.yaml that's
+                    # already in the ``files`` dict for the rare
+                    # ``properties.serviceType`` path.
+                    if not content.testing_service_id and content.deployment.example_version:
                         try:
-                            meta_yaml_bytes = files.get('meta.yaml')
+                            ev = content.deployment.example_version
+                            language = None
+
+                            # New ``properties.serviceType`` path lives only
+                            # in meta.yaml — parse the workspace copy if we
+                            # have it.
+                            meta_yaml_bytes = files.get('meta.yaml') if files else None
                             if meta_yaml_bytes:
-                                import yaml
-                                meta_data = yaml.safe_load(meta_yaml_bytes)
-                                language = None
+                                import yaml as _yaml
+                                try:
+                                    meta_data = _yaml.safe_load(meta_yaml_bytes) or {}
+                                except Exception:
+                                    meta_data = {}
+                                props = meta_data.get('properties') if isinstance(meta_data.get('properties'), dict) else {}
+                                service_type_spec = props.get('serviceType') or props.get('service_type')
+                                if service_type_spec and isinstance(service_type_spec, str) and service_type_spec.startswith('testing.'):
+                                    # e.g., "testing.python" -> "python"
+                                    language = service_type_spec.split('.')[-1]
 
-                                if meta_data:
-                                    props = (meta_data.get('properties') or {})
-                                    # Check for new service_type path or legacy executionBackend slug
-                                    service_type_spec = props.get('serviceType') or props.get('service_type')
+                            if not language:
+                                # Legacy: map executionBackend.slug suffix to language
+                                backend_slug = (ev.execution_backend or {}).get('slug') if isinstance(ev.execution_backend, dict) else None
+                                if backend_slug:
+                                    slug_parts = backend_slug.split('.')
+                                    backend_type = slug_parts[-1] if slug_parts else backend_slug
+                                    legacy_mapping = {
+                                        'py': 'python',
+                                        'python': 'python',
+                                        'matlab': 'matlab',
+                                        'mat': 'matlab',
+                                    }
+                                    language = legacy_mapping.get(backend_type)
 
-                                    if service_type_spec:
-                                        # Extract language from service type spec
-                                        # e.g., "testing.python" -> "python", "testing.matlab" -> "matlab"
-                                        if service_type_spec.startswith('testing.'):
-                                            language = service_type_spec.split('.')[-1]
+                            if language:
+                                from sqlalchemy_utils import Ltree
+                                from ..model.service import Service
 
-                                    if not language:
-                                        # Legacy support: map old backend slugs to languages
-                                        eb = props.get('executionBackend') or {}
-                                        backend_slug = eb.get('slug')
-                                        if backend_slug:
-                                            # Extract language from legacy slug
-                                            # e.g., 'python' -> 'python', 'itpcp.exec.py' -> 'py' -> 'python'
-                                            slug_parts = backend_slug.split('.')
-                                            backend_type = slug_parts[-1] if slug_parts else backend_slug
-                                            # Map legacy backend types to languages
-                                            legacy_mapping = {
-                                                'py': 'python',
-                                                'python': 'python',
-                                                'matlab': 'matlab',
-                                                'mat': 'matlab',
-                                            }
-                                            language = legacy_mapping.get(backend_type)
+                                # Find the testing.temporal ServiceType
+                                service_type = db.query(ServiceType).filter(
+                                    ServiceType.path == Ltree('testing.temporal')
+                                ).first()
 
-                                if language:
-                                    from sqlalchemy_utils import Ltree
-                                    from ..model.service import Service
-
-                                    # Find the testing.temporal ServiceType
-                                    service_type = db.query(ServiceType).filter(
-                                        ServiceType.path == Ltree('testing.temporal')
+                                if service_type:
+                                    # Find a Service with this service_type_id AND matching language
+                                    # Prefer enabled services
+                                    service = db.query(Service).filter(
+                                        Service.service_type_id == service_type.id,
+                                        Service.enabled == True,
+                                        Service.properties['language'].astext == language
                                     ).first()
 
-                                    if service_type:
-                                        # Find a Service with this service_type_id AND matching language
-                                        # Prefer enabled services
-                                        service = db.query(Service).filter(
-                                            Service.service_type_id == service_type.id,
-                                            Service.enabled == True,
-                                            Service.properties['language'].astext == language
-                                        ).first()
-
-                                        if service:
-                                            content.testing_service_id = service.id
-                                            logger.info(f"Linked service '{service.slug}' (language: {language}) to course content {content.path}")
-                                        else:
-                                            logger.warning(f"No enabled Service found for language '{language}' with ServiceType 'testing.temporal'")
+                                    if service:
+                                        content.testing_service_id = service.id
+                                        logger.info(f"Linked service '{service.slug}' (language: {language}) to course content {content.path}")
                                     else:
-                                        logger.warning(f"ServiceType 'testing.temporal' not found - run seed_testing_temporal_service_type.py")
+                                        logger.warning(f"No enabled Service found for language '{language}' with ServiceType 'testing.temporal'")
+                                else:
+                                    logger.warning(f"ServiceType 'testing.temporal' not found - run seed_testing_temporal_service_type.py")
                         except Exception as e:
                             logger.warning(f"Failed to link service: {e}")
 

--- a/computor-cli/src/computor_cli/deployment.py
+++ b/computor-cli/src/computor_cli/deployment.py
@@ -947,19 +947,16 @@ def _deploy_course_contents(course_id: str, course_config: HierarchicalCourseCon
                                 if v.get('version_tag') == version_tag:
                                     version = v
                                     break
-                        # Fetch full version details to access meta_yaml
-                        if version and not version.get('meta_yaml'):
+                        # Fetch full version details if the list view didn't carry
+                        # title/description (the GET version response always does).
+                        if version and version.get('title') is None and version.get('description') is None:
                             try:
                                 version = custom_client.get(f"examples/versions/{version['id']}") or version
                             except Exception:
                                 pass
-                        if version and version.get('meta_yaml'):
-                            try:
-                                meta = yaml.safe_load(version.get('meta_yaml') or "") or {}
-                                meta_title = meta.get('title')
-                                meta_description = meta.get('description')
-                            except Exception:
-                                pass
+                        if version:
+                            meta_title = version.get('title')
+                            meta_description = version.get('description')
                 except Exception:
                     pass
 

--- a/computor-types/src/computor_types/course_contents.py
+++ b/computor-types/src/computor_types/course_contents.py
@@ -42,7 +42,11 @@ class CourseContentCreate(BaseModel):
     max_group_size: Optional[int] = None
     max_test_runs: Optional[int] = None
     max_submissions: Optional[int] = None
-    testing_service_id: Optional[str] = None
+    # Note: testing_service_id is no longer client-settable. It's derived
+    # from the assigned example version's executionBackend declaration
+    # (resolved at upload, propagated by the deployment API). Setting it
+    # by hand on create/update could decouple it from the example version
+    # and break testing.
     # Note: Example assignments are now handled through the deployment API
     # Use POST /course-contents/{id}/assign-example instead
 
@@ -144,7 +148,9 @@ class CourseContentUpdate(BaseModel):
     max_group_size: Optional[int] = None
     max_test_runs: Optional[int] = None
     max_submissions: Optional[int] = None
-    testing_service_id: Optional[str] = None
+    # Note: testing_service_id is no longer client-settable. It's derived
+    # from the assigned example version's executionBackend declaration.
+    # See CourseContentCreate for rationale.
     # Note: Example assignments cannot be updated here
     # Use the deployment API endpoints instead
 

--- a/computor-types/src/computor_types/example.py
+++ b/computor-types/src/computor_types/example.py
@@ -132,23 +132,48 @@ class ExampleUpdate(BaseModel):
     tags: Optional[List[str]] = None
 
 class ExampleVersionCreate(BaseModel):
-    """Create a new example version."""
+    """Create a new example version.
+
+    Clients pass an already-parsed meta.yaml as ``meta`` — the server
+    extracts the promoted scalar / array / FK columns from it and
+    discards the rest. The full meta.yaml document lives in MinIO
+    alongside the other example files; the download endpoint serves
+    it from there.
+    """
     example_id: str
     version_tag: str = Field(..., max_length=64)
     version_number: int = Field(..., ge=1)
     storage_path: str
-    meta_yaml: str = Field(..., description="Content of meta.yaml")
-    test_yaml: Optional[str] = Field(None, description="Content of test.yaml")
+    meta: Dict[str, Any] = Field(..., description="Parsed meta.yaml — used to populate promoted columns")
 
 class ExampleVersionGet(BaseEntityGet):
-    """Get example version details."""
+    """Get example version details — promoted columns only.
+
+    The full parsed meta.yaml / test.yaml documents are not returned
+    here; call ``GET /examples/download/{version_id}`` for those.
+    """
     id: str
     example_id: str
     version_tag: str
     version_number: int
     storage_path: str
-    meta_yaml: str
-    test_yaml: Optional[str] = None
+    # Promoted fields — direct column reads, no dict navigation.
+    title: Optional[str] = None
+    description: Optional[str] = None
+    language: Optional[str] = None
+    license: Optional[str] = None
+    execution_backend: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Full meta.yaml properties.executionBackend (slug + version + settings)",
+    )
+    student_submission_files: List[str] = Field(default_factory=list)
+    additional_files: List[str] = Field(default_factory=list)
+    student_templates: List[str] = Field(default_factory=list)
+    test_files: List[str] = Field(default_factory=list)
+    testing_service_id: Optional[str] = Field(
+        None,
+        description="Resolved Service.id derived from properties.executionBackend.slug",
+    )
     created_at: datetime
     created_by: Optional[str] = None
 
@@ -159,6 +184,9 @@ class ExampleVersionList(BaseModel):
     id: str
     version_tag: str
     version_number: int
+    title: Optional[str] = None
+    description: Optional[str] = None
+    testing_service_id: Optional[str] = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
@@ -242,9 +270,9 @@ class ExampleFileSet(BaseModel):
     directory: str
     identifier: str
     title: str
-    files: Dict[str, str] = Field(..., description="Map of filename to content")
-    meta_yaml: str
-    test_yaml: Optional[str] = None
+    files: Dict[str, str] = Field(..., description="Map of filename to content (meta.yaml and test.yaml ride inside this dict)")
+    meta: Dict[str, Any] = Field(..., description="Parsed meta.yaml (fetched from MinIO with Redis cache)")
+    test: Optional[Dict[str, Any]] = Field(None, description="Parsed test.yaml (fetched from MinIO with Redis cache); None if absent")
 
 class ExampleDownloadResponse(BaseModel):
     """Response containing downloaded example files."""
@@ -253,9 +281,9 @@ class ExampleDownloadResponse(BaseModel):
     version_tag: str
     identifier: str = Field(..., description="Hierarchical identifier of the example (e.g., itpcp.pgph.py.quadratic_eq)")
     directory: str = Field(..., description="Directory name of the example")
-    files: Dict[str, str] = Field(..., description="Map of filename to content")
-    meta_yaml: str
-    test_yaml: Optional[str] = None
+    files: Dict[str, str] = Field(..., description="Map of filename to content (includes meta.yaml and test.yaml)")
+    meta: Dict[str, Any] = Field(..., description="Parsed meta.yaml (fetched from MinIO with Redis cache)")
+    test: Optional[Dict[str, Any]] = Field(None, description="Parsed test.yaml (fetched from MinIO with Redis cache); None if absent")
     # Dependencies included when with_dependencies=True
     dependencies: Optional[List[ExampleFileSet]] = Field(None, description="Dependency examples when with_dependencies=True")
 

--- a/computor-types/src/computor_types/generated/error_codes.py
+++ b/computor-types/src/computor_types/generated/error_codes.py
@@ -2,7 +2,7 @@
 Auto-generated error code constants
 
 DO NOT EDIT MANUALLY
-Generated at: 2026-05-01T19:35:09.631976
+Generated at: 2026-05-05T23:44:23.386638
 
 To regenerate: bash generate_error_codes.sh
 """
@@ -16,11 +16,13 @@ class ErrorCode(str, Enum):
     AUTH_002 = "AUTH_002"  # Invalid Credentials
     AUTH_003 = "AUTH_003"  # Token Expired
     AUTH_004 = "AUTH_004"  # SSO Authentication Failed
+    AUTH_005 = "AUTH_005"  # API Token Expired
     AUTHZ_001 = "AUTHZ_001"  # Insufficient Permissions
     AUTHZ_002 = "AUTHZ_002"  # Admin Access Required
     AUTHZ_003 = "AUTHZ_003"  # Course Access Denied
     AUTHZ_004 = "AUTHZ_004"  # Insufficient Course Role
     AUTHZ_005 = "AUTHZ_005"  # Role Escalation Denied
+    AUTHZ_010 = "AUTHZ_010"  # Service Account Required
     VAL_001 = "VAL_001"  # Invalid Request Data
     VAL_002 = "VAL_002"  # Missing Required Field
     VAL_003 = "VAL_003"  # Invalid Field Format
@@ -29,6 +31,7 @@ class ErrorCode(str, Enum):
     NF_002 = "NF_002"  # User Not Found
     NF_003 = "NF_003"  # Course Not Found
     NF_004 = "NF_004"  # Endpoint Not Found
+    NF_010 = "NF_010"  # Service Record Not Found
     CONFLICT_001 = "CONFLICT_001"  # Resource Already Exists
     CONFLICT_002 = "CONFLICT_002"  # Concurrent Modification
     RATE_001 = "RATE_001"  # Rate Limit Exceeded
@@ -72,6 +75,7 @@ class ErrorCode(str, Enum):
     EXT_003 = "EXT_003"  # MinIO Service Unavailable
     EXT_004 = "EXT_004"  # Temporal Service Unavailable
     EXT_005 = "EXT_005"  # Task Queue Unavailable
+    EXT_006 = "EXT_006"  # Service Unavailable
     DB_001 = "DB_001"  # Database Connection Failed
     DB_002 = "DB_002"  # Database Query Failed
     DB_003 = "DB_003"  # Transaction Failed
@@ -100,11 +104,13 @@ ERROR_CATEGORIES = {
     ErrorCode.AUTH_002: "authentication",
     ErrorCode.AUTH_003: "authentication",
     ErrorCode.AUTH_004: "authentication",
+    ErrorCode.AUTH_005: "authentication",
     ErrorCode.AUTHZ_001: "authorization",
     ErrorCode.AUTHZ_002: "authorization",
     ErrorCode.AUTHZ_003: "authorization",
     ErrorCode.AUTHZ_004: "authorization",
     ErrorCode.AUTHZ_005: "authorization",
+    ErrorCode.AUTHZ_010: "authorization",
     ErrorCode.VAL_001: "validation",
     ErrorCode.VAL_002: "validation",
     ErrorCode.VAL_003: "validation",
@@ -113,6 +119,7 @@ ERROR_CATEGORIES = {
     ErrorCode.NF_002: "not_found",
     ErrorCode.NF_003: "not_found",
     ErrorCode.NF_004: "not_found",
+    ErrorCode.NF_010: "not_found",
     ErrorCode.CONFLICT_001: "conflict",
     ErrorCode.CONFLICT_002: "conflict",
     ErrorCode.RATE_001: "rate_limit",
@@ -156,6 +163,7 @@ ERROR_CATEGORIES = {
     ErrorCode.EXT_003: "external_service",
     ErrorCode.EXT_004: "external_service",
     ErrorCode.EXT_005: "external_service",
+    ErrorCode.EXT_006: "external_service",
     ErrorCode.DB_001: "database",
     ErrorCode.DB_002: "database",
     ErrorCode.DB_003: "database",

--- a/computor-web/src/generated/clients/ServicesClient.ts
+++ b/computor-web/src/generated/clients/ServicesClient.ts
@@ -63,8 +63,9 @@ export class ServicesClient extends BaseEndpointClient {
    * Delete Service Endpoint
    * Delete (archive) a service account.
    */
-  async deleteServiceEndpointServiceAccountsServiceIdDelete({ serviceId, userId }: { serviceId: string | string; userId?: string | null }): Promise<void> {
+  async deleteServiceEndpointServiceAccountsServiceIdDelete({ serviceId, force, userId }: { serviceId: string | string; force?: boolean; userId?: string | null }): Promise<void> {
     const queryParams: Record<string, unknown> = {
+      force,
       user_id: userId,
     };
     return this.client.delete<void>(this.buildPath(serviceId), { params: queryParams });
@@ -85,8 +86,9 @@ export class ServicesClient extends BaseEndpointClient {
    * Update Service Endpoint
    * Update service account details.
    */
-  async updateServiceEndpointServiceAccountsServiceIdPatch({ serviceId, userId, body }: { serviceId: string | string; userId?: string | null; body: ServiceUpdate }): Promise<ServiceGet> {
+  async updateServiceEndpointServiceAccountsServiceIdPatch({ serviceId, force, userId, body }: { serviceId: string | string; force?: boolean; userId?: string | null; body: ServiceUpdate }): Promise<ServiceGet> {
     const queryParams: Record<string, unknown> = {
+      force,
       user_id: userId,
     };
     return this.client.patch<ServiceGet>(this.buildPath(serviceId), body, { params: queryParams });

--- a/computor-web/src/generated/errors/ERROR_CODES.md
+++ b/computor-web/src/generated/errors/ERROR_CODES.md
@@ -1,8 +1,8 @@
 # Error Code Reference
 
 **Auto-generated documentation**
-**Generated:** 2026-05-01 19:35:09
-**Total errors:** 66
+**Generated:** 2026-05-05 23:44:23
+**Total errors:** 70
 
 To regenerate: `bash generate_error_codes.sh`
 
@@ -137,6 +137,31 @@ Keycloak or other SSO provider authentication failed
 1. Retry authentication
 2. Check SSO provider status
 3. Contact administrator to verify SSO configuration
+
+---
+
+### AUTH_005 - API Token Expired
+
+**HTTP Status:** `401`  
+**Severity:** `warning`  
+**Category:** `authentication`  
+**Documentation:** [/docs/authentication#api-tokens](/docs/authentication#api-tokens)  
+
+**Description:**  
+ApiToken.expires_at is in the past — token validation rejected the request before reaching the endpoint.
+
+**User Message:**  
+> Your API token has expired. Generate a new one and retry.
+
+**Affected Functions:**
+- `_authenticate_api_token`
+
+**Common Causes:**
+- Token TTL elapsed since issuance
+
+**Resolution Steps:**
+1. Issue a new API token via /api-tokens
+2. Update the client to use the new token
 
 ---
 
@@ -336,6 +361,30 @@ User attempted to assign a course role higher than their own privilege level
 **Resolution Steps:**
 1. Request a user with higher privileges to perform this action
 2. Assign a role at or below your own privilege level
+
+---
+
+### AUTHZ_010 - Service Account Required
+
+**HTTP Status:** `403`  
+**Severity:** `warning`  
+**Category:** `authorization`  
+**Documentation:** [/docs/authentication#service-accounts](/docs/authentication#service-accounts)  
+
+**Description:**  
+Endpoint requires User.is_service=True; called with a regular human user.
+
+**User Message:**  
+> This endpoint is only available for service accounts.
+
+**Affected Functions:**
+- `get_service_by_user_id`
+
+**Common Causes:**
+- Calling a service-account endpoint with a normal user token
+
+**Resolution Steps:**
+1. Use the service-account user_id when calling this endpoint
 
 ---
 
@@ -758,6 +807,29 @@ Temporal task queue has no available workers or queue configuration is invalid
 
 ---
 
+### EXT_006 - Service Unavailable
+
+**HTTP Status:** `503`  
+**Severity:** `error`  
+**Category:** `external_service`  
+**Retry After:** 60 seconds  
+
+**Description:**  
+Generic 503 fallback when the specific upstream service is unknown or not yet categorised; prefer EXT_001 (GitLab), EXT_003 (MinIO), EXT_004 (Temporal), or EXT_005 (task queue) when the source is known.
+
+**User Message:**  
+> An external service is temporarily unavailable.
+
+**Common Causes:**
+- Generic upstream failure surfaced through Starlette's HTTPException
+- Service-specific exception subclass not yet introduced for this code path
+
+**Resolution Steps:**
+1. Inspect server logs for the underlying cause
+2. Retry the request after a short backoff
+
+---
+
 ## Internal
 
 ### TASK_002 - Task Submission Failed
@@ -961,6 +1033,32 @@ HTTP route not registered in FastAPI application
 1. Check API documentation for correct endpoint
 2. Verify API version
 3. Check HTTP method (GET, POST, etc.)
+
+---
+
+### NF_010 - Service Record Not Found
+
+**HTTP Status:** `404`  
+**Severity:** `warning`  
+**Category:** `not_found`  
+**Documentation:** [/docs/services](/docs/services)  
+
+**Description:**  
+ServiceRepository.find_by_user_id returned None for a User.is_service=True row.
+
+**User Message:**  
+> No service record exists for this service account.
+
+**Affected Functions:**
+- `get_service_by_user_id`
+
+**Common Causes:**
+- Service account created without provisioning a Service row
+- Service row deleted while the user was kept
+
+**Resolution Steps:**
+1. Re-provision the service via the admin API
+2. Or delete the orphan service-account user
 
 ---
 

--- a/computor-web/src/generated/errors/error-catalog.json
+++ b/computor-web/src/generated/errors/error-catalog.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-01T19:35:09.626700",
-  "error_count": 66,
+  "generated_at": "2026-05-05T23:44:23.381406",
+  "error_count": 70,
   "errors": {
     "AUTH_001": {
       "code": "AUTH_001",
@@ -116,6 +116,31 @@
         "Retry authentication",
         "Check SSO provider status",
         "Contact administrator to verify SSO configuration"
+      ]
+    },
+    "AUTH_005": {
+      "code": "AUTH_005",
+      "http_status": 401,
+      "category": "authentication",
+      "severity": "warning",
+      "title": "API Token Expired",
+      "message": {
+        "plain": "Your API token has expired. Generate a new one and retry.",
+        "markdown": "**API Token Expired**\n\nThe API token used for this request has expired. Generate a new token and retry.",
+        "html": "<strong>API Token Expired</strong><p>The API token used for this request has expired. Generate a new token and retry.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/authentication#api-tokens",
+      "internal_description": "ApiToken.expires_at is in the past \u2014 token validation rejected the request before reaching the endpoint.",
+      "affected_functions": [
+        "_authenticate_api_token"
+      ],
+      "common_causes": [
+        "Token TTL elapsed since issuance"
+      ],
+      "resolution_steps": [
+        "Issue a new API token via /api-tokens",
+        "Update the client to use the new token"
       ]
     },
     "AUTHZ_001": {
@@ -256,6 +281,30 @@
       "resolution_steps": [
         "Request a user with higher privileges to perform this action",
         "Assign a role at or below your own privilege level"
+      ]
+    },
+    "AUTHZ_010": {
+      "code": "AUTHZ_010",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "warning",
+      "title": "Service Account Required",
+      "message": {
+        "plain": "This endpoint is only available for service accounts.",
+        "markdown": "**Service Account Required**\n\nThis endpoint is only available for users marked as service accounts.",
+        "html": "<strong>Service Account Required</strong><p>This endpoint is only available for users marked as service accounts.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/authentication#service-accounts",
+      "internal_description": "Endpoint requires User.is_service=True; called with a regular human user.",
+      "affected_functions": [
+        "get_service_by_user_id"
+      ],
+      "common_causes": [
+        "Calling a service-account endpoint with a normal user token"
+      ],
+      "resolution_steps": [
+        "Use the service-account user_id when calling this endpoint"
       ]
     },
     "VAL_001": {
@@ -485,6 +534,32 @@
         "Check API documentation for correct endpoint",
         "Verify API version",
         "Check HTTP method (GET, POST, etc.)"
+      ]
+    },
+    "NF_010": {
+      "code": "NF_010",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "warning",
+      "title": "Service Record Not Found",
+      "message": {
+        "plain": "No service record exists for this service account.",
+        "markdown": "**Service Record Not Found**\n\nThe service-account user has no associated ``Service`` row. The account exists but is not linked to a service definition.",
+        "html": "<strong>Service Record Not Found</strong><p>The service-account user has no associated <code>Service</code> row. The account exists but is not linked to a service definition.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/services",
+      "internal_description": "ServiceRepository.find_by_user_id returned None for a User.is_service=True row.",
+      "affected_functions": [
+        "get_service_by_user_id"
+      ],
+      "common_causes": [
+        "Service account created without provisioning a Service row",
+        "Service row deleted while the user was kept"
+      ],
+      "resolution_steps": [
+        "Re-provision the service via the admin API",
+        "Or delete the orphan service-account user"
       ]
     },
     "CONFLICT_001": {
@@ -1698,6 +1773,30 @@
         "Ensure configuration follows the correct structure: {\"temporal\": {\"task_queue\": \"queue-name\"}}",
         "Check that a worker is running for the specified task queue",
         "Contact administrator to verify testing service setup"
+      ]
+    },
+    "EXT_006": {
+      "code": "EXT_006",
+      "http_status": 503,
+      "category": "external_service",
+      "severity": "error",
+      "title": "Service Unavailable",
+      "message": {
+        "plain": "An external service is temporarily unavailable.",
+        "markdown": "**Service Unavailable**\n\nAn external service is temporarily unavailable. Please try again later.",
+        "html": "<strong>Service Unavailable</strong><p>An external service is temporarily unavailable. Please try again later.</p>"
+      },
+      "retry_after": 60,
+      "documentation_url": null,
+      "internal_description": "Generic 503 fallback when the specific upstream service is unknown or not yet categorised; prefer EXT_001 (GitLab), EXT_003 (MinIO), EXT_004 (Temporal), or EXT_005 (task queue) when the source is known.",
+      "affected_functions": [],
+      "common_causes": [
+        "Generic upstream failure surfaced through Starlette's HTTPException",
+        "Service-specific exception subclass not yet introduced for this code path"
+      ],
+      "resolution_steps": [
+        "Inspect server logs for the underlying cause",
+        "Retry the request after a short backoff"
       ]
     },
     "DB_001": {

--- a/computor-web/src/generated/errors/error-catalog.vscode.json
+++ b/computor-web/src/generated/errors/error-catalog.vscode.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-01T19:35:09.629600",
-  "error_count": 66,
+  "generated_at": "2026-05-05T23:44:23.383979",
+  "error_count": 70,
   "errors": {
     "AUTH_001": {
       "code": "AUTH_001",
@@ -52,6 +52,19 @@
         "plain": "Single Sign-On authentication failed. Please try again or contact support.",
         "markdown": "**SSO Authentication Failed**\n\nSingle Sign-On authentication failed. Please try again or contact support if the problem persists.",
         "html": "<strong>SSO Authentication Failed</strong><p>Single Sign-On authentication failed. Please try again or contact support if the problem persists.</p>"
+      },
+      "retry_after": null
+    },
+    "AUTH_005": {
+      "code": "AUTH_005",
+      "http_status": 401,
+      "category": "authentication",
+      "severity": "warning",
+      "title": "API Token Expired",
+      "message": {
+        "plain": "Your API token has expired. Generate a new one and retry.",
+        "markdown": "**API Token Expired**\n\nThe API token used for this request has expired. Generate a new token and retry.",
+        "html": "<strong>API Token Expired</strong><p>The API token used for this request has expired. Generate a new token and retry.</p>"
       },
       "retry_after": null
     },
@@ -117,6 +130,19 @@
         "plain": "You cannot assign a role higher than your own.",
         "markdown": "**Role Escalation Denied**\n\nYou cannot assign the role '{target_role}'. Your role '{user_role}' can only assign roles at or below your privilege level.",
         "html": "<strong>Role Escalation Denied</strong><p>You cannot assign the role <code>{target_role}</code>. Your role <code>{user_role}</code> can only assign roles at or below your privilege level.</p>"
+      },
+      "retry_after": null
+    },
+    "AUTHZ_010": {
+      "code": "AUTHZ_010",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "warning",
+      "title": "Service Account Required",
+      "message": {
+        "plain": "This endpoint is only available for service accounts.",
+        "markdown": "**Service Account Required**\n\nThis endpoint is only available for users marked as service accounts.",
+        "html": "<strong>Service Account Required</strong><p>This endpoint is only available for users marked as service accounts.</p>"
       },
       "retry_after": null
     },
@@ -221,6 +247,19 @@
         "plain": "The requested API endpoint does not exist.",
         "markdown": "**Endpoint Not Found**\n\nThe requested API endpoint does not exist. Please check the URL and API version.",
         "html": "<strong>Endpoint Not Found</strong><p>The requested API endpoint does not exist. Please check the URL and API version.</p>"
+      },
+      "retry_after": null
+    },
+    "NF_010": {
+      "code": "NF_010",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "warning",
+      "title": "Service Record Not Found",
+      "message": {
+        "plain": "No service record exists for this service account.",
+        "markdown": "**Service Record Not Found**\n\nThe service-account user has no associated ``Service`` row. The account exists but is not linked to a service definition.",
+        "html": "<strong>Service Record Not Found</strong><p>The service-account user has no associated <code>Service</code> row. The account exists but is not linked to a service definition.</p>"
       },
       "retry_after": null
     },
@@ -782,6 +821,19 @@
         "html": "<strong>Task Queue Unavailable</strong><p>No worker is available to process tasks on the specified queue. The testing service may be misconfigured or the worker is not running.</p>"
       },
       "retry_after": 120
+    },
+    "EXT_006": {
+      "code": "EXT_006",
+      "http_status": 503,
+      "category": "external_service",
+      "severity": "error",
+      "title": "Service Unavailable",
+      "message": {
+        "plain": "An external service is temporarily unavailable.",
+        "markdown": "**Service Unavailable**\n\nAn external service is temporarily unavailable. Please try again later.",
+        "html": "<strong>Service Unavailable</strong><p>An external service is temporarily unavailable. Please try again later.</p>"
+      },
+      "retry_after": 60
     },
     "DB_001": {
       "code": "DB_001",

--- a/computor-web/src/generated/types/courses.ts
+++ b/computor-web/src/generated/types/courses.ts
@@ -314,7 +314,6 @@ export interface CourseContentCreate {
   max_group_size?: number | null;
   max_test_runs?: number | null;
   max_submissions?: number | null;
-  testing_service_id?: string | null;
 }
 
 /**
@@ -389,7 +388,6 @@ export interface CourseContentUpdate {
   max_group_size?: number | null;
   max_test_runs?: number | null;
   max_submissions?: number | null;
-  testing_service_id?: string | null;
 }
 
 /**

--- a/computor-web/src/generated/types/error-codes.ts
+++ b/computor-web/src/generated/types/error-codes.ts
@@ -2,7 +2,7 @@
  * Auto-generated error code definitions
  *
  * DO NOT EDIT MANUALLY
- * Generated at: 2026-05-01T19:35:09.625964
+ * Generated at: 2026-05-05T23:44:23.380712
  *
  * To regenerate: bash generate_error_codes.sh
  */
@@ -65,11 +65,13 @@ export const ErrorCodes = {
   AUTH_002: "AUTH_002", // Invalid Credentials
   AUTH_003: "AUTH_003", // Token Expired
   AUTH_004: "AUTH_004", // SSO Authentication Failed
+  AUTH_005: "AUTH_005", // API Token Expired
   AUTHZ_001: "AUTHZ_001", // Insufficient Permissions
   AUTHZ_002: "AUTHZ_002", // Admin Access Required
   AUTHZ_003: "AUTHZ_003", // Course Access Denied
   AUTHZ_004: "AUTHZ_004", // Insufficient Course Role
   AUTHZ_005: "AUTHZ_005", // Role Escalation Denied
+  AUTHZ_010: "AUTHZ_010", // Service Account Required
   VAL_001: "VAL_001", // Invalid Request Data
   VAL_002: "VAL_002", // Missing Required Field
   VAL_003: "VAL_003", // Invalid Field Format
@@ -78,6 +80,7 @@ export const ErrorCodes = {
   NF_002: "NF_002", // User Not Found
   NF_003: "NF_003", // Course Not Found
   NF_004: "NF_004", // Endpoint Not Found
+  NF_010: "NF_010", // Service Record Not Found
   CONFLICT_001: "CONFLICT_001", // Resource Already Exists
   CONFLICT_002: "CONFLICT_002", // Concurrent Modification
   RATE_001: "RATE_001", // Rate Limit Exceeded
@@ -121,6 +124,7 @@ export const ErrorCodes = {
   EXT_003: "EXT_003", // MinIO Service Unavailable
   EXT_004: "EXT_004", // Temporal Service Unavailable
   EXT_005: "EXT_005", // Task Queue Unavailable
+  EXT_006: "EXT_006", // Service Unavailable
   DB_001: "DB_001", // Database Connection Failed
   DB_002: "DB_002", // Database Query Failed
   DB_003: "DB_003", // Transaction Failed
@@ -207,6 +211,20 @@ export const ERROR_DEFINITIONS: Record<string, ErrorDefinition> = {
     retryAfter: undefined,
     documentationUrl: "/docs/authentication#sso",
   },
+  AUTH_005: {
+    code: "AUTH_005",
+    httpStatus: 401,
+    category: ErrorCategory.AUTHENTICATION,
+    severity: ErrorSeverity.WARNING,
+    title: "API Token Expired",
+    message: {
+      plain: "Your API token has expired. Generate a new one and retry.",
+      markdown: "**API Token Expired**\n\nThe API token used for this request has expired. Generate a new token and retry.",
+      html: "<strong>API Token Expired</strong><p>The API token used for this request has expired. Generate a new token and retry.</p>",
+    },
+    retryAfter: undefined,
+    documentationUrl: "/docs/authentication#api-tokens",
+  },
   AUTHZ_001: {
     code: "AUTHZ_001",
     httpStatus: 403,
@@ -276,6 +294,20 @@ export const ERROR_DEFINITIONS: Record<string, ErrorDefinition> = {
     },
     retryAfter: undefined,
     documentationUrl: "/docs/permissions#role-assignment",
+  },
+  AUTHZ_010: {
+    code: "AUTHZ_010",
+    httpStatus: 403,
+    category: ErrorCategory.AUTHORIZATION,
+    severity: ErrorSeverity.WARNING,
+    title: "Service Account Required",
+    message: {
+      plain: "This endpoint is only available for service accounts.",
+      markdown: "**Service Account Required**\n\nThis endpoint is only available for users marked as service accounts.",
+      html: "<strong>Service Account Required</strong><p>This endpoint is only available for users marked as service accounts.</p>",
+    },
+    retryAfter: undefined,
+    documentationUrl: "/docs/authentication#service-accounts",
   },
   VAL_001: {
     code: "VAL_001",
@@ -388,6 +420,20 @@ export const ERROR_DEFINITIONS: Record<string, ErrorDefinition> = {
     },
     retryAfter: undefined,
     documentationUrl: "/docs/api",
+  },
+  NF_010: {
+    code: "NF_010",
+    httpStatus: 404,
+    category: ErrorCategory.NOT_FOUND,
+    severity: ErrorSeverity.WARNING,
+    title: "Service Record Not Found",
+    message: {
+      plain: "No service record exists for this service account.",
+      markdown: "**Service Record Not Found**\n\nThe service-account user has no associated ``Service`` row. The account exists but is not linked to a service definition.",
+      html: "<strong>Service Record Not Found</strong><p>The service-account user has no associated <code>Service</code> row. The account exists but is not linked to a service definition.</p>",
+    },
+    retryAfter: undefined,
+    documentationUrl: "/docs/services",
   },
   CONFLICT_001: {
     code: "CONFLICT_001",
@@ -990,6 +1036,20 @@ export const ERROR_DEFINITIONS: Record<string, ErrorDefinition> = {
     },
     retryAfter: 120,
     documentationUrl: "/docs/testing-services",
+  },
+  EXT_006: {
+    code: "EXT_006",
+    httpStatus: 503,
+    category: ErrorCategory.EXTERNAL_SERVICE,
+    severity: ErrorSeverity.ERROR,
+    title: "Service Unavailable",
+    message: {
+      plain: "An external service is temporarily unavailable.",
+      markdown: "**Service Unavailable**\n\nAn external service is temporarily unavailable. Please try again later.",
+      html: "<strong>Service Unavailable</strong><p>An external service is temporarily unavailable. Please try again later.</p>",
+    },
+    retryAfter: 60,
+    documentationUrl: undefined,
   },
   DB_001: {
     code: "DB_001",

--- a/computor-web/src/generated/types/examples.ts
+++ b/computor-web/src/generated/types/examples.ts
@@ -147,20 +147,27 @@ export interface ExampleUpdate {
 
 /**
  * Create a new example version.
+ * 
+ * Clients pass an already-parsed meta.yaml as ``meta`` — the server
+ * extracts the promoted scalar / array / FK columns from it and
+ * discards the rest. The full meta.yaml document lives in MinIO
+ * alongside the other example files; the download endpoint serves
+ * it from there.
  */
 export interface ExampleVersionCreate {
   example_id: string;
   version_tag: string;
   version_number: number;
   storage_path: string;
-  /** Content of meta.yaml */
-  meta_yaml: string;
-  /** Content of test.yaml */
-  test_yaml?: string | null;
+  /** Parsed meta.yaml — used to populate promoted columns */
+  meta: Record<string, any>;
 }
 
 /**
- * Get example version details.
+ * Get example version details — promoted columns only.
+ * 
+ * The full parsed meta.yaml / test.yaml documents are not returned
+ * here; call ``GET /examples/download/{version_id}`` for those.
  */
 export interface ExampleVersionGet {
   created_at: string;
@@ -173,8 +180,18 @@ export interface ExampleVersionGet {
   version_tag: string;
   version_number: number;
   storage_path: string;
-  meta_yaml: string;
-  test_yaml?: string | null;
+  title?: string | null;
+  description?: string | null;
+  language?: string | null;
+  license?: string | null;
+  /** Full meta.yaml properties.executionBackend (slug + version + settings) */
+  execution_backend?: Record<string, any> | null;
+  student_submission_files?: string[];
+  additional_files?: string[];
+  student_templates?: string[];
+  test_files?: string[];
+  /** Resolved Service.id derived from properties.executionBackend.slug */
+  testing_service_id?: string | null;
 }
 
 /**
@@ -184,6 +201,9 @@ export interface ExampleVersionList {
   id: string;
   version_tag: string;
   version_number: number;
+  title?: string | null;
+  description?: string | null;
+  testing_service_id?: string | null;
   created_at: string;
 }
 
@@ -286,10 +306,12 @@ export interface ExampleFileSet {
   directory: string;
   identifier: string;
   title: string;
-  /** Map of filename to content */
+  /** Map of filename to content (meta.yaml and test.yaml ride inside this dict) */
   files: Record<string, string>;
-  meta_yaml: string;
-  test_yaml?: string | null;
+  /** Parsed meta.yaml (fetched from MinIO with Redis cache) */
+  meta: Record<string, any>;
+  /** Parsed test.yaml (fetched from MinIO with Redis cache); None if absent */
+  test?: Record<string, any> | null;
 }
 
 /**
@@ -303,10 +325,12 @@ export interface ExampleDownloadResponse {
   identifier: string;
   /** Directory name of the example */
   directory: string;
-  /** Map of filename to content */
+  /** Map of filename to content (includes meta.yaml and test.yaml) */
   files: Record<string, string>;
-  meta_yaml: string;
-  test_yaml?: string | null;
+  /** Parsed meta.yaml (fetched from MinIO with Redis cache) */
+  meta: Record<string, any>;
+  /** Parsed test.yaml (fetched from MinIO with Redis cache); None if absent */
+  test?: Record<string, any> | null;
   /** Dependency examples when with_dependencies=True */
   dependencies?: ExampleFileSet[] | null;
 }


### PR DESCRIPTION
## Summary

- Replace ad-hoc `meta_yaml`/`test_yaml` text blobs on `example_version` with typed columns derived once at upload; raw documents live in MinIO.
- Resolve `properties.executionBackend.slug` → `Service.id` at upload, store as a real FK; assignment now copies the validated FK instead of running a silent best-effort lookup at every reassign.
- Tighten `course_content.testing_service_id` lifecycle and gate `Service` archive/disable when dependents exist.

Closes audit gaps **G1, G2, G6–G15** from the cleanup pass. Issue [#133](https://github.com/computor-org/computor-fullstack/issues/133) tracks the deferred `CourseContentGet.example_version_id` shim removal.

## Migrations (apply in order)

| Revision | What it does |
|---|---|
| `f1c2d3e4a5b6` | Add `example_version.testing_service_id` (UUID FK to `service.id`, ON DELETE RESTRICT) + Python backfill that parses each existing `meta_yaml` and resolves the slug. Logs match / no-slug / unresolved counts via `RAISE NOTICE`. |
| `c4d5e6f7a8b9` | Add typed scalar/array columns (`title`, `description`, `language`, `license`, `execution_backend` JSONB, four `TEXT[]` file-list columns); backfill from `meta_yaml`; drop `meta_yaml`. |
| `d5e6f7a8b9c0` | Drop `meta` JSONB and `test_yaml` text — yaml documents already live in MinIO at `{storage_path}/{filename}`; the download endpoint reads them with a Redis cache (7-day TTL, invalidated on re-upload). |

## Schema delta on `example_version`

```
+ testing_service_id (UUID FK -> service.id, ON DELETE RESTRICT)
+ title, description, language, license
+ execution_backend (JSONB: full meta.yaml executionBackend block)
+ student_submission_files, additional_files,
  student_templates, test_files (TEXT[])
- meta_yaml, meta, test_yaml
```

## Behavior changes

- **Upload validation.** `_resolve_testing_service_id` runs at example-version upload and raises `BadRequestException` with `EXAMPLE_VERSION_NO_BACKEND` / `EXAMPLE_VERSION_UNKNOWN_BACKEND` when meta.yaml lacks `executionBackend.slug` or the slug doesn't resolve to an enabled, non-archived `Service`.
- **Assignment is a copy.** `assign_example_to_content` → `_link_testing_service` copies `example_version.testing_service_id` onto the course content. Legacy fallback (for rows whose backfill couldn't resolve) still runs and self-heals by writing the FK back onto the `example_version`.
- **`course_content.testing_service_id` is no longer a client-settable field** on `CourseContentCreate` / `CourseContentUpdate` (G11/G12).
- **Unassign clears the cached link** so it doesn't outlive the assignment (G13).
- **Service archive / disable returns 409** (`SERVICE_HAS_DEPENDENTS`) when course contents or example versions still reference the service. Pass `?force=true` to override after acknowledging the affected IDs in the error context.
- **Download endpoint** serves meta.yaml/test.yaml from MinIO via a Redis-backed helper. `GET /examples/versions/{id}` returns promoted columns only — clients that need the full document call `GET /examples/download/{version_id}`.

## Wire format (W2)

DTO changes are safe at runtime for the VS Code extension and web frontend — both verified to never read `meta_yaml`/`test_yaml`/`testing_service_id` at runtime; only generated TS types reference them, and those are regenerated in this PR.

- `ExampleVersionCreate.meta_yaml: str` → `meta: dict` (parsed dict input).
- `ExampleVersionGet`: drops `meta_yaml`/`test_yaml`; exposes promoted columns + `testing_service_id`.
- `ExampleDownloadResponse` / `ExampleFileSet`: drop `test_yaml`; add `test: Optional[dict]`. `meta` is now a parsed dict (was a yaml string).
- `CourseContentCreate` / `CourseContentUpdate`: drop `testing_service_id`.
- `ServicesClient` (TS): adds `force?: boolean` query param on `PATCH` and `DELETE`.
- New error codes: `EXAMPLE_VERSION_NO_BACKEND`, `EXAMPLE_VERSION_UNKNOWN_BACKEND`, `SERVICE_HAS_DEPENDENTS`.

## What's still on the table (deferred)

| Gap | Status |
|---|---|
| G3 — DB-level CHECK enforcing "deployment exists ⟹ cc.testing_service_id IS NOT NULL" | Defense-in-depth, not blocking |
| G4 / G17 — explicit `testing_service_override_id` for manual lecturer overrides | Defer until a real use case lands |
| G5 — `Service.slug` rename safety | Already `unique=True`; renames still desync new uploads |
| G9 — different versions declaring different slugs | Current behavior intentional, undocumented |
| G18 | Filed as #133 (paired backend+extension PR) |
| G19 — verify `Result.testing_service_id` is a snapshot | Worth a quick verify before/after merge |
| G20 — admin observability for orphaned content | Author noted manual prod fix, deferred |
| G21 — promote WARNING to audit-trail entry | Cosmetic |
| G22 — docs page explaining the derivation contract | Deferred |
| G23 — tests for the new failure paths | Deferred |

## Test plan

- [ ] Apply all three migrations against a dev database; verify the `RAISE NOTICE` backfill counts make sense.
- [ ] Upload an example with a valid `executionBackend.slug` → expect `testing_service_id` populated, promoted columns set.
- [ ] Upload an example without `executionBackend` → expect 400 `EXAMPLE_VERSION_NO_BACKEND`.
- [ ] Upload an example with a slug that doesn't match any enabled `Service` → expect 400 `EXAMPLE_VERSION_UNKNOWN_BACKEND`.
- [ ] Assign / unassign / reassign example to course content; verify `course_content.testing_service_id` tracks through the lifecycle (set on assign, cleared on unassign).
- [ ] Try `DELETE /service-accounts/{id}` for a service with dependents → expect 409 with `course_content_count` / `example_version_count` in the error context.
- [ ] Repeat with `?force=true` → expect 204.
- [ ] Try `PATCH /service-accounts/{id}` with `enabled: false` for a service with dependents → expect 409.
- [ ] `GET /examples/download/{version_id}` returns `meta` / `test` parsed from MinIO; cache hit on second call (check Redis or logs).
- [ ] VS Code extension: open submission groups, view course contents, run tests — confirm runtime works against the new DTOs even before extension types regen.
- [ ] Pre-existing test collection failures (`test_course_member_import.py`, `test_models.py`) are not touched by this PR; flagged separately.

## Operational notes

- VS Code extension's generated types at `/home/theta/computor/computor-vsc-extension/src/types/generated/` need a follow-up regen in that repo. Runtime is unaffected; this is type-checker hygiene.
- `bash generate.sh` was run; web client + types + error catalogs updated and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)