### PR TITLE
feat(documents): files & directories API with scoped RBAC

### DIFF
--- a/computor-backend/src/computor_backend/api/documents.py
+++ b/computor-backend/src/computor_backend/api/documents.py
@@ -1,23 +1,40 @@
-"""Documents API — write side.
+"""Documents API.
 
-Read access is served by the ``static-server`` container at ``/docs``;
-this router only handles writes (file upload, file delete, mkdir,
-rmdir). Each request carries its scope (system, organization,
-course_family, course) and the relative path inside that scope's
-documents area.
+Public read access is served by the ``static-server`` container at
+``/docs``. This router covers writes (file upload, file delete, mkdir,
+rmdir, rename) plus authenticated GETs (list a directory, fetch a
+file) for callers that already hold a session — VS Code extension,
+admin scripts, etc. Each request carries its scope (system,
+organization, course_family, course) and the relative path inside
+that scope's documents area.
 """
 import logging
+import os
 import shutil
+from datetime import datetime, timezone
+from email.utils import formatdate
 from typing import Annotated, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, UploadFile, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    Header,
+    Query,
+    Response,
+    UploadFile,
+    status,
+)
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from computor_backend.business_logic.documents import (
     check_documents_write_permission,
     check_reserved_name_collision,
     resolve_absolute_path,
+    resolve_listing_target,
     resolve_scope_root,
     validate_relative_path,
     DocumentScope,
@@ -37,7 +54,10 @@ from computor_types.documents import (
     DocumentDirectoryCreate,
     DocumentDirectoryDelete,
     DocumentDirectoryGet,
+    DocumentDirectoryRename,
     DocumentGet,
+    DocumentList,
+    DocumentRename,
 )
 
 
@@ -48,6 +68,40 @@ documents_router = APIRouter(prefix="/documents", tags=["documents"])
 _UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MiB — read in chunks so a malicious
                                   # client can't OOM us with a huge body
                                   # before we hit the configured limit.
+
+
+def _stat_etag(stat: os.stat_result) -> str:
+    """Quoted ETag derived from mtime+size.
+
+    Same format Starlette's ``FileResponse`` uses by default, so the
+    values returned by the listing endpoint match the ``ETag`` header
+    the file GET endpoint emits — clients can compare without
+    normalizing.
+    """
+    return f'"{stat.st_mtime}-{stat.st_size}"'
+
+
+def _if_none_match_hits(header: str, etag: str) -> bool:
+    """Compare a client's ``If-None-Match`` header against ``etag``.
+
+    Accepts a comma-separated list and the wildcard ``*``; ``W/``
+    weak prefixes on either side are stripped before comparison so a
+    client that re-quotes the etag as weak still matches.
+    """
+    def normalize(s: str) -> str:
+        s = s.strip()
+        if s.startswith("W/"):
+            s = s[2:]
+        return s
+
+    target = normalize(etag)
+    for raw in header.split(","):
+        candidate = raw.strip()
+        if candidate == "*":
+            return True
+        if normalize(candidate) == target:
+            return True
+    return False
 
 
 async def _read_upload_with_limit(file: UploadFile, max_bytes: int) -> bytes:
@@ -236,4 +290,235 @@ async def delete_document_directory(
     logger.info(
         "Deleted documents directory %s (scope=%s scope_id=%s)",
         payload.path, payload.scope, payload.scope_id,
+    )
+
+
+@documents_router.patch("/files", response_model=DocumentGet)
+async def rename_document_file(
+    payload: DocumentRename,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> DocumentGet:
+    """Rename a documents file inside the same scope.
+
+    Source must exist and be a file; target must not exist. Both
+    paths are validated. Atomic on the same filesystem (which is
+    always true for ``DOCUMENTS_ROOT``).
+    """
+    check_documents_write_permission(permissions, payload.scope, payload.scope_id)
+    src_segments = validate_relative_path(payload.path)
+    dst_segments = validate_relative_path(payload.new_path)
+    check_reserved_name_collision(payload.scope, payload.scope_id, src_segments[0], db)
+    check_reserved_name_collision(payload.scope, payload.scope_id, dst_segments[0], db)
+
+    scope_root = resolve_scope_root(payload.scope, payload.scope_id, db)
+    src = resolve_absolute_path(scope_root, src_segments)
+    dst = resolve_absolute_path(scope_root, dst_segments)
+
+    if src == dst:
+        raise BadRequestException(
+            detail="Source and target paths are identical",
+            context={"path": payload.path},
+        )
+    if not src.exists():
+        raise NotFoundException(
+            detail="File not found", context={"path": payload.path}
+        )
+    if not src.is_file():
+        raise ConflictException(
+            detail="Source is not a file; use the directory endpoint",
+            context={"path": payload.path},
+        )
+    if dst.exists():
+        raise ConflictException(
+            detail="Target path already exists",
+            context={"path": payload.new_path},
+        )
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src.replace(dst)
+
+    stat = dst.stat()
+    logger.info(
+        "Renamed documents file %s -> %s (scope=%s scope_id=%s)",
+        payload.path, payload.new_path, payload.scope, payload.scope_id,
+    )
+    return DocumentGet(
+        scope=payload.scope,
+        scope_id=payload.scope_id,
+        path=payload.new_path,
+        size=stat.st_size,
+        content_type=None,
+    )
+
+
+@documents_router.patch("/directories", response_model=DocumentDirectoryGet)
+async def rename_document_directory(
+    payload: DocumentDirectoryRename,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> DocumentDirectoryGet:
+    """Rename a documents directory inside the same scope.
+
+    Source must exist and be a directory; target must not exist;
+    target must not lie inside the source (no moving a dir into
+    itself). ``created`` in the response is always ``False`` — the
+    directory was moved, not freshly created.
+    """
+    check_documents_write_permission(permissions, payload.scope, payload.scope_id)
+    src_segments = validate_relative_path(payload.path)
+    dst_segments = validate_relative_path(payload.new_path)
+    check_reserved_name_collision(payload.scope, payload.scope_id, src_segments[0], db)
+    check_reserved_name_collision(payload.scope, payload.scope_id, dst_segments[0], db)
+
+    scope_root = resolve_scope_root(payload.scope, payload.scope_id, db)
+    src = resolve_absolute_path(scope_root, src_segments)
+    dst = resolve_absolute_path(scope_root, dst_segments)
+
+    if src == dst:
+        raise BadRequestException(
+            detail="Source and target paths are identical",
+            context={"path": payload.path},
+        )
+    if dst.is_relative_to(src):
+        raise BadRequestException(
+            detail="Cannot move a directory into itself",
+            context={"path": payload.path, "new_path": payload.new_path},
+        )
+    if not src.exists():
+        raise NotFoundException(
+            detail="Directory not found", context={"path": payload.path}
+        )
+    if not src.is_dir():
+        raise ConflictException(
+            detail="Source is not a directory; use the file endpoint",
+            context={"path": payload.path},
+        )
+    if dst.exists():
+        raise ConflictException(
+            detail="Target path already exists",
+            context={"path": payload.new_path},
+        )
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src.replace(dst)
+
+    logger.info(
+        "Renamed documents directory %s -> %s (scope=%s scope_id=%s)",
+        payload.path, payload.new_path, payload.scope, payload.scope_id,
+    )
+    return DocumentDirectoryGet(
+        scope=payload.scope,
+        scope_id=payload.scope_id,
+        path=payload.new_path,
+        created=False,
+    )
+
+
+@documents_router.get("/list", response_model=list[DocumentList])
+async def list_documents_directory(
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    scope: Annotated[DocumentScope, Query()],
+    scope_id: Annotated[Optional[UUID], Query()] = None,
+    path: Annotated[Optional[str], Query()] = None,
+    db: Session = Depends(get_db),
+) -> list[DocumentList]:
+    """List entries in a documents directory.
+
+    Available to any authenticated user. An unwritten scope root
+    returns an empty list (so a fresh course/family/org does not 404);
+    a missing non-root path is a 404.
+    """
+    target = resolve_listing_target(scope, scope_id, path, db)
+
+    if not target.exists():
+        if not path:
+            return []
+        raise NotFoundException(
+            detail="Directory not found", context={"path": path}
+        )
+    if not target.is_dir():
+        raise ConflictException(
+            detail="Target is not a directory", context={"path": path}
+        )
+
+    entries: list[DocumentList] = []
+    for child in sorted(target.iterdir(), key=lambda p: p.name):
+        # Skip symlinks (and broken ones) — writes refuse to create
+        # them, and following them would defeat the scope-root
+        # containment guarantee from resolve_absolute_path.
+        if child.is_symlink():
+            continue
+        try:
+            stat = child.stat()
+        except OSError:
+            continue
+        last_modified = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+        etag = _stat_etag(stat)
+        if child.is_dir():
+            entries.append(
+                DocumentList(
+                    name=child.name,
+                    type="directory",
+                    etag=etag,
+                    last_modified=last_modified,
+                )
+            )
+        elif child.is_file():
+            entries.append(
+                DocumentList(
+                    name=child.name,
+                    type="file",
+                    size=stat.st_size,
+                    etag=etag,
+                    last_modified=last_modified,
+                )
+            )
+
+    return entries
+
+
+@documents_router.get("/files", response_class=FileResponse)
+async def get_document_file(
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    scope: Annotated[DocumentScope, Query()],
+    path: Annotated[str, Query()],
+    scope_id: Annotated[Optional[UUID], Query()] = None,
+    if_none_match: Annotated[Optional[str], Header(alias="if-none-match")] = None,
+    db: Session = Depends(get_db),
+) -> Response:
+    """Fetch a documents file. Available to any authenticated user.
+
+    The same content is reachable unauthenticated via the static-server
+    at ``/docs/<...>``; this endpoint serves authenticated callers
+    through the same auth chain they use for everything else.
+
+    Supports ``If-None-Match`` for cheap revalidation: when the
+    supplied ETag matches the current file, returns ``304 Not
+    Modified`` with the same ``ETag`` and ``Last-Modified`` headers
+    the 200 response would carry.
+    """
+    segments = validate_relative_path(path)
+    scope_root = resolve_scope_root(scope, scope_id, db)
+    target = resolve_absolute_path(scope_root, segments)
+
+    if not target.exists():
+        raise NotFoundException(detail="File not found", context={"path": path})
+    if not target.is_file():
+        raise ConflictException(
+            detail="Target is not a file", context={"path": path}
+        )
+
+    stat = target.stat()
+    etag = _stat_etag(stat)
+    last_modified = formatdate(stat.st_mtime, usegmt=True)
+    cache_headers = {"ETag": etag, "Last-Modified": last_modified}
+
+    if if_none_match and _if_none_match_hits(if_none_match, etag):
+        return Response(status_code=304, headers=cache_headers)
+
+    return FileResponse(
+        path=str(target),
+        filename=target.name,
+        headers=cache_headers,
     )

--- a/computor-backend/src/computor_backend/api/documents.py
+++ b/computor-backend/src/computor_backend/api/documents.py
@@ -1,0 +1,239 @@
+"""Documents API — write side.
+
+Read access is served by the ``static-server`` container at ``/docs``;
+this router only handles writes (file upload, file delete, mkdir,
+rmdir). Each request carries its scope (system, organization,
+course_family, course) and the relative path inside that scope's
+documents area.
+"""
+import logging
+import shutil
+from typing import Annotated, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile, status
+from sqlalchemy.orm import Session
+
+from computor_backend.business_logic.documents import (
+    check_documents_write_permission,
+    check_reserved_name_collision,
+    resolve_absolute_path,
+    resolve_scope_root,
+    validate_relative_path,
+    DocumentScope,
+)
+from computor_backend.database import get_db
+from computor_backend.exceptions import (
+    BadRequestException,
+    ConflictException,
+    NotFoundException,
+)
+from computor_backend.permissions.auth import get_current_principal
+from computor_backend.permissions.principal import Principal
+from computor_backend.settings import settings
+from computor_types.documents import (
+    DocumentCreate,
+    DocumentDelete,
+    DocumentDirectoryCreate,
+    DocumentDirectoryDelete,
+    DocumentDirectoryGet,
+    DocumentGet,
+)
+
+
+logger = logging.getLogger(__name__)
+documents_router = APIRouter(prefix="/documents", tags=["documents"])
+
+
+_UPLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MiB — read in chunks so a malicious
+                                  # client can't OOM us with a huge body
+                                  # before we hit the configured limit.
+
+
+async def _read_upload_with_limit(file: UploadFile, max_bytes: int) -> bytes:
+    """Read an ``UploadFile`` in chunks, aborting if it exceeds ``max_bytes``.
+
+    Reading in chunks avoids buffering an unbounded amount in memory if a
+    client lies about the body size (or doesn't set Content-Length).
+    """
+    parts: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await file.read(_UPLOAD_CHUNK_SIZE)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise BadRequestException(
+                detail=f"File exceeds the {max_bytes}-byte limit",
+                context={"limit": max_bytes},
+            )
+        parts.append(chunk)
+    return b"".join(parts)
+
+
+@documents_router.post(
+    "/files",
+    response_model=DocumentGet,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_document_file(
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    scope: Annotated[DocumentScope, Form()],
+    path: Annotated[str, Form()],
+    file: Annotated[UploadFile, File()],
+    scope_id: Annotated[Optional[UUID], Form()] = None,
+    db: Session = Depends(get_db),
+) -> DocumentGet:
+    """Create or overwrite a documents file at the given scope and path."""
+    payload = DocumentCreate(scope=scope, scope_id=scope_id, path=path)
+
+    check_documents_write_permission(permissions, payload.scope, payload.scope_id)
+    segments = validate_relative_path(payload.path)
+    check_reserved_name_collision(payload.scope, payload.scope_id, segments[0], db)
+
+    scope_root = resolve_scope_root(payload.scope, payload.scope_id, db)
+    target = resolve_absolute_path(scope_root, segments)
+
+    if target.is_dir():
+        raise ConflictException(
+            detail="A directory exists at the target path",
+            context={"path": payload.path},
+        )
+
+    content = await _read_upload_with_limit(file, settings.DOCUMENTS_MAX_FILE_SIZE)
+
+    # Atomic write: write to a sibling tmp file then rename, so the
+    # static-server never sees half-written content.
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(target.name + ".tmp")
+    tmp.write_bytes(content)
+    tmp.replace(target)
+
+    logger.info(
+        "Uploaded document %s (scope=%s scope_id=%s size=%d)",
+        payload.path, payload.scope, payload.scope_id, len(content),
+    )
+
+    return DocumentGet(
+        scope=payload.scope,
+        scope_id=payload.scope_id,
+        path=payload.path,
+        size=len(content),
+        content_type=file.content_type,
+    )
+
+
+@documents_router.delete("/files", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_document_file(
+    payload: DocumentDelete,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete a documents file."""
+    check_documents_write_permission(permissions, payload.scope, payload.scope_id)
+    segments = validate_relative_path(payload.path)
+    check_reserved_name_collision(payload.scope, payload.scope_id, segments[0], db)
+
+    scope_root = resolve_scope_root(payload.scope, payload.scope_id, db)
+    target = resolve_absolute_path(scope_root, segments)
+
+    if not target.exists():
+        raise NotFoundException(
+            detail="File not found",
+            context={"path": payload.path},
+        )
+    if not target.is_file():
+        raise ConflictException(
+            detail="Target is not a file; use the directory endpoints",
+            context={"path": payload.path},
+        )
+
+    target.unlink()
+    logger.info(
+        "Deleted document %s (scope=%s scope_id=%s)",
+        payload.path, payload.scope, payload.scope_id,
+    )
+
+
+@documents_router.post(
+    "/directories",
+    response_model=DocumentDirectoryGet,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_document_directory(
+    payload: DocumentDirectoryCreate,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> DocumentDirectoryGet:
+    """Create a documents directory (idempotent — returns ``created=False``
+    when it already existed).
+    """
+    check_documents_write_permission(permissions, payload.scope, payload.scope_id)
+    segments = validate_relative_path(payload.path)
+    check_reserved_name_collision(payload.scope, payload.scope_id, segments[0], db)
+
+    scope_root = resolve_scope_root(payload.scope, payload.scope_id, db)
+    target = resolve_absolute_path(scope_root, segments)
+
+    if target.exists():
+        if target.is_dir():
+            return DocumentDirectoryGet(
+                scope=payload.scope,
+                scope_id=payload.scope_id,
+                path=payload.path,
+                created=False,
+            )
+        raise ConflictException(
+            detail="A file exists at the target path",
+            context={"path": payload.path},
+        )
+
+    target.mkdir(parents=True, exist_ok=False)
+    logger.info(
+        "Created documents directory %s (scope=%s scope_id=%s)",
+        payload.path, payload.scope, payload.scope_id,
+    )
+    return DocumentDirectoryGet(
+        scope=payload.scope,
+        scope_id=payload.scope_id,
+        path=payload.path,
+        created=True,
+    )
+
+
+@documents_router.delete("/directories", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_document_directory(
+    payload: DocumentDirectoryDelete,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete a documents directory recursively.
+
+    Refuses (409) when the leading segment matches an entity's path —
+    those directories are entity-bound and can only be removed via
+    entity deletion.
+    """
+    check_documents_write_permission(permissions, payload.scope, payload.scope_id)
+    segments = validate_relative_path(payload.path)
+    check_reserved_name_collision(payload.scope, payload.scope_id, segments[0], db)
+
+    scope_root = resolve_scope_root(payload.scope, payload.scope_id, db)
+    target = resolve_absolute_path(scope_root, segments)
+
+    if not target.exists():
+        raise NotFoundException(
+            detail="Directory not found",
+            context={"path": payload.path},
+        )
+    if not target.is_dir():
+        raise ConflictException(
+            detail="Target is not a directory; use the file endpoints",
+            context={"path": payload.path},
+        )
+
+    shutil.rmtree(target)
+    logger.info(
+        "Deleted documents directory %s (scope=%s scope_id=%s)",
+        payload.path, payload.scope, payload.scope_id,
+    )

--- a/computor-backend/src/computor_backend/business_logic/crud.py
+++ b/computor-backend/src/computor_backend/business_logic/crud.py
@@ -43,7 +43,7 @@ async def create_entity(
     entity: BaseModel,
     db_type: Any,
     response_type: BaseModel,
-    post_create: Optional[Callable] = None
+    post_create: Optional[Callable] = None,
 ) -> BaseModel:
     """
     Create a new database entity with permission checks and validation.

--- a/computor-backend/src/computor_backend/business_logic/documents.py
+++ b/computor-backend/src/computor_backend/business_logic/documents.py
@@ -137,6 +137,12 @@ def resolve_scope_root(
             context={"scope": scope},
         )
 
+    # SQLAlchemy + psycopg2's UUID bind processor calls ``uuid.UUID(value)``
+    # on the parameter, which fails if ``value`` is already a UUID instance.
+    # Coerce to str at the boundary so the rest of the function can pass
+    # ``scope_id`` straight into filters regardless of input type.
+    scope_id = str(scope_id)
+
     if scope == "organization":
         org = db.query(Organization).filter(Organization.id == scope_id).first()
         if org is None:
@@ -222,6 +228,11 @@ def check_reserved_name_collision(
                 context={"name": first_segment, "scope": scope},
             )
         return
+
+    # See ``resolve_scope_root`` — coerce to str so the psycopg2 UUID
+    # bind processor doesn't choke on a uuid.UUID instance.
+    if scope_id is not None:
+        scope_id = str(scope_id)
 
     if scope == "organization":
         hit = (

--- a/computor-backend/src/computor_backend/business_logic/documents.py
+++ b/computor-backend/src/computor_backend/business_logic/documents.py
@@ -1,0 +1,264 @@
+"""Business logic for the Documents API.
+
+Path validation, scope-aware filesystem mapping, and the reserved-name
+collision check that keeps free-form documents from shadowing
+entity-owned directories (or vice versa).
+
+Read access is served by the ``static-server`` container at ``/docs``;
+this module only handles the write side.
+"""
+
+from pathlib import Path
+from typing import List, Literal, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from computor_backend.custom_types import Ltree
+from computor_backend.exceptions import (
+    BadRequestException,
+    ConflictException,
+    ForbiddenException,
+    NotFoundException,
+)
+from computor_backend.model.course import Course, CourseFamily
+from computor_backend.model.organization import Organization
+from computor_backend.permissions.principal import Principal
+from computor_backend.permissions.roles import CourseRole, ScopeRole
+from computor_backend.settings import settings
+
+
+DocumentScope = Literal["system", "organization", "course_family", "course"]
+
+
+def check_documents_write_permission(
+    permissions: Principal,
+    scope: DocumentScope,
+    scope_id: Optional[UUID | str],
+) -> None:
+    """Authorize a write operation against a documents scope.
+
+    The four levels — admin only, org-scoped ``_developer``+, family-scoped
+    ``_developer``+, course ``_lecturer``+ — match the policy in the
+    issue spec. Admins bypass everything; everyone else needs the
+    scope-specific role.
+    """
+    if permissions.is_admin:
+        return
+
+    if scope == "system":
+        raise ForbiddenException(
+            detail="Only administrators can write at the system documents root",
+        )
+
+    if scope_id is None:
+        raise BadRequestException(
+            detail="scope_id is required for non-system scopes",
+            context={"scope": scope},
+        )
+
+    scope_id_str = str(scope_id)
+
+    if scope == "organization":
+        if not permissions.has_organization_role(scope_id_str, ScopeRole.DEVELOPER):
+            raise ForbiddenException(
+                detail="Requires organization _developer or higher to write organization documents",
+                context={"organization_id": scope_id_str},
+            )
+        return
+
+    if scope == "course_family":
+        if not permissions.has_course_family_role(scope_id_str, ScopeRole.DEVELOPER):
+            raise ForbiddenException(
+                detail="Requires course_family _developer or higher to write course-family documents",
+                context={"course_family_id": scope_id_str},
+            )
+        return
+
+    if scope == "course":
+        if not permissions.has_course_role(scope_id_str, CourseRole.LECTURER):
+            raise ForbiddenException(
+                detail="Requires course _lecturer or higher to write course documents",
+                context={"course_id": scope_id_str},
+            )
+        return
+
+    raise BadRequestException(detail=f"Unknown scope: {scope}")
+
+
+def validate_relative_path(rel: str) -> List[str]:
+    """Split and validate a user-supplied relative path.
+
+    Returns the cleaned list of segments. Raises ``BadRequestException``
+    on traversal (``..``), absolute paths, or empty/dot segments.
+    """
+    if rel is None:
+        raise BadRequestException(detail="path is required")
+    if rel.startswith("/"):
+        raise BadRequestException(detail="path must be relative")
+    segments = rel.split("/")
+    cleaned: List[str] = []
+    for segment in segments:
+        if segment in ("", ".", ".."):
+            raise BadRequestException(
+                detail="path must not contain empty segments, '.' or '..'",
+                context={"path": rel},
+            )
+        if "\x00" in segment:
+            raise BadRequestException(detail="path contains a null byte")
+        cleaned.append(segment)
+    if not cleaned:
+        raise BadRequestException(detail="path must not be empty")
+    return cleaned
+
+
+def resolve_scope_root(
+    scope: DocumentScope,
+    scope_id: Optional[UUID | str],
+    db: Session,
+) -> Path:
+    """Return the absolute filesystem root for a documents scope.
+
+    For ``system`` returns ``DOCUMENTS_ROOT``; otherwise descends through
+    the entity tree (organization → course_family → course) using each
+    entity's ``path``. Raises ``NotFoundException`` when ``scope_id``
+    doesn't resolve.
+    """
+    if not settings.DOCUMENTS_ROOT:
+        raise BadRequestException(detail="DOCUMENTS_ROOT is not configured on the server")
+    root = Path(settings.DOCUMENTS_ROOT).resolve()
+
+    if scope == "system":
+        return root
+
+    if scope_id is None:
+        raise BadRequestException(
+            detail="scope_id is required for non-system scopes",
+            context={"scope": scope},
+        )
+
+    if scope == "organization":
+        org = db.query(Organization).filter(Organization.id == scope_id).first()
+        if org is None:
+            raise NotFoundException(
+                detail="Organization not found",
+                context={"organization_id": str(scope_id)},
+            )
+        return root / str(org.path)
+
+    if scope == "course_family":
+        family = db.query(CourseFamily).filter(CourseFamily.id == scope_id).first()
+        if family is None:
+            raise NotFoundException(
+                detail="CourseFamily not found",
+                context={"course_family_id": str(scope_id)},
+            )
+        org = db.query(Organization).filter(Organization.id == family.organization_id).first()
+        return root / str(org.path) / str(family.path)
+
+    if scope == "course":
+        course = db.query(Course).filter(Course.id == scope_id).first()
+        if course is None:
+            raise NotFoundException(
+                detail="Course not found",
+                context={"course_id": str(scope_id)},
+            )
+        family = db.query(CourseFamily).filter(CourseFamily.id == course.course_family_id).first()
+        org = db.query(Organization).filter(Organization.id == course.organization_id).first()
+        return root / str(org.path) / str(family.path) / str(course.path)
+
+    raise BadRequestException(detail=f"Unknown scope: {scope}")
+
+
+def resolve_absolute_path(scope_root: Path, segments: List[str]) -> Path:
+    """Join validated segments under ``scope_root``, refusing escapes.
+
+    ``validate_relative_path`` already rejects ``..``; this is the
+    second guard that re-checks the resolved path is contained in
+    ``scope_root`` (also catches symlink games on the filesystem).
+    """
+    target = (scope_root / Path(*segments)).resolve()
+    try:
+        target.relative_to(scope_root)
+    except ValueError as e:
+        raise BadRequestException(
+            detail="path escapes the scope root",
+            context={"resolved": str(target)},
+        ) from e
+    return target
+
+
+def check_reserved_name_collision(
+    scope: DocumentScope,
+    scope_id: Optional[UUID | str],
+    first_segment: str,
+    db: Session,
+) -> None:
+    """Raise ``ConflictException`` if ``first_segment`` shadows a child entity.
+
+    At the system scope, children are Organizations; at the organization
+    scope, children are CourseFamilies; at the course_family scope,
+    children are Courses. The course scope has no nested entities.
+
+    Used both for create operations (refuse to overwrite/upload into an
+    entity-owned subtree) and for delete operations (refuse to remove
+    an entity-bound directory).
+    """
+    if scope == "course":
+        return  # courses have no nested entities
+
+    try:
+        candidate = Ltree(first_segment)
+    except ValueError:
+        # Not a valid Ltree label (e.g. contains spaces) — by construction
+        # cannot collide with any entity path. Nothing to enforce.
+        return
+
+    if scope == "system":
+        hit = db.query(Organization.id).filter(Organization.path == candidate).first()
+        if hit:
+            raise ConflictException(
+                detail="A documents directory cannot share a name with an existing organization",
+                context={"name": first_segment, "scope": scope},
+            )
+        return
+
+    if scope == "organization":
+        hit = (
+            db.query(CourseFamily.id)
+            .filter(
+                CourseFamily.organization_id == scope_id,
+                CourseFamily.path == candidate,
+            )
+            .first()
+        )
+        if hit:
+            raise ConflictException(
+                detail="A documents directory cannot share a name with an existing course family",
+                context={
+                    "name": first_segment,
+                    "scope": scope,
+                    "organization_id": str(scope_id),
+                },
+            )
+        return
+
+    if scope == "course_family":
+        hit = (
+            db.query(Course.id)
+            .filter(
+                Course.course_family_id == scope_id,
+                Course.path == candidate,
+            )
+            .first()
+        )
+        if hit:
+            raise ConflictException(
+                detail="A documents directory cannot share a name with an existing course",
+                context={
+                    "name": first_segment,
+                    "scope": scope,
+                    "course_family_id": str(scope_id),
+                },
+            )
+        return

--- a/computor-backend/src/computor_backend/business_logic/documents.py
+++ b/computor-backend/src/computor_backend/business_logic/documents.py
@@ -262,3 +262,21 @@ def check_reserved_name_collision(
                 },
             )
         return
+
+
+def resolve_listing_target(
+    scope: DocumentScope,
+    scope_id: Optional[UUID | str],
+    path: Optional[str],
+    db: Session,
+) -> Path:
+    """Resolve the target directory for a list operation.
+
+    Empty/None ``path`` → the scope root itself; non-empty path runs
+    through the same validation and escape-protection as writes.
+    """
+    scope_root = resolve_scope_root(scope, scope_id, db)
+    if not path:
+        return scope_root
+    segments = validate_relative_path(path)
+    return resolve_absolute_path(scope_root, segments)

--- a/computor-backend/src/computor_backend/scripts/generate_error_codes.py
+++ b/computor-backend/src/computor_backend/scripts/generate_error_codes.py
@@ -12,7 +12,6 @@ import yaml
 import json
 from pathlib import Path
 from typing import Any, Dict, List
-from datetime import datetime
 
 
 def load_error_registry(registry_path: Path) -> Dict[str, Any]:
@@ -35,7 +34,6 @@ def generate_typescript(errors: List[Dict], output_path: Path) -> None:
  * Auto-generated error code definitions
  *
  * DO NOT EDIT MANUALLY
- * Generated at: {datetime.now().isoformat()}
  *
  * To regenerate: bash generate_error_codes.sh
  */
@@ -279,7 +277,6 @@ def generate_json_catalog(errors: List[Dict], output_path: Path) -> None:
     """
     catalog = {
         "version": "1.0.0",
-        "generated_at": datetime.now().isoformat(),
         "error_count": len(errors),
         "errors": {}
     }
@@ -322,7 +319,6 @@ def generate_vscode_catalog(errors: List[Dict], output_path: Path) -> None:
     """
     catalog = {
         "version": "1.0.0",
-        "generated_at": datetime.now().isoformat(),
         "error_count": len(errors),
         "errors": {}
     }
@@ -357,7 +353,6 @@ def generate_markdown_docs(errors: List[Dict], output_path: Path) -> None:
     md_content = f'''# Error Code Reference
 
 **Auto-generated documentation**
-**Generated:** {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
 **Total errors:** {len(errors)}
 
 To regenerate: `bash generate_error_codes.sh`
@@ -451,7 +446,6 @@ def generate_python_constants(errors: List[Dict], output_path: Path) -> None:
 Auto-generated error code constants
 
 DO NOT EDIT MANUALLY
-Generated at: {datetime.now().isoformat()}
 
 To regenerate: bash generate_error_codes.sh
 """

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -76,6 +76,7 @@ from computor_backend.api.course_member_import import course_member_import_route
 from computor_backend.api.course_member_gradings import course_member_gradings_router
 from computor_backend.api.workspace_roles import workspace_roles_router
 from computor_backend.api.maintenance import maintenance_router
+from computor_backend.api.documents import documents_router
 from computor_backend.exceptions import register_exception_handlers
 from computor_backend.websocket.router import ws_router
 from computor_backend.websocket.connection_manager import manager as ws_manager
@@ -381,6 +382,11 @@ app.include_router(
     prefix="/lecturers",
     tags=["lecturers"],
     dependencies=[Depends(get_current_principal),Depends(get_redis_client)]
+)
+
+app.include_router(
+    documents_router,
+    dependencies=[Depends(get_current_principal)],
 )
 
 app.include_router(

--- a/computor-backend/src/computor_backend/settings.py
+++ b/computor-backend/src/computor_backend/settings.py
@@ -9,6 +9,13 @@ class BackendSettings:
         self.DEBUG_MODE = os.environ.get("DEBUG_MODE","development")
         self.API_LOCAL_STORAGE_DIR = os.environ.get("API_LOCAL_STORAGE_DIR",None)
 
+        # Documents API: write side maintained by ``api/documents.py``,
+        # read side served by the ``static-server`` container at /docs.
+        # Both must point at the same host directory; see DOCUMENTS_LEGACY.md
+        # and the compose mounts.
+        self.DOCUMENTS_ROOT = os.environ.get("DOCUMENTS_ROOT", None)
+        self.DOCUMENTS_MAX_FILE_SIZE = int(os.environ.get("DOCUMENTS_MAX_FILE_SIZE", str(10 * 1024 * 1024)))
+
         # Security: Force disable debug info in API responses (overrides DEBUG_MODE)
         # Set DISABLE_API_DEBUG_INFO=true to hide sensitive information even in development
         self.DISABLE_API_DEBUG_INFO = os.environ.get("DISABLE_API_DEBUG_INFO", "false").lower() in ["true", "1", "yes", "on"]

--- a/computor-backend/src/computor_backend/tests/test_documents.py
+++ b/computor-backend/src/computor_backend/tests/test_documents.py
@@ -1,0 +1,295 @@
+"""Tests for the Documents API.
+
+Pure-unit coverage of the business-logic helpers (path validation,
+scope-aware resolution, reserved-name collision, RBAC) plus a small
+filesystem round-trip for the four endpoints. SQLAlchemy is mocked so
+the tests stay fast and don't need a live database.
+"""
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from computor_backend.business_logic import documents as bl
+from computor_backend.exceptions import (
+    BadRequestException,
+    ConflictException,
+    ForbiddenException,
+    NotFoundException,
+)
+from computor_backend.permissions.principal import Claims, Principal
+from computor_types.documents import DocumentCreate, DocumentDelete
+
+
+# ---------------------------------------------------------------------------
+# validate_relative_path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("good", ["foo", "a/b", "a/b/c.md", "deep/nested/path/x"])
+def test_validate_relative_path_accepts_safe_inputs(good):
+    assert bl.validate_relative_path(good) == good.split("/")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "../escape",
+        "/abs/path",
+        "foo/../bar",
+        "foo//bar",
+        "",
+        "foo/.",
+        "./foo",
+        "foo/",
+        "/",
+    ],
+)
+def test_validate_relative_path_rejects_unsafe_inputs(bad):
+    with pytest.raises(BadRequestException):
+        bl.validate_relative_path(bad)
+
+
+def test_validate_relative_path_rejects_null_byte():
+    with pytest.raises(BadRequestException):
+        bl.validate_relative_path("foo/bar\x00.md")
+
+
+# ---------------------------------------------------------------------------
+# resolve_scope_root
+# ---------------------------------------------------------------------------
+
+def test_resolve_scope_root_system_returns_documents_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(bl.settings, "DOCUMENTS_ROOT", str(tmp_path))
+    db = MagicMock()
+    assert bl.resolve_scope_root("system", None, db) == tmp_path.resolve()
+
+
+def test_resolve_scope_root_organization_appends_org_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(bl.settings, "DOCUMENTS_ROOT", str(tmp_path))
+
+    org = MagicMock()
+    org.path = "tu_graz"
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = org
+
+    out = bl.resolve_scope_root("organization", uuid4(), db)
+    assert out == (tmp_path / "tu_graz").resolve()
+
+
+def test_resolve_scope_root_requires_scope_id_for_non_system(tmp_path, monkeypatch):
+    monkeypatch.setattr(bl.settings, "DOCUMENTS_ROOT", str(tmp_path))
+    with pytest.raises(BadRequestException):
+        bl.resolve_scope_root("organization", None, MagicMock())
+
+
+def test_resolve_scope_root_organization_not_found(tmp_path, monkeypatch):
+    monkeypatch.setattr(bl.settings, "DOCUMENTS_ROOT", str(tmp_path))
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    with pytest.raises(NotFoundException):
+        bl.resolve_scope_root("organization", uuid4(), db)
+
+
+def test_resolve_scope_root_unknown_scope(tmp_path, monkeypatch):
+    monkeypatch.setattr(bl.settings, "DOCUMENTS_ROOT", str(tmp_path))
+    with pytest.raises(BadRequestException):
+        bl.resolve_scope_root("bogus", uuid4(), MagicMock())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# resolve_absolute_path — escape detection
+# ---------------------------------------------------------------------------
+
+def test_resolve_absolute_path_returns_path_under_root(tmp_path):
+    out = bl.resolve_absolute_path(tmp_path, ["foo", "bar.md"])
+    assert out == (tmp_path / "foo" / "bar.md").resolve()
+
+
+def test_resolve_absolute_path_rejects_symlink_escape(tmp_path):
+    # Create a symlink that points outside the scope_root
+    outside = tmp_path.parent / "outside_target"
+    outside.mkdir(exist_ok=True)
+    link = tmp_path / "escape"
+    link.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(BadRequestException):
+        bl.resolve_absolute_path(tmp_path, ["escape", "anything"])
+
+
+# ---------------------------------------------------------------------------
+# check_reserved_name_collision
+# ---------------------------------------------------------------------------
+
+def test_reserved_collision_course_scope_is_noop():
+    """Courses have no nested entities — the check should never raise."""
+    db = MagicMock()
+    bl.check_reserved_name_collision("course", uuid4(), "anything", db)
+    # No exception, no DB query inspected (children-of-course query never runs)
+
+
+def test_reserved_collision_invalid_ltree_label_is_noop():
+    """A segment that isn't a valid Ltree label can't collide with any entity path."""
+    db = MagicMock()
+    bl.check_reserved_name_collision("organization", uuid4(), "has spaces", db)
+    db.query.assert_not_called()
+
+
+def test_reserved_collision_system_hits_organizations_table():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = ("hit",)
+    with pytest.raises(ConflictException):
+        bl.check_reserved_name_collision("system", None, "tu_graz", db)
+
+
+def test_reserved_collision_organization_hits_course_families_table():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = ("hit",)
+    with pytest.raises(ConflictException):
+        bl.check_reserved_name_collision("organization", uuid4(), "ws25", db)
+
+
+def test_reserved_collision_course_family_hits_courses_table():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = ("hit",)
+    with pytest.raises(ConflictException):
+        bl.check_reserved_name_collision("course_family", uuid4(), "algo", db)
+
+
+def test_reserved_collision_no_match_does_not_raise():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    bl.check_reserved_name_collision("system", None, "no_such_org", db)
+
+
+# ---------------------------------------------------------------------------
+# check_documents_write_permission
+# ---------------------------------------------------------------------------
+
+def _principal(*, is_admin=False, claims=None):
+    return Principal(
+        is_admin=is_admin,
+        user_id=str(uuid4()),
+        claims=claims or Claims(),
+    )
+
+
+def test_rbac_admin_passes_every_scope():
+    admin = _principal(is_admin=True)
+    for scope in ("system", "organization", "course_family", "course"):
+        bl.check_documents_write_permission(admin, scope, uuid4())
+
+
+def test_rbac_system_requires_admin():
+    plain = _principal()
+    with pytest.raises(ForbiddenException):
+        bl.check_documents_write_permission(plain, "system", None)
+
+
+def test_rbac_non_system_requires_scope_id():
+    plain = _principal()
+    with pytest.raises(BadRequestException):
+        bl.check_documents_write_permission(plain, "organization", None)
+
+
+def test_rbac_organization_developer_passes():
+    org_id = str(uuid4())
+    p = _principal(claims=Claims(dependent={"organization": {org_id: {"_developer"}}}))
+    bl.check_documents_write_permission(p, "organization", org_id)
+
+
+def test_rbac_organization_role_below_developer_denied():
+    """The org scope ladder is _developer < _manager < _owner — there is no
+    role below _developer, so this just verifies the empty-claims case."""
+    org_id = str(uuid4())
+    p = _principal()
+    with pytest.raises(ForbiddenException):
+        bl.check_documents_write_permission(p, "organization", org_id)
+
+
+def test_rbac_organization_owner_passes_via_hierarchy():
+    org_id = str(uuid4())
+    p = _principal(claims=Claims(dependent={"organization": {org_id: {"_owner"}}}))
+    bl.check_documents_write_permission(p, "organization", org_id)
+
+
+def test_rbac_organization_developer_for_other_org_is_denied():
+    p = _principal(claims=Claims(dependent={"organization": {str(uuid4()): {"_developer"}}}))
+    with pytest.raises(ForbiddenException):
+        bl.check_documents_write_permission(p, "organization", uuid4())
+
+
+def test_rbac_course_lecturer_passes():
+    course_id = str(uuid4())
+    p = _principal(claims=Claims(dependent={"course": {course_id: {"_lecturer"}}}))
+    bl.check_documents_write_permission(p, "course", course_id)
+
+
+def test_rbac_course_tutor_denied():
+    course_id = str(uuid4())
+    p = _principal(claims=Claims(dependent={"course": {course_id: {"_tutor"}}}))
+    with pytest.raises(ForbiddenException):
+        bl.check_documents_write_permission(p, "course", course_id)
+
+
+# ---------------------------------------------------------------------------
+# DocumentCreate / DocumentDelete payload validation
+# ---------------------------------------------------------------------------
+
+def test_payload_rejects_non_system_without_scope_id():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        DocumentCreate(scope="organization", path="foo")
+
+
+def test_payload_accepts_system_without_scope_id():
+    DocumentCreate(scope="system", path="foo")
+
+
+def test_payload_rejects_empty_path():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        DocumentDelete(scope="system", path="")
+
+
+# ---------------------------------------------------------------------------
+# Filesystem round-trip via the FastAPI client (integration smoke)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def docs_root(tmp_path, monkeypatch):
+    """Point DOCUMENTS_ROOT at a clean tmp dir for the duration of one test."""
+    monkeypatch.setattr(bl.settings, "DOCUMENTS_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def test_filesystem_roundtrip_at_system_scope(docs_root, monkeypatch):
+    """Upload → file appears at expected path; delete → file gone."""
+    # Skip the FastAPI client and the auth chain — exercise the BL/FS path
+    # directly. The endpoints are thin wrappers and the API contract is
+    # covered by the unit tests above.
+    segments = bl.validate_relative_path("subdir/x.md")
+    target = bl.resolve_absolute_path(docs_root, segments)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"hello world")
+    assert target.read_bytes() == b"hello world"
+    assert (docs_root / "subdir" / "x.md").exists()
+
+    target.unlink()
+    assert not target.exists()
+
+
+def test_filesystem_resolve_keeps_path_under_scope_root(docs_root):
+    """Even if a malicious caller bypasses validate_relative_path,
+    resolve_absolute_path's relative_to() check keeps the result inside
+    the scope root."""
+    # The validator catches '..' before resolve runs, so the only way
+    # to escape is via a symlink — covered by test_resolve_absolute_path_rejects_symlink_escape.
+    target = bl.resolve_absolute_path(docs_root, ["a", "b", "c"])
+    assert target.is_relative_to(docs_root.resolve())

--- a/computor-client/src/computor_client/endpoints/__init__.py
+++ b/computor-client/src/computor_client/endpoints/__init__.py
@@ -20,6 +20,7 @@ from computor_client.endpoints.course_member_import import CourseMemberImportCli
 from computor_client.endpoints.course_members import CourseMembersClient
 from computor_client.endpoints.course_roles import CourseRolesClient
 from computor_client.endpoints.courses import CoursesClient
+from computor_client.endpoints.documents import DocumentsClient
 from computor_client.endpoints.example_repositories import ExampleRepositoriesClient
 from computor_client.endpoints.examples import ExamplesClient
 from computor_client.endpoints.extensions import ExtensionsClient
@@ -68,6 +69,7 @@ __all__ = [
     "CourseMembersClient",
     "CourseRolesClient",
     "CoursesClient",
+    "DocumentsClient",
     "ExampleRepositoriesClient",
     "ExamplesClient",
     "ExtensionsClient",

--- a/computor-client/src/computor_client/endpoints/documents.py
+++ b/computor-client/src/computor_client/endpoints/documents.py
@@ -1,0 +1,93 @@
+"""
+Auto-generated endpoint client.
+
+This module is auto-generated from the OpenAPI specification.
+Run `bash generate.sh python-client` to regenerate.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel
+
+
+from computor_client.http import AsyncHTTPClient
+
+
+class DocumentsClient:
+    """
+    Client for documents endpoints.
+    """
+
+    def __init__(self, http_client: AsyncHTTPClient) -> None:
+        self._http = http_client
+
+    async def files(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Upload Document File"""
+        response = await self._http.post(f"/documents/files", params=kwargs)
+        return response.json()
+
+    async def delete_files(
+        self,
+        **kwargs: Any,
+    ) -> None:
+        """Delete Document File"""
+        await self._http.delete(f"/documents/files", params=kwargs)
+        return
+
+    async def patch_files(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Rename Document File"""
+        response = await self._http.patch(f"/documents/files", params=kwargs)
+        return response.json()
+
+    async def get_files(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Get Document File"""
+        response = await self._http.get(f"/documents/files", params=kwargs)
+        return response.json()
+
+    async def directories(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Create Document Directory"""
+        response = await self._http.post(f"/documents/directories", params=kwargs)
+        return response.json()
+
+    async def delete_directories(
+        self,
+        **kwargs: Any,
+    ) -> None:
+        """Delete Document Directory"""
+        await self._http.delete(f"/documents/directories", params=kwargs)
+        return
+
+    async def patch_directories(
+        self,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Rename Document Directory"""
+        response = await self._http.patch(f"/documents/directories", params=kwargs)
+        return response.json()
+
+    async def list(
+        self,
+        query: Optional[BaseModel] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """List Documents Directory"""
+        params = query.model_dump(exclude_none=True) if query else {}
+        params.update(kwargs)
+        response = await self._http.get(
+            f"/documents/list",
+            params=params,
+        )
+        return response.json()
+

--- a/computor-types/src/computor_types/documents.py
+++ b/computor-types/src/computor_types/documents.py
@@ -1,10 +1,14 @@
 """DTOs for the Documents API.
 
-The API is write-only — reads are served by the ``static-server``
-container at ``/docs``. Each request carries the scope (system,
-organization, course_family, course) and the relative path inside
-that scope's documents area.
+Public read access is served by the ``static-server`` container at
+``/docs``. The API surface here covers writes (file upload, file
+delete, mkdir, rmdir) plus authenticated GETs (list a directory, fetch
+a file) for callers that already have a session — VS Code extension,
+admin scripts, etc. Each request carries the scope (system,
+organization, course_family, course) and the relative path inside that
+scope's documents area.
 """
+from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
 
@@ -62,6 +66,20 @@ class DocumentGet(BaseModel):
     content_type: Optional[str] = None
 
 
+class DocumentRename(_DocumentScopedPathBase):
+    """Body for ``PATCH /documents/files`` (rename a file).
+
+    ``path`` is the source; ``new_path`` is the target. Both validated
+    against the same rules. The scope itself is unchanged — this is a
+    same-scope rename, not a cross-scope move.
+    """
+    new_path: str = Field(
+        description="Target relative path inside the scope's documents "
+                    "area. Same validation rules as ``path``.",
+        min_length=1,
+    )
+
+
 class DocumentDirectoryCreate(_DocumentScopedPathBase):
     """Body for ``POST /documents/directories``."""
 
@@ -70,9 +88,44 @@ class DocumentDirectoryDelete(_DocumentScopedPathBase):
     """Body for ``DELETE /documents/directories``."""
 
 
+class DocumentDirectoryRename(_DocumentScopedPathBase):
+    """Body for ``PATCH /documents/directories`` (rename a directory).
+
+    Same shape as :class:`DocumentRename`. Refuses to move a directory
+    into a path that lies inside itself.
+    """
+    new_path: str = Field(
+        description="Target relative path inside the scope's documents "
+                    "area. Same validation rules as ``path``.",
+        min_length=1,
+    )
+
+
 class DocumentDirectoryGet(BaseModel):
     """Response from a successful mkdir."""
     scope: DocumentScopeName
     scope_id: Optional[UUID] = None
     path: str
     created: bool = Field(description="False if the directory already existed.")
+
+
+class DocumentList(BaseModel):
+    """One entry in a ``GET /documents/list`` response.
+
+    A directory listing mixes files and subdirectories — ``type``
+    discriminates, and ``size`` is null for directories. ``etag`` and
+    ``last_modified`` are derived from the filesystem stat and let
+    clients revalidate per entry against ``GET /documents/files`` via
+    ``If-None-Match`` without a full re-download.
+    """
+    name: str
+    type: Literal["file", "directory"]
+    size: Optional[int] = Field(
+        default=None,
+        description="File size in bytes; null for directories.",
+    )
+    etag: str = Field(
+        description="Quoted weak validator (matches the ETag the file "
+                    "GET endpoint returns) for cache revalidation.",
+    )
+    last_modified: datetime = Field(description="UTC mtime of the entry.")

--- a/computor-types/src/computor_types/documents.py
+++ b/computor-types/src/computor_types/documents.py
@@ -1,0 +1,78 @@
+"""DTOs for the Documents API.
+
+The API is write-only — reads are served by the ``static-server``
+container at ``/docs``. Each request carries the scope (system,
+organization, course_family, course) and the relative path inside
+that scope's documents area.
+"""
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+
+DocumentScopeName = Literal["system", "organization", "course_family", "course"]
+
+
+class _DocumentScopedPathBase(BaseModel):
+    """Shared fields and validation for all documents-API payloads.
+
+    Not exported — concrete request/response classes inherit from it so
+    the per-endpoint type still follows the ``<Entity><Action>`` naming
+    convention used elsewhere in this package.
+    """
+    scope: DocumentScopeName = Field(
+        description="Documents scope. 'system' = top-level admin-only area; "
+                    "others must be paired with the matching scope_id."
+    )
+    scope_id: Optional[UUID] = Field(
+        default=None,
+        description="Entity ID for the chosen scope. Required for "
+                    "organization / course_family / course; ignored for system.",
+    )
+    path: str = Field(
+        description="Relative path inside the scope's documents area. "
+                    "Must not contain '..' or absolute components.",
+        min_length=1,
+    )
+
+    @model_validator(mode="after")
+    def _scope_id_required_unless_system(self) -> "_DocumentScopedPathBase":
+        if self.scope != "system" and self.scope_id is None:
+            raise ValueError("scope_id is required for non-system scopes")
+        return self
+
+
+class DocumentCreate(_DocumentScopedPathBase):
+    """Form fields for ``POST /documents/files`` (the file itself is
+    sent as a multipart upload alongside this payload).
+    """
+
+
+class DocumentDelete(_DocumentScopedPathBase):
+    """Body for ``DELETE /documents/files``."""
+
+
+class DocumentGet(BaseModel):
+    """Response from a successful file upload."""
+    scope: DocumentScopeName
+    scope_id: Optional[UUID] = None
+    path: str
+    size: int = Field(description="File size in bytes after writing.")
+    content_type: Optional[str] = None
+
+
+class DocumentDirectoryCreate(_DocumentScopedPathBase):
+    """Body for ``POST /documents/directories``."""
+
+
+class DocumentDirectoryDelete(_DocumentScopedPathBase):
+    """Body for ``DELETE /documents/directories``."""
+
+
+class DocumentDirectoryGet(BaseModel):
+    """Response from a successful mkdir."""
+    scope: DocumentScopeName
+    scope_id: Optional[UUID] = None
+    path: str
+    created: bool = Field(description="False if the directory already existed.")

--- a/computor-types/src/computor_types/generated/error_codes.py
+++ b/computor-types/src/computor_types/generated/error_codes.py
@@ -2,7 +2,6 @@
 Auto-generated error code constants
 
 DO NOT EDIT MANUALLY
-Generated at: 2026-05-05T23:44:23.386638
 
 To regenerate: bash generate_error_codes.sh
 """

--- a/computor-web/src/generated/clients/DocumentsClient.ts
+++ b/computor-web/src/generated/clients/DocumentsClient.ts
@@ -1,0 +1,129 @@
+/**
+ * Auto-generated client for DocumentsClient.
+ * Endpoint: /documents
+ */
+
+import type { DocumentDelete, DocumentDirectoryCreate, DocumentDirectoryDelete, DocumentDirectoryGet, DocumentDirectoryRename, DocumentGet, DocumentList, DocumentRename } from 'types/generated';
+import { APIClient, apiClient } from 'api/client';
+import { BaseEndpointClient } from './baseClient';
+
+export class DocumentsClient extends BaseEndpointClient {
+  constructor(client: APIClient = apiClient) {
+    super(client, '/documents');
+  }
+
+  /**
+   * Delete Document Directory
+   * Delete a documents directory recursively.
+   * Refuses (409) when the leading segment matches an entity's path —
+   * those directories are entity-bound and can only be removed via
+   * entity deletion.
+   */
+  async deleteDocumentDirectoryDocumentsDirectoriesDelete({ userId, body }: { userId?: string | null; body: DocumentDirectoryDelete }): Promise<void> {
+    const queryParams: Record<string, unknown> = {
+      user_id: userId,
+    };
+    return this.client.delete<void>(this.buildPath('directories'), body, { params: queryParams });
+  }
+
+  /**
+   * Rename Document Directory
+   * Rename a documents directory inside the same scope.
+   * Source must exist and be a directory; target must not exist;
+   * target must not lie inside the source (no moving a dir into
+   * itself). ``created`` in the response is always ``False`` — the
+   * directory was moved, not freshly created.
+   */
+  async renameDocumentDirectoryDocumentsDirectoriesPatch({ userId, body }: { userId?: string | null; body: DocumentDirectoryRename }): Promise<DocumentDirectoryGet> {
+    const queryParams: Record<string, unknown> = {
+      user_id: userId,
+    };
+    return this.client.patch<DocumentDirectoryGet>(this.buildPath('directories'), body, { params: queryParams });
+  }
+
+  /**
+   * Create Document Directory
+   * Create a documents directory (idempotent — returns ``created=False``
+   * when it already existed).
+   */
+  async createDocumentDirectoryDocumentsDirectoriesPost({ userId, body }: { userId?: string | null; body: DocumentDirectoryCreate }): Promise<DocumentDirectoryGet> {
+    const queryParams: Record<string, unknown> = {
+      user_id: userId,
+    };
+    return this.client.post<DocumentDirectoryGet>(this.buildPath('directories'), body, { params: queryParams });
+  }
+
+  /**
+   * Delete Document File
+   * Delete a documents file.
+   */
+  async deleteDocumentFileDocumentsFilesDelete({ userId, body }: { userId?: string | null; body: DocumentDelete }): Promise<void> {
+    const queryParams: Record<string, unknown> = {
+      user_id: userId,
+    };
+    return this.client.delete<void>(this.buildPath('files'), body, { params: queryParams });
+  }
+
+  /**
+   * Get Document File
+   * Fetch a documents file. Available to any authenticated user.
+   * The same content is reachable unauthenticated via the static-server
+   * at ``/docs/<...>``; this endpoint serves authenticated callers
+   * through the same auth chain they use for everything else.
+   * Supports ``If-None-Match`` for cheap revalidation: when the
+   * supplied ETag matches the current file, returns ``304 Not
+   * Modified`` with the same ``ETag`` and ``Last-Modified`` headers
+   * the 200 response would carry.
+   */
+  async getDocumentFileDocumentsFilesGet({ path, scope, scopeId, userId }: { path: string; scope: 'system' | 'organization' | 'course_family' | 'course'; scopeId?: string | null; userId?: string | null }): Promise<void> {
+    const queryParams: Record<string, unknown> = {
+      path,
+      scope,
+      scope_id: scopeId,
+      user_id: userId,
+    };
+    return this.client.get<void>(this.buildPath('files'), { params: queryParams });
+  }
+
+  /**
+   * Rename Document File
+   * Rename a documents file inside the same scope.
+   * Source must exist and be a file; target must not exist. Both
+   * paths are validated. Atomic on the same filesystem (which is
+   * always true for ``DOCUMENTS_ROOT``).
+   */
+  async renameDocumentFileDocumentsFilesPatch({ userId, body }: { userId?: string | null; body: DocumentRename }): Promise<DocumentGet> {
+    const queryParams: Record<string, unknown> = {
+      user_id: userId,
+    };
+    return this.client.patch<DocumentGet>(this.buildPath('files'), body, { params: queryParams });
+  }
+
+  /**
+   * Upload Document File
+   * Create or overwrite a documents file at the given scope and path.
+   */
+  async uploadDocumentFileDocumentsFilesPost({ userId }: { userId?: string | null }): Promise<DocumentGet> {
+    const queryParams: Record<string, unknown> = {
+      user_id: userId,
+    };
+    return this.client.post<DocumentGet>(this.buildPath('files'), { params: queryParams });
+  }
+
+  /**
+   * List Documents Directory
+   * List entries in a documents directory.
+   * Available to any authenticated user. An unwritten scope root
+   * returns an empty list (so a fresh course/family/org does not 404);
+   * a missing non-root path is a 404.
+   */
+  async listDocumentsDirectoryDocumentsListGet({ path, scope, scopeId, userId }: { path?: string | null; scope: 'system' | 'organization' | 'course_family' | 'course'; scopeId?: string | null; userId?: string | null }): Promise<DocumentList[]> {
+    const queryParams: Record<string, unknown> = {
+      path,
+      scope,
+      scope_id: scopeId,
+      user_id: userId,
+    };
+    return this.client.get<DocumentList[]>(this.buildPath('list'), { params: queryParams });
+  }
+}

--- a/computor-web/src/generated/clients/client-endpoints.md
+++ b/computor-web/src/generated/clients/client-endpoints.md
@@ -202,6 +202,21 @@
 | `getCoursesCoursesIdGet` | GET | `/courses/{id}` | — | `CourseGet` |
 | `updateCoursesCoursesIdPatch` | PATCH | `/courses/{id}` | `CourseUpdate` | `CourseGet` |
 
+## DocumentsClient
+- Base path: `/documents`
+- Note: custom operations discovered from OpenAPI schema
+
+| TS Method | HTTP | Path | Request | Response |
+| --- | --- | --- | --- | --- |
+| `deleteDocumentDirectoryDocumentsDirectoriesDelete` | DELETE | `/documents/directories` | `DocumentDirectoryDelete` | `void` |
+| `renameDocumentDirectoryDocumentsDirectoriesPatch` | PATCH | `/documents/directories` | `DocumentDirectoryRename` | `DocumentDirectoryGet` |
+| `createDocumentDirectoryDocumentsDirectoriesPost` | POST | `/documents/directories` | `DocumentDirectoryCreate` | `DocumentDirectoryGet` |
+| `deleteDocumentFileDocumentsFilesDelete` | DELETE | `/documents/files` | `DocumentDelete` | `void` |
+| `getDocumentFileDocumentsFilesGet` | GET | `/documents/files` | — | `void` |
+| `renameDocumentFileDocumentsFilesPatch` | PATCH | `/documents/files` | `DocumentRename` | `DocumentGet` |
+| `uploadDocumentFileDocumentsFilesPost` | POST | `/documents/files` | — | `DocumentGet` |
+| `listDocumentsDirectoryDocumentsListGet` | GET | `/documents/list` | — | `DocumentList[]` |
+
 ## ExampleRepositoriesClient
 - Base path: `/example-repositories`
 - Note: custom operations discovered from OpenAPI schema

--- a/computor-web/src/generated/clients/index.ts
+++ b/computor-web/src/generated/clients/index.ts
@@ -19,6 +19,7 @@ export * from './CourseMemberImportClient';
 export * from './CourseMembersClient';
 export * from './CourseRolesClient';
 export * from './CoursesClient';
+export * from './DocumentsClient';
 export * from './ExampleRepositoriesClient';
 export * from './ExamplesClient';
 export * from './ExtensionsClient';

--- a/computor-web/src/generated/errors/ERROR_CODES.md
+++ b/computor-web/src/generated/errors/ERROR_CODES.md
@@ -1,7 +1,6 @@
 # Error Code Reference
 
 **Auto-generated documentation**
-**Generated:** 2026-05-05 23:44:23
 **Total errors:** 70
 
 To regenerate: `bash generate_error_codes.sh`

--- a/computor-web/src/generated/errors/error-catalog.json
+++ b/computor-web/src/generated/errors/error-catalog.json
@@ -1,6 +1,5 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-05T23:44:23.381406",
   "error_count": 70,
   "errors": {
     "AUTH_001": {

--- a/computor-web/src/generated/errors/error-catalog.vscode.json
+++ b/computor-web/src/generated/errors/error-catalog.vscode.json
@@ -1,6 +1,5 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-05T23:44:23.383979",
   "error_count": 70,
   "errors": {
     "AUTH_001": {

--- a/computor-web/src/generated/types/common.ts
+++ b/computor-web/src/generated/types/common.ts
@@ -3401,6 +3401,149 @@ export interface ProfileQuery {
 }
 
 /**
+ * Shared fields and validation for all documents-API payloads.
+ * 
+ * Not exported — concrete request/response classes inherit from it so
+ * the per-endpoint type still follows the ``<Entity><Action>`` naming
+ * convention used elsewhere in this package.
+ */
+export interface _DocumentScopedPathBase {
+  /** Documents scope. 'system' = top-level admin-only area; others must be paired with the matching scope_id. */
+  scope: "system" | "organization" | "course_family" | "course";
+  /** Entity ID for the chosen scope. Required for organization / course_family / course; ignored for system. */
+  scope_id?: string | null;
+  /** Relative path inside the scope's documents area. Must not contain '..' or absolute components. */
+  path: string;
+}
+
+/**
+ * Form fields for ``POST /documents/files`` (the file itself is
+ * sent as a multipart upload alongside this payload).
+ */
+export interface DocumentCreate {
+  /** Documents scope. 'system' = top-level admin-only area; others must be paired with the matching scope_id. */
+  scope: "system" | "organization" | "course_family" | "course";
+  /** Entity ID for the chosen scope. Required for organization / course_family / course; ignored for system. */
+  scope_id?: string | null;
+  /** Relative path inside the scope's documents area. Must not contain '..' or absolute components. */
+  path: string;
+}
+
+/**
+ * Body for ``DELETE /documents/files``.
+ */
+export interface DocumentDelete {
+  /** Documents scope. 'system' = top-level admin-only area; others must be paired with the matching scope_id. */
+  scope: "system" | "organization" | "course_family" | "course";
+  /** Entity ID for the chosen scope. Required for organization / course_family / course; ignored for system. */
+  scope_id?: string | null;
+  /** Relative path inside the scope's documents area. Must not contain '..' or absolute components. */
+  path: string;
+}
+
+/**
+ * Response from a successful file upload.
+ */
+export interface DocumentGet {
+  scope: "system" | "organization" | "course_family" | "course";
+  scope_id?: string | null;
+  path: string;
+  /** File size in bytes after writing. */
+  size: number;
+  content_type?: string | null;
+}
+
+/**
+ * Body for ``PATCH /documents/files`` (rename a file).
+ * 
+ * ``path`` is the source; ``new_path`` is the target. Both validated
+ * against the same rules. The scope itself is unchanged — this is a
+ * same-scope rename, not a cross-scope move.
+ */
+export interface DocumentRename {
+  /** Documents scope. 'system' = top-level admin-only area; others must be paired with the matching scope_id. */
+  scope: "system" | "organization" | "course_family" | "course";
+  /** Entity ID for the chosen scope. Required for organization / course_family / course; ignored for system. */
+  scope_id?: string | null;
+  /** Relative path inside the scope's documents area. Must not contain '..' or absolute components. */
+  path: string;
+  /** Target relative path inside the scope's documents area. Same validation rules as ``path``. */
+  new_path: string;
+}
+
+/**
+ * Body for ``POST /documents/directories``.
+ */
+export interface DocumentDirectoryCreate {
+  /** Documents scope. 'system' = top-level admin-only area; others must be paired with the matching scope_id. */
+  scope: "system" | "organization" | "course_family" | "course";
+  /** Entity ID for the chosen scope. Required for organization / course_family / course; ignored for system. */
+  scope_id?: string | null;
+  /** Relative path inside the scope's documents area. Must not contain '..' or absolute components. */
+  path: string;
+}
+
+/**
+ * Body for ``DELETE /documents/directories``.
+ */
+export interface DocumentDirectoryDelete {
+  /** Documents scope. 'system' = top-level admin-only area; others must be paired with the matching scope_id. */
+  scope: "system" | "organization" | "course_family" | "course";
+  /** Entity ID for the chosen scope. Required for organization / course_family / course; ignored for system. */
+  scope_id?: string | null;
+  /** Relative path inside the scope's documents area. Must not contain '..' or absolute components. */
+  path: string;
+}
+
+/**
+ * Body for ``PATCH /documents/directories`` (rename a directory).
+ * 
+ * Same shape as :class:`DocumentRename`. Refuses to move a directory
+ * into a path that lies inside itself.
+ */
+export interface DocumentDirectoryRename {
+  /** Documents scope. 'system' = top-level admin-only area; others must be paired with the matching scope_id. */
+  scope: "system" | "organization" | "course_family" | "course";
+  /** Entity ID for the chosen scope. Required for organization / course_family / course; ignored for system. */
+  scope_id?: string | null;
+  /** Relative path inside the scope's documents area. Must not contain '..' or absolute components. */
+  path: string;
+  /** Target relative path inside the scope's documents area. Same validation rules as ``path``. */
+  new_path: string;
+}
+
+/**
+ * Response from a successful mkdir.
+ */
+export interface DocumentDirectoryGet {
+  scope: "system" | "organization" | "course_family" | "course";
+  scope_id?: string | null;
+  path: string;
+  /** False if the directory already existed. */
+  created: boolean;
+}
+
+/**
+ * One entry in a ``GET /documents/list`` response.
+ * 
+ * A directory listing mixes files and subdirectories — ``type``
+ * discriminates, and ``size`` is null for directories. ``etag`` and
+ * ``last_modified`` are derived from the filesystem stat and let
+ * clients revalidate per entry against ``GET /documents/files`` via
+ * ``If-None-Match`` without a full re-download.
+ */
+export interface DocumentList {
+  name: string;
+  type: "file" | "directory";
+  /** File size in bytes; null for directories. */
+  size?: number | null;
+  /** Quoted weak validator (matches the ETag the file GET endpoint returns) for cache revalidation. */
+  etag: string;
+  /** UTC mtime of the entry. */
+  last_modified: string;
+}
+
+/**
  * DTO for creating a grade through the tutor endpoint.
  * 
  * This is used when a tutor grades a student's submission for a specific course content.
@@ -3978,4 +4121,4 @@ export type ErrorCategory = "authentication" | "authorization" | "validation" | 
 
 export type GradingStatus = 0 | 1 | 2 | 3;
 
-export type ErrorCode = "AUTH_001" | "AUTH_002" | "AUTH_003" | "AUTH_004" | "AUTHZ_001" | "AUTHZ_002" | "AUTHZ_003" | "AUTHZ_004" | "AUTHZ_005" | "VAL_001" | "VAL_002" | "VAL_003" | "VAL_004" | "NF_001" | "NF_002" | "NF_003" | "NF_004" | "CONFLICT_001" | "CONFLICT_002" | "RATE_001" | "RATE_002" | "RATE_003" | "CONTENT_001" | "CONTENT_002" | "CONTENT_003" | "CONTENT_004" | "CONTENT_005" | "CONTENT_006" | "CONTENT_007" | "VERSION_001" | "DEPLOY_001" | "DEPLOY_002" | "DEPLOY_003" | "DEPLOY_004" | "DEPLOY_005" | "SUBMIT_001" | "SUBMIT_002" | "SUBMIT_003" | "SUBMIT_004" | "SUBMIT_005" | "SUBMIT_006" | "SUBMIT_007" | "SUBMIT_008" | "TASK_001" | "TASK_002" | "TASK_003" | "TASK_004" | "GITLAB_001" | "GITLAB_002" | "GITLAB_003" | "GITLAB_004" | "GITLAB_005" | "GITLAB_006" | "GITLAB_007" | "GITLAB_008" | "EXT_001" | "EXT_002" | "EXT_003" | "EXT_004" | "EXT_005" | "DB_001" | "DB_002" | "DB_003" | "INT_001" | "INT_002" | "NIMPL_001";
+export type ErrorCode = "AUTH_001" | "AUTH_002" | "AUTH_003" | "AUTH_004" | "AUTH_005" | "AUTHZ_001" | "AUTHZ_002" | "AUTHZ_003" | "AUTHZ_004" | "AUTHZ_005" | "AUTHZ_010" | "VAL_001" | "VAL_002" | "VAL_003" | "VAL_004" | "NF_001" | "NF_002" | "NF_003" | "NF_004" | "NF_010" | "CONFLICT_001" | "CONFLICT_002" | "RATE_001" | "RATE_002" | "RATE_003" | "CONTENT_001" | "CONTENT_002" | "CONTENT_003" | "CONTENT_004" | "CONTENT_005" | "CONTENT_006" | "CONTENT_007" | "VERSION_001" | "DEPLOY_001" | "DEPLOY_002" | "DEPLOY_003" | "DEPLOY_004" | "DEPLOY_005" | "SUBMIT_001" | "SUBMIT_002" | "SUBMIT_003" | "SUBMIT_004" | "SUBMIT_005" | "SUBMIT_006" | "SUBMIT_007" | "SUBMIT_008" | "TASK_001" | "TASK_002" | "TASK_003" | "TASK_004" | "GITLAB_001" | "GITLAB_002" | "GITLAB_003" | "GITLAB_004" | "GITLAB_005" | "GITLAB_006" | "GITLAB_007" | "GITLAB_008" | "EXT_001" | "EXT_002" | "EXT_003" | "EXT_004" | "EXT_005" | "EXT_006" | "DB_001" | "DB_002" | "DB_003" | "INT_001" | "INT_002" | "NIMPL_001";

--- a/computor-web/src/generated/types/error-codes.ts
+++ b/computor-web/src/generated/types/error-codes.ts
@@ -2,7 +2,6 @@
  * Auto-generated error code definitions
  *
  * DO NOT EDIT MANUALLY
- * Generated at: 2026-05-05T23:44:23.380712
  *
  * To regenerate: bash generate_error_codes.sh
  */

--- a/ops/docker/docker-compose.base.yaml
+++ b/ops/docker/docker-compose.base.yaml
@@ -148,14 +148,15 @@ services:
     labels:
       - "traefik.enable=false"
 
-  # Static file server
+  # Static file server — read-only view of the documents tree maintained by
+  # the /documents API. Both must point at the same host directory.
   static-server:
     image: halverneus/static-file-server:latest
     networks:
       - computor-network
     restart: unless-stopped
     volumes:
-      - ${SYSTEM_DEPLOYMENT_PATH}/shared/documents:/web:ro
+      - ${DOCUMENTS_ROOT:-${SYSTEM_DEPLOYMENT_PATH}/shared/documents}:/web:ro
     environment:
       - FOLDER=/web
       - PORT=8080

--- a/ops/docker/docker-compose.prod.yaml
+++ b/ops/docker/docker-compose.prod.yaml
@@ -13,6 +13,10 @@ services:
     command: ["sh", "startup.bash"]
     volumes:
       - ${SYSTEM_DEPLOYMENT_PATH}/shared:${API_ROOT_PATH}/shared
+      # Documents tree shared with static-server (which mounts the same host
+      # path read-only). Same path inside the container as outside so
+      # ``settings.DOCUMENTS_ROOT`` resolves consistently in both processes.
+      - ${DOCUMENTS_ROOT:-${SYSTEM_DEPLOYMENT_PATH}/shared/documents}:${DOCUMENTS_ROOT:-/opt/computor/shared/documents}
     ports:
       - "${API_PORT:-8000}:8000"
     environment:
@@ -21,6 +25,8 @@ services:
       API_ADMIN_USER: ${API_ADMIN_USER}
       API_ADMIN_PASSWORD: ${API_ADMIN_PASSWORD}
       API_LOCAL_STORAGE_DIR: ${API_LOCAL_STORAGE_DIR}
+      DOCUMENTS_ROOT: ${DOCUMENTS_ROOT:-/opt/computor/shared/documents}
+      DOCUMENTS_MAX_FILE_SIZE: ${DOCUMENTS_MAX_FILE_SIZE:-10485760}
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5437
       POSTGRES_USER: ${POSTGRES_USER}

--- a/ops/environments/.env.common.template
+++ b/ops/environments/.env.common.template
@@ -152,6 +152,15 @@ CODER_WORKSPACE_BASE_URL=http://localhost:8080/coder
 BACKEND_EXTERNAL_URL_PROD=
 
 # ============================================
+# DOCUMENTS API
+# ============================================
+# Root of the documents tree. The /documents API writes here; the
+# static-server container exposes the same path read-only at /docs.
+DOCUMENTS_ROOT=/opt/computor/shared/documents
+# Max bytes per file upload via the /documents API (default 10 MiB).
+DOCUMENTS_MAX_FILE_SIZE=10485760
+
+# ============================================
 # EXTENSION CONFIGURATION
 # ============================================
 EXTENSION_PUBLIC_DOWNLOAD_URL=


### PR DESCRIPTION
## Summary
- New documents API for files & directories backed by `DOCUMENTS_ROOT` on the host filesystem, with `DOCUMENTS_MAX_FILE_SIZE` enforcement and docker-compose mounts wired in (dev + prod)
- Write endpoints (create/update/delete for files and directories) gated by scoped RBAC; read endpoints (list/get) support ETag revalidation, and rename is supported
- Generated Python + TypeScript clients and updated common types; minor cleanup: dropped `generated_at` timestamps from error-code outputs

## Commits
- `50ad507` feat(documents): add `DOCUMENTS_ROOT` and `DOCUMENTS_MAX_FILE_SIZE` env vars + compose mounts
- `c2f8128` feat(documents): write-only API for files and directories with scoped RBAC
- `75e21a7` feat(documents): add list/get/rename endpoints with ETag revalidation; drop generation timestamps from error-code outputs
- `cd6f75f` fix(documents): uuid str bug

## Test plan
- [ ] `bash startup.sh dev -d && bash api.sh` boots cleanly with the new `DOCUMENTS_ROOT` mount
- [ ] Run `computor-backend/src/computor_backend/tests/test_documents.py` against a clean DB
- [ ] Manually exercise create / list / get (with `If-None-Match`) / rename / delete via `/docs`
- [ ] Verify `DOCUMENTS_MAX_FILE_SIZE` enforcement for uploads
- [ ] Confirm scoped RBAC rejects writes from unprivileged principals
- [ ] Verify regenerated TS/Python clients compile and consume the new endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)