### PR TITLE
fix(setup-env): plug prod-config gaps + drop dead PYTHON_TEST_VERSION

### DIFF
--- a/docker/temporal-worker-testing/README.md
+++ b/docker/temporal-worker-testing/README.md
@@ -12,23 +12,22 @@ Handles test execution for multiple programming languages:
    - Runs computor-testing framework CLI
    - Manages test orchestration
 
-2. **Test Execution Environment** (Configurable, default: Python 3.13)
+2. **Test Execution Environment** (Python 3.13, fixed at build time)
    - Runs actual student code
    - Has scientific/testing dependencies (numpy, scipy, matplotlib, etc.)
    - Isolated venv at `/home/worker/test-venv`
+   - Python version is baked into the worker [Dockerfile](Dockerfile); to change
+     it, edit the Dockerfile and rebuild — there is no runtime knob.
 
 ## Configuration
 
-### Python Test Environment
+### Test Execution Environment
 
-Configure via environment variables in `.env` or `docker-compose-dev.yaml`:
+Configure via environment variable in `.env` or the docker-compose file:
 
 ```bash
-# Python version for test execution (e.g., 3.13, 3.12, 3.11)
-PYTHON_TEST_VERSION=3.13
-
-# Additional Python packages (comma-separated)
-# Example: pandas,scikit-learn,requests,beautifulsoup4
+# Additional Python packages installed into the test venv at worker startup
+# (comma-separated). Example: pandas,scikit-learn,requests,beautifulsoup4
 PYTHON_TEST_REQUIREMENTS=
 ```
 
@@ -88,16 +87,8 @@ docker exec -u worker computor-fullstack-temporal-worker-testing-1 \
   /home/worker/test-venv/bin/python -c "import numpy; print(numpy.__version__)"
 ```
 
-### Adding More Python Versions
+### Changing the Test Python Version
 
-Edit Dockerfile to install additional Python versions:
-```dockerfile
-RUN wget https://www.python.org/ftp/python/3.12.X/Python-3.12.X.tgz && \
-    tar -xzf Python-3.12.X.tgz && \
-    cd Python-3.12.X && \
-    ./configure --prefix=/usr/local/python3.12 && \
-    make -j$(nproc) && \
-    make altinstall
-```
-
-Then set `PYTHON_TEST_VERSION=3.12` in environment.
+The test Python version is hard-coded in the [Dockerfile](Dockerfile) (see the
+`Python-3.13.1.tgz` download). To change it: update the URL/version in the
+Dockerfile, rebuild the worker image, and rebuild the pre-built test venv.

--- a/ops/docker/docker-compose.dev.yaml
+++ b/ops/docker/docker-compose.dev.yaml
@@ -99,8 +99,9 @@ services:
       - API_TOKEN=${TESTING_WORKER_TOKEN}
       # Default testing configuration (can be overridden by service.config)
       - TESTING_EXECUTABLE=computor-test
-      # Python test execution environment
-      - PYTHON_TEST_VERSION=${PYTHON_TEST_VERSION:-3.13}
+      # Extra pip packages installed into the test venv at worker startup
+      # (see docker/temporal-worker-testing/testing-worker.py).
+      # The Python version itself is fixed in the worker Dockerfile.
       - PYTHON_TEST_REQUIREMENTS=${PYTHON_TEST_REQUIREMENTS:-}
       # R configuration
       - R_LIBS_USER=/home/worker/.local/lib/R/library

--- a/ops/docker/docker-compose.prod.yaml
+++ b/ops/docker/docker-compose.prod.yaml
@@ -133,7 +133,8 @@ services:
       - TEMPORAL_NAMESPACE=default
       - API_URL=${API_URL}
       - API_TOKEN=${TESTING_WORKER_TOKEN}
-      - PYTHON_TEST_VERSION=${PYTHON_TEST_VERSION:-3.13}
+      # Python version is baked into the worker Dockerfile; only the extra
+      # pip packages are runtime-configurable.
       - PYTHON_TEST_REQUIREMENTS=${PYTHON_TEST_REQUIREMENTS:-}
       - R_LIBS_USER=/home/worker/.local/lib/R/library
     depends_on:

--- a/ops/environments/.env.common.template
+++ b/ops/environments/.env.common.template
@@ -128,6 +128,9 @@ CODER_ADMIN_PASSWORD=CHANGE_ME_CODER_PASSWORD
 # Admin API secret for Traefik-protected endpoints (generate with: openssl rand -hex 32)
 CODER_ADMIN_API_SECRET=CHANGE_ME_GENERATE_WITH_OPENSSL
 
+# External hostname for Coder (referenced by docs; set when running behind a real domain)
+CODER_DOMAIN=coder.localhost
+
 # Docker configuration (auto-detected by startup.sh if empty)
 DOCKER_GID=
 
@@ -144,6 +147,9 @@ CODER_TELEMETRY_ENABLE=false
 CODER_URL=http://localhost:7080
 # Traefik base URL for workspace access (code-server via /coder/{user}/{workspace}/)
 CODER_WORKSPACE_BASE_URL=http://localhost:8080/coder
+# URL Coder uses to call back into the backend in production (empty in dev — defaults
+# to http://host.docker.internal:8000 via BACKEND_EXTERNAL_URL_DEV in the compose file).
+BACKEND_EXTERNAL_URL_PROD=
 
 # ============================================
 # EXTENSION CONFIGURATION

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -35,8 +35,18 @@ fi
 echo -e "${GREEN}=== Computor Environment Setup ===${NC}"
 echo -e "This script creates a unified environment configuration.\n"
 
+# Check for --force across all args (not just $1, otherwise `setup-env.sh --auto --force`
+# wouldn't suppress this warning).
+HAS_FORCE_ARG=false
+for arg in "$@"; do
+    if [ "$arg" = "--force" ]; then
+        HAS_FORCE_ARG=true
+        break
+    fi
+done
+
 # Check for existing .env file
-if [ -f .env ] && [ "$1" != "--force" ]; then
+if [ -f .env ] && [ "$HAS_FORCE_ARG" != true ]; then
     echo -e "${YELLOW}⚠️  Warning: Existing .env file detected!${NC}"
     echo -e "This file will be backed up and replaced."
     echo -e "Your existing configuration will be preserved in a backup file.\n"
@@ -267,8 +277,16 @@ if [ "$SKIP_COMMON" != true ]; then
                 echo -e "  Generated password: ${YELLOW}$CODER_ADMIN_PASSWORD${NC}"
             fi
 
-            # Generate CODER_ADMIN_API_SECRET using same method as computor-coder/deployment/generate-secret.sh
-            CODER_API_SECRET=$(openssl rand -hex 32 2>/dev/null || generate_hex_token)
+            # Ask before generating CODER_ADMIN_API_SECRET (used by Traefik-protected
+            # endpoints; equivalent to ``openssl rand -hex 32``).
+            CODER_API_SECRET=""
+            read -r -p "Generate CODER_ADMIN_API_SECRET now via 'openssl rand -hex 32'? (Y/n): " gen_api_secret
+            if [ -z "$gen_api_secret" ] || [ "$gen_api_secret" = "y" ] || [ "$gen_api_secret" = "Y" ]; then
+                CODER_API_SECRET=$(openssl rand -hex 32 2>/dev/null || generate_hex_token)
+                echo -e "  ${GREEN}✓${NC} Generated CODER_ADMIN_API_SECRET"
+            else
+                echo -e "  ${YELLOW}Skipping CODER_ADMIN_API_SECRET — placeholder kept; fill it in manually.${NC}"
+            fi
 
             # Escape any pipe characters in user input for sed
             CODER_DOMAIN_ESCAPED=$(echo "$CODER_DOMAIN" | sed 's/|/\\|/g')
@@ -280,12 +298,19 @@ if [ "$SKIP_COMMON" != true ]; then
                 sed -i '' "s|CODER_DOMAIN=.*|CODER_DOMAIN=$CODER_DOMAIN_ESCAPED|" "$TARGET_FILE"
                 sed -i '' "s|CODER_ADMIN_EMAIL=.*|CODER_ADMIN_EMAIL=$CODER_ADMIN_EMAIL_ESCAPED|" "$TARGET_FILE"
                 sed -i '' "s|CODER_ADMIN_PASSWORD=.*|CODER_ADMIN_PASSWORD=$CODER_ADMIN_PASSWORD_ESCAPED|" "$TARGET_FILE"
-                sed -i '' "s|CODER_ADMIN_API_SECRET=.*|CODER_ADMIN_API_SECRET=$CODER_API_SECRET|" "$TARGET_FILE"
             else
                 sed -i "s|CODER_DOMAIN=.*|CODER_DOMAIN=$CODER_DOMAIN_ESCAPED|" "$TARGET_FILE"
                 sed -i "s|CODER_ADMIN_EMAIL=.*|CODER_ADMIN_EMAIL=$CODER_ADMIN_EMAIL_ESCAPED|" "$TARGET_FILE"
                 sed -i "s|CODER_ADMIN_PASSWORD=.*|CODER_ADMIN_PASSWORD=$CODER_ADMIN_PASSWORD_ESCAPED|" "$TARGET_FILE"
-                sed -i "s|CODER_ADMIN_API_SECRET=.*|CODER_ADMIN_API_SECRET=$CODER_API_SECRET|" "$TARGET_FILE"
+            fi
+            # Only overwrite the CODER_ADMIN_API_SECRET line when the user said yes
+            # to generation; otherwise leave the placeholder intact.
+            if [ -n "$CODER_API_SECRET" ]; then
+                if [[ "$OSTYPE" == "darwin"* ]]; then
+                    sed -i '' "s|CODER_ADMIN_API_SECRET=.*|CODER_ADMIN_API_SECRET=$CODER_API_SECRET|" "$TARGET_FILE"
+                else
+                    sed -i "s|CODER_ADMIN_API_SECRET=.*|CODER_ADMIN_API_SECRET=$CODER_API_SECRET|" "$TARGET_FILE"
+                fi
             fi
         else
             # Auto mode - generate Coder credentials


### PR DESCRIPTION
## Summary

Audit of \`setup-env.sh\` against \`docker-compose.{base,prod,coder,web}.yaml\` revealed config gaps and dead env vars. This PR closes them.

### Template additions (\`ops/environments/.env.common.template\`)
- \`CODER_DOMAIN\` — script previously prompted for it but the template had no line, so \`sed\` silently dropped the user's input.
- \`BACKEND_EXTERNAL_URL_PROD\` — needed by Coder to call the backend in production; was relying on an empty fallback.

### Dead-code removal
- \`PYTHON_TEST_VERSION\` — set by both compose files but **never read**. The testing-worker Dockerfile hard-codes Python 3.13.1; no \`os.getenv("PYTHON_TEST_VERSION")\` anywhere. Removed from both compose files and the misleading README.

### \`setup-env.sh\` fixes
- Asks before generating \`CODER_ADMIN_API_SECRET\` via \`openssl rand -hex 32\` (placeholder kept on decline).
- \`--force\` now works regardless of arg position (previously only checked \`\$1\`, so \`--auto --force\` didn't suppress the warning).

## Test plan
- [x] \`bash -n setup-env.sh\` — syntax OK
- [x] Sandbox \`./setup-env.sh --auto --force\` run — generates a valid \`.env.common\`
- [x] Verified \`CODER_DOMAIN\` and \`BACKEND_EXTERNAL_URL_PROD\` land in the generated file
- [ ] Spot-check that prod stack still boots after pulling these changes