### PR TITLE
feat: user management — invites, accounts, roles & claims

### DIFF
--- a/computor-backend/src/computor_backend/account_types.py
+++ b/computor-backend/src/computor_backend/account_types.py
@@ -1,0 +1,34 @@
+"""
+Supported account providers.
+
+Defines which external providers the system can link to a user account.
+Currently a static list — replace ACCOUNT_PROVIDERS with a DB query later
+without changing the endpoint URL or response shape.
+"""
+
+from typing import List
+from pydantic import BaseModel
+
+
+class AccountProvider(BaseModel):
+    """A supported external provider that can be linked to a user account."""
+    id: str           # short key, e.g. "gitlab"
+    display_name: str
+    description: str
+    provider: str     # value written to account.provider, e.g. "gitlab.com"
+    type: str         # value written to account.type, e.g. "gitlab"
+    field_label: str  # label for the provider_account_id input
+    placeholder: str  # placeholder for the provider_account_id input
+
+
+ACCOUNT_PROVIDERS: List[AccountProvider] = [
+    AccountProvider(
+        id="gitlab",
+        display_name="GitLab",
+        description="GitLab account used for repository access and submission validation",
+        provider="gitlab.com",
+        type="gitlab",
+        field_label="GitLab Username",
+        placeholder="johndoe",
+    ),
+]

--- a/computor-backend/src/computor_backend/alembic/versions/cc1d2e3f4a5b_add_invite_links_table.py
+++ b/computor-backend/src/computor_backend/alembic/versions/cc1d2e3f4a5b_add_invite_links_table.py
@@ -1,0 +1,44 @@
+"""Add invite_link table
+
+Revision ID: cc1d2e3f4a5b
+Revises: d5e6f7a8b9c0
+Create Date: 2026-05-19 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'cc1d2e3f4a5b'
+down_revision = 'd5e6f7a8b9c0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'invite_link',
+        sa.Column('id', postgresql.UUID(), server_default=sa.text('uuid_generate_v4()'), nullable=False),
+        sa.Column('version', sa.BigInteger(), server_default=sa.text('0'), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('created_by', postgresql.UUID(), nullable=True),
+        sa.Column('token', sa.String(64), nullable=False),
+        sa.Column('email', sa.String(320), nullable=True),
+        sa.Column('max_uses', sa.Integer(), server_default=sa.text('1'), nullable=False),
+        sa.Column('use_count', sa.Integer(), server_default=sa.text('0'), nullable=False),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('roles', postgresql.JSONB(), server_default=sa.text("'[]'::jsonb"), nullable=False),
+        sa.Column('note', sa.Text(), nullable=True),
+        sa.Column('revoked_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['created_by'], ['user.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('invite_link_token_idx', 'invite_link', ['token'], unique=True)
+    op.create_index('invite_link_created_by_idx', 'invite_link', ['created_by'])
+
+
+def downgrade():
+    op.drop_index('invite_link_created_by_idx', table_name='invite_link')
+    op.drop_index('invite_link_token_idx', table_name='invite_link')
+    op.drop_table('invite_link')

--- a/computor-backend/src/computor_backend/api/accounts.py
+++ b/computor-backend/src/computor_backend/api/accounts.py
@@ -1,0 +1,22 @@
+"""
+Account-specific endpoints that extend the generic CrudRouter for /accounts.
+
+GET /accounts/providers  — list supported provider definitions (public).
+"""
+
+from typing import List
+from fastapi import APIRouter
+from computor_backend.account_types import AccountProvider, ACCOUNT_PROVIDERS
+
+accounts_router = APIRouter()
+
+
+@accounts_router.get("/accounts/providers", response_model=List[AccountProvider])
+async def list_account_providers() -> List[AccountProvider]:
+    """
+    Return the list of supported account providers.
+
+    Public — no authentication required. The frontend uses this to render
+    the correct form when linking a provider account to a user.
+    """
+    return ACCOUNT_PROVIDERS

--- a/computor-backend/src/computor_backend/api/api_builder.py
+++ b/computor-backend/src/computor_backend/api/api_builder.py
@@ -44,6 +44,7 @@ class CrudRouter:
         self.on_updated = []
         self.on_deleted = []
         self.on_archived = []
+        self.pre_archive = []  # sync guards: (entity, permissions, db) -> None, raise to block
 
     def create(self):
         async def route(
@@ -123,6 +124,8 @@ class CrudRouter:
 
     def archive(self):
         if hasattr(self.dto.model, "archived_at"):
+            pre_archive_guards = self.pre_archive
+
             async def route(
                     background_tasks: BackgroundTasks,
                     permissions: Annotated[Principal, Depends(get_current_principal)],
@@ -130,6 +133,9 @@ class CrudRouter:
                     db: Session = Depends(get_db)
             ):
                 entity_archived = await get_id_db(permissions, db, id, self.dto)
+
+                for guard in pre_archive_guards:
+                    guard(entity_archived, permissions, db)
 
                 for task in self.on_archived:
                     background_tasks.add_task(task, entity_archived, permissions)

--- a/computor-backend/src/computor_backend/api/invites.py
+++ b/computor-backend/src/computor_backend/api/invites.py
@@ -1,0 +1,342 @@
+"""
+Invite link API endpoints.
+
+Admins and _user_manager role holders can create invite links.
+Invite acceptance is public (no authentication required).
+"""
+
+import json
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Annotated, List, Optional
+
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.orm import Session
+
+from computor_backend.database import get_db
+from computor_backend.exceptions import (
+    BadRequestException,
+    ForbiddenException,
+    NotFoundException,
+)
+from computor_backend.model.auth import User
+from computor_backend.model.invite import InviteLink
+from computor_backend.model.role import UserRole
+from computor_backend.permissions.auth import get_current_principal
+from computor_backend.permissions.principal import Principal
+from computor_types.invites import (
+    InviteAccept,
+    InviteLinkCreate,
+    InviteLinkGet,
+    InviteLinkList,
+    InviteLinkPublic,
+)
+from computor_types.password_utils import create_password_hash, PasswordValidationError
+
+logger = logging.getLogger(__name__)
+
+invites_router = APIRouter()
+
+
+def _require_invite_manager(principal: Principal, db: Session) -> None:
+    """Raise ForbiddenException unless caller is admin or has _user_manager role."""
+    if principal.is_admin:
+        return
+    user_role = db.query(UserRole).filter(
+        UserRole.user_id == principal.user_id,
+        UserRole.role_id == "_user_manager",
+    ).first()
+    if not user_role:
+        raise ForbiddenException("Requires _admin or _user_manager role")
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints
+# ---------------------------------------------------------------------------
+
+@invites_router.post("/admin/invites", response_model=InviteLinkGet, status_code=201)
+async def create_invite(
+    payload: InviteLinkCreate,
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> InviteLinkGet:
+    """Create a new invite link (admin or _user_manager)."""
+    _require_invite_manager(principal, db)
+
+    expires_at = datetime.now(timezone.utc) + timedelta(days=payload.expires_in_days)
+
+    invite = InviteLink(
+        token=InviteLink.generate_token(),
+        created_by=principal.user_id,
+        email=payload.email.lower().strip() if payload.email else None,
+        max_uses=payload.max_uses,
+        use_count=0,
+        expires_at=expires_at,
+        roles=payload.roles,
+        note=payload.note,
+    )
+    db.add(invite)
+    db.commit()
+    db.refresh(invite)
+
+    logger.info(f"Invite {invite.id} created by {principal.user_id}")
+    return _to_get(invite)
+
+
+@invites_router.get("/admin/invites", response_model=List[InviteLinkList])
+async def list_invites(
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> List[InviteLinkList]:
+    """List all invite links (admin or _user_manager)."""
+    _require_invite_manager(principal, db)
+    invites = db.query(InviteLink).order_by(InviteLink.created_at.desc()).all()
+    return [_to_list(i) for i in invites]
+
+
+@invites_router.get("/admin/invites/{invite_id}", response_model=InviteLinkGet)
+async def get_invite(
+    invite_id: str,
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> InviteLinkGet:
+    """Get a single invite link (admin or _user_manager)."""
+    _require_invite_manager(principal, db)
+    invite = db.query(InviteLink).filter(InviteLink.id == invite_id).first()
+    if not invite:
+        raise NotFoundException("Invite not found")
+    return _to_get(invite)
+
+
+@invites_router.delete("/admin/invites/{invite_id}", status_code=204)
+async def revoke_invite(
+    invite_id: str,
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> None:
+    """Revoke an invite link (admin or _user_manager)."""
+    _require_invite_manager(principal, db)
+    invite = db.query(InviteLink).filter(InviteLink.id == invite_id).first()
+    if not invite:
+        raise NotFoundException("Invite not found")
+    invite.revoked_at = datetime.now(timezone.utc)
+    db.commit()
+    logger.info(f"Invite {invite_id} revoked by {principal.user_id}")
+
+
+# ---------------------------------------------------------------------------
+# Public endpoints (no authentication required)
+# ---------------------------------------------------------------------------
+
+@invites_router.get("/invites/{token}", response_model=InviteLinkPublic)
+async def get_invite_public(
+    token: str,
+    db: Session = Depends(get_db),
+) -> InviteLinkPublic:
+    """Get invite metadata for the registration page (public, no auth)."""
+    invite = _resolve_token(token, db)
+    return InviteLinkPublic(
+        id=str(invite.id),
+        email=invite.email,
+        roles=invite.roles or [],
+        expires_at=invite.expires_at,
+        note=invite.note,
+    )
+
+
+@invites_router.post("/invites/{token}/accept", response_model=dict)
+async def accept_invite(
+    token: str,
+    payload: InviteAccept,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict:
+    """
+    Accept an invite and create a new user account.
+
+    On success the response sets HttpOnly cookies (ct_access_token /
+    ct_refresh_token) so the browser is immediately authenticated.
+    """
+    invite = _resolve_token(token, db)
+
+    # Email restriction check
+    if invite.email and invite.email.lower() != payload.email.lower():
+        raise BadRequestException("This invite is restricted to a different email address")
+
+    # Password confirmation
+    if payload.password != payload.confirm_password:
+        raise BadRequestException("Passwords do not match")
+
+    # Uniqueness checks
+    if db.query(User).filter(User.username == payload.username).first():
+        raise BadRequestException(f"Username '{payload.username}' is already taken")
+    if db.query(User).filter(User.email == payload.email).first():
+        raise BadRequestException(f"Email '{payload.email}' is already registered")
+
+    # Hash password
+    try:
+        password_hash = create_password_hash(
+            payload.password,
+            validate=True,
+            username=payload.username,
+            email=payload.email,
+        )
+    except PasswordValidationError as e:
+        raise BadRequestException(str(e))
+
+    # Create user
+    user = User(
+        username=payload.username,
+        email=payload.email,
+        given_name=payload.given_name,
+        family_name=payload.family_name,
+        password=password_hash,
+        password_reset_required=False,
+    )
+    db.add(user)
+    db.flush()  # Get user.id without committing
+
+    # Assign roles from invite
+    for role_id in (invite.roles or []):
+        db.add(UserRole(user_id=str(user.id), role_id=role_id))
+
+    # Consume invite
+    invite.use_count += 1
+    db.commit()
+    db.refresh(user)
+
+    logger.info(f"User {user.id} ({user.username}) created via invite {invite.id}")
+
+    # Create session (auto-login)
+    from computor_backend.utils.client_info import get_client_ip, get_user_agent, make_device_label
+    access_token, refresh_token = await _create_session(
+        user_id=str(user.id),
+        ip_address=get_client_ip(request),
+        user_agent=get_user_agent(request),
+        db=db,
+    )
+
+    _set_auth_cookies(response, access_token, refresh_token)
+
+    return {
+        "user_id": str(user.id),
+        "username": user.username,
+        "access_token": access_token,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_token(token: str, db: Session) -> InviteLink:
+    """Validate a token and return the InviteLink, raising on any problem."""
+    invite = db.query(InviteLink).filter(InviteLink.token == token).first()
+    if not invite:
+        raise NotFoundException("Invite not found or invalid")
+    if invite.revoked_at is not None:
+        raise BadRequestException("This invite has been revoked")
+    now = datetime.now(timezone.utc)
+    exp = invite.expires_at
+    if exp.tzinfo is None:
+        exp = exp.replace(tzinfo=timezone.utc)
+    if now > exp:
+        raise BadRequestException("This invite has expired")
+    if invite.use_count >= invite.max_uses:
+        raise BadRequestException("This invite has already been used the maximum number of times")
+    return invite
+
+
+async def _create_session(
+    user_id: str,
+    ip_address: str,
+    user_agent: str,
+    db: Session,
+) -> tuple[str, str]:
+    """Create Redis + DB session for a user. Returns (access_token, refresh_token)."""
+    from computor_backend.utils.token_hash import generate_token, hash_token, hash_token_binary
+    from computor_backend.utils.client_info import make_device_label
+    from computor_backend.repositories.session_repo import SessionRepository
+    from computor_backend.redis_cache import get_redis_client
+    from computor_backend.model.auth import Session as SessionModel
+    from computor_backend.business_logic.auth import ACCESS_TOKEN_TTL, REFRESH_TOKEN_TTL
+
+    access_token = generate_token(32)
+    refresh_token = generate_token(32)
+    access_token_hash = hash_token(access_token)
+    refresh_token_hash_binary = hash_token_binary(refresh_token)
+
+    redis_client = await get_redis_client()
+    now = datetime.now(timezone.utc)
+
+    await redis_client.set(
+        f"sso_session:{access_token_hash}",
+        json.dumps({"user_id": user_id, "provider": "local", "created_at": str(now), "token_type": "access"}),
+        ex=ACCESS_TOKEN_TTL,
+    )
+    await redis_client.set(
+        f"refresh_token:{hash_token(refresh_token)}",
+        json.dumps({
+            "user_id": user_id,
+            "provider": "local",
+            "created_at": str(now),
+            "expires_at": str(now + timedelta(seconds=REFRESH_TOKEN_TTL)),
+            "token_type": "refresh",
+            "access_token_hash": access_token_hash,
+        }),
+        ex=REFRESH_TOKEN_TTL,
+    )
+
+    session_repo = SessionRepository(db, SessionModel, None)
+    session_repo.create(SessionModel(
+        user_id=user_id,
+        session_id=access_token_hash,
+        refresh_token_hash=refresh_token_hash_binary,
+        created_ip=ip_address,
+        last_ip=ip_address,
+        user_agent=user_agent,
+        device_label=make_device_label(user_agent),
+        expires_at=now + timedelta(seconds=ACCESS_TOKEN_TTL),
+        refresh_expires_at=now + timedelta(seconds=REFRESH_TOKEN_TTL),
+        properties={"provider": "local", "login_method": "invite"},
+    ))
+
+    return access_token, refresh_token
+
+
+def _set_auth_cookies(response: Response, access_token: str, refresh_token: str) -> None:
+    response.set_cookie(key="ct_access_token", value=access_token, httponly=True, secure=False, samesite="lax", max_age=3600)
+    response.set_cookie(key="ct_refresh_token", value=refresh_token, httponly=True, secure=False, samesite="lax", max_age=604800)
+
+
+def _to_get(invite: InviteLink) -> InviteLinkGet:
+    return InviteLinkGet(
+        id=str(invite.id),
+        token=invite.token,
+        created_by=str(invite.created_by) if invite.created_by else None,
+        email=invite.email,
+        max_uses=invite.max_uses,
+        use_count=invite.use_count,
+        expires_at=invite.expires_at,
+        roles=invite.roles or [],
+        note=invite.note,
+        revoked_at=invite.revoked_at,
+        created_at=invite.created_at,
+        updated_at=invite.updated_at,
+    )
+
+
+def _to_list(invite: InviteLink) -> InviteLinkList:
+    return InviteLinkList(
+        id=str(invite.id),
+        token=invite.token,
+        email=invite.email,
+        max_uses=invite.max_uses,
+        use_count=invite.use_count,
+        expires_at=invite.expires_at,
+        roles=invite.roles or [],
+        note=invite.note,
+        revoked_at=invite.revoked_at,
+        created_at=invite.created_at,
+    )

--- a/computor-backend/src/computor_backend/model/__init__.py
+++ b/computor-backend/src/computor_backend/model/__init__.py
@@ -27,6 +27,7 @@ from .extension import Extension, ExtensionVersion
 from .deployment import CourseContentDeployment, DeploymentHistory
 from .artifact import SubmissionArtifact, ResultArtifact, SubmissionGrade, SubmissionReview
 from .service import Service, ServiceType, ApiToken
+from .invite import InviteLink
 
 # Import all models to ensure relationships are properly set up
 from . import (
@@ -44,6 +45,7 @@ from . import (
     deployment,
     artifact,
     service,
+    invite,
 )
 
 __all__ = [
@@ -110,4 +112,6 @@ __all__ = [
     'Service',
     'ServiceType',
     'ApiToken',
+    # Invite link
+    'InviteLink',
 ]

--- a/computor-backend/src/computor_backend/model/invite.py
+++ b/computor-backend/src/computor_backend/model/invite.py
@@ -1,0 +1,31 @@
+import secrets
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, ForeignKey, Integer, String, Text, text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class InviteLink(Base):
+    __tablename__ = 'invite_link'
+
+    id = Column(UUID, primary_key=True, server_default=text("uuid_generate_v4()"))
+    version = Column(BigInteger, server_default=text("0"))
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    created_by = Column(ForeignKey('user.id', ondelete='SET NULL'), nullable=True, index=True)
+
+    token = Column(String(64), nullable=False, unique=True, index=True)
+    email = Column(String(320), nullable=True)  # if set, only this email may accept
+    max_uses = Column(Integer, nullable=False, server_default=text("1"))
+    use_count = Column(Integer, nullable=False, server_default=text("0"))
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    roles = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))  # list of role_ids
+    note = Column(Text, nullable=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+    creator = relationship('User', foreign_keys=[created_by])
+
+    @staticmethod
+    def generate_token() -> str:
+        return secrets.token_urlsafe(32)

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -302,6 +302,9 @@ def _guard_no_archive_admin(entity, permissions, db):
 _user_router = CrudRouter(UserInterface)
 _user_router.pre_archive.append(_guard_no_archive_admin)
 _user_router.register_routes(app)
+# accounts_router must be registered before CrudRouter(AccountInterface) so that
+# GET /accounts/providers is matched before the authenticated GET /accounts/{id} route.
+app.include_router(accounts_router, tags=["accounts"])
 CrudRouter(AccountInterface).register_routes(app)
 CrudRouter(GroupInterface).register_routes(app)
 # ProfileInterface and StudentProfileInterface use custom routers for fine-grained permissions
@@ -475,11 +478,6 @@ app.include_router(
 app.include_router(
     invites_router,
     tags=["invites", "user-management"]
-)
-
-app.include_router(
-    accounts_router,
-    tags=["accounts"]
 )
 
 app.include_router(

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -287,7 +287,20 @@ app.add_middleware(
     expose_headers=["X-Total-Count"],
 )
 
-CrudRouter(UserInterface).register_routes(app)
+def _guard_no_archive_admin(entity, permissions, db):
+    """Prevent archiving a user who holds the _admin role."""
+    from computor_backend.model.role import UserRole
+    from computor_backend.exceptions import ForbiddenException
+    is_admin_target = db.query(UserRole).filter(
+        UserRole.user_id == entity.id,
+        UserRole.role_id == "_admin",
+    ).first() is not None
+    if is_admin_target:
+        raise ForbiddenException("Admin users cannot be archived")
+
+_user_router = CrudRouter(UserInterface)
+_user_router.pre_archive.append(_guard_no_archive_admin)
+_user_router.register_routes(app)
 CrudRouter(AccountInterface).register_routes(app)
 CrudRouter(GroupInterface).register_routes(app)
 # ProfileInterface and StudentProfileInterface use custom routers for fine-grained permissions

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -77,6 +77,7 @@ from computor_backend.api.course_member_gradings import course_member_gradings_r
 from computor_backend.api.workspace_roles import workspace_roles_router
 from computor_backend.api.maintenance import maintenance_router
 from computor_backend.api.invites import invites_router
+from computor_backend.api.accounts import accounts_router
 from computor_backend.api.documents import documents_router
 from computor_backend.exceptions import register_exception_handlers
 from computor_backend.websocket.router import ws_router
@@ -474,6 +475,11 @@ app.include_router(
 app.include_router(
     invites_router,
     tags=["invites", "user-management"]
+)
+
+app.include_router(
+    accounts_router,
+    tags=["accounts"]
 )
 
 app.include_router(

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -76,6 +76,7 @@ from computor_backend.api.course_member_import import course_member_import_route
 from computor_backend.api.course_member_gradings import course_member_gradings_router
 from computor_backend.api.workspace_roles import workspace_roles_router
 from computor_backend.api.maintenance import maintenance_router
+from computor_backend.api.invites import invites_router
 from computor_backend.api.documents import documents_router
 from computor_backend.exceptions import register_exception_handlers
 from computor_backend.websocket.router import ws_router
@@ -455,6 +456,11 @@ app.include_router(
 app.include_router(
     auth_router,
     tags=["authentication", "sso"]
+)
+
+app.include_router(
+    invites_router,
+    tags=["invites", "user-management"]
 )
 
 app.include_router(

--- a/computor-types/src/computor_types/invites.py
+++ b/computor-types/src/computor_types/invites.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+from typing import Optional, List
+from pydantic import BaseModel, Field, field_validator
+import re
+
+
+class InviteLinkCreate(BaseModel):
+    email: Optional[str] = Field(None, description="If set, only this email may accept the invite")
+    max_uses: int = Field(1, ge=1, le=100, description="Maximum number of times this invite can be used")
+    expires_in_days: int = Field(7, ge=1, le=365, description="Number of days until the invite expires")
+    roles: List[str] = Field(default_factory=list, description="Role IDs to assign to the user on acceptance")
+    note: Optional[str] = Field(None, max_length=255, description="Admin label for this invite")
+
+
+class InviteLinkGet(BaseModel):
+    id: str
+    token: str
+    created_by: Optional[str] = None
+    email: Optional[str] = None
+    max_uses: int
+    use_count: int
+    expires_at: datetime
+    roles: List[str] = []
+    note: Optional[str] = None
+    revoked_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True}
+
+
+class InviteLinkList(BaseModel):
+    id: str
+    token: str
+    email: Optional[str] = None
+    max_uses: int
+    use_count: int
+    expires_at: datetime
+    roles: List[str] = []
+    note: Optional[str] = None
+    revoked_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True}
+
+
+class InviteLinkPublic(BaseModel):
+    """Invite info visible to unauthenticated users (no token, no creator details)."""
+    id: str
+    email: Optional[str] = None  # null if no restriction, otherwise the restricted email
+    roles: List[str] = []
+    expires_at: datetime
+    note: Optional[str] = None
+
+
+class InviteAccept(BaseModel):
+    username: str = Field(..., min_length=2, max_length=50)
+    given_name: str = Field(..., min_length=1, max_length=100)
+    family_name: str = Field(..., min_length=1, max_length=100)
+    email: str = Field(..., description="Required; must match invite restriction if set")
+    password: str = Field(..., min_length=8)
+    confirm_password: str
+
+    @field_validator('username')
+    @classmethod
+    def username_valid(cls, v: str) -> str:
+        if not re.match(r'^[a-zA-Z0-9_\-\.]+$', v):
+            raise ValueError("Username may only contain letters, digits, underscores, hyphens, and dots")
+        return v
+
+    @field_validator('email')
+    @classmethod
+    def email_valid(cls, v: str) -> str:
+        if '@' not in v or ' ' in v:
+            raise ValueError("Invalid email address")
+        return v.lower().strip()

--- a/computor-web/app/admin/users/invites/page.tsx
+++ b/computor-web/app/admin/users/invites/page.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import AuthenticatedLayout from '@/src/components/AuthenticatedLayout';
+import { useAuth } from '@/src/contexts/AuthContext';
+import { InvitesClient, InviteLinkList, InviteLinkCreate } from '@/src/generated/clients/InvitesClient';
+
+const invitesClient = new InvitesClient();
+
+const SYSTEM_ROLES = ['_admin', '_user_manager', '_organization_manager', '_workspace_user', '_workspace_maintainer'];
+
+const BASE_URL = typeof window !== 'undefined' ? window.location.origin : '';
+
+function StatusBadge({ invite }: { invite: InviteLinkList }) {
+  const now = new Date();
+  const expired = new Date(invite.expires_at) < now;
+  const revoked = !!invite.revoked_at;
+  const exhausted = invite.use_count >= invite.max_uses;
+
+  if (revoked) return <span className="px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">Revoked</span>;
+  if (expired) return <span className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">Expired</span>;
+  if (exhausted) return <span className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">Used</span>;
+  return <span className="px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">Active</span>;
+}
+
+interface CreateModal {
+  open: boolean;
+  email: string;
+  maxUses: number;
+  expiresInDays: number;
+  roles: string[];
+  note: string;
+  saving: boolean;
+  error: string | null;
+}
+
+export default function InvitesPage() {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const [invites, setInvites] = useState<InviteLinkList[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notification, setNotification] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [revokeConfirm, setRevokeConfirm] = useState<string | null>(null);
+
+  const [createModal, setCreateModal] = useState<CreateModal>({
+    open: false, email: '', maxUses: 1, expiresInDays: 7, roles: [], note: '', saving: false, error: null,
+  });
+
+  const isAdmin = user?.role === 'admin';
+  const isUserManager = isAdmin || (user?.systemRoles?.includes('_user_manager') ?? false);
+
+  const notify = (message: string, type: 'success' | 'error') => {
+    setNotification({ message, type });
+    setTimeout(() => setNotification(null), 4000);
+  };
+
+  const fetchInvites = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await invitesClient.listInvites();
+      setInvites(data);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load invites');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading || !isAuthenticated || !isUserManager) return;
+    fetchInvites();
+  }, [authLoading, isAuthenticated, isUserManager, fetchInvites]);
+
+  if (authLoading) return <AuthenticatedLayout><div className="p-8 text-gray-500">Loading…</div></AuthenticatedLayout>;
+  if (!isAuthenticated || !isUserManager) {
+    return (
+      <AuthenticatedLayout>
+        <div className="p-8 text-red-600 font-medium">Access denied. Requires admin or _user_manager role.</div>
+      </AuthenticatedLayout>
+    );
+  }
+
+  const inviteUrl = (token: string) => `${BASE_URL}/invite/${token}`;
+
+  const handleCopy = (id: string, token: string) => {
+    navigator.clipboard.writeText(inviteUrl(token)).then(() => {
+      setCopiedId(id);
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+  };
+
+  const handleCreate = async () => {
+    setCreateModal(m => ({ ...m, saving: true, error: null }));
+    try {
+      const payload: InviteLinkCreate = {
+        email: createModal.email.trim() || undefined,
+        max_uses: createModal.maxUses,
+        expires_in_days: createModal.expiresInDays,
+        roles: createModal.roles,
+        note: createModal.note.trim() || undefined,
+      };
+      await invitesClient.createInvite(payload);
+      setCreateModal(m => ({ ...m, open: false, email: '', maxUses: 1, expiresInDays: 7, roles: [], note: '', saving: false }));
+      notify('Invite link created', 'success');
+      fetchInvites();
+    } catch (e) {
+      setCreateModal(m => ({ ...m, error: e instanceof Error ? e.message : 'Failed to create invite', saving: false }));
+    }
+  };
+
+  const handleRevoke = async (id: string) => {
+    try {
+      await invitesClient.revokeInvite(id);
+      notify('Invite revoked', 'success');
+      fetchInvites();
+    } catch (e) {
+      notify(e instanceof Error ? e.message : 'Failed to revoke invite', 'error');
+    }
+    setRevokeConfirm(null);
+  };
+
+  return (
+    <AuthenticatedLayout>
+      <div className="p-6">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Invite Links</h1>
+            <p className="text-sm text-gray-500 mt-1">Create one-time links to onboard new users without GitLab PAT</p>
+          </div>
+          <button
+            onClick={() => setCreateModal(m => ({ ...m, open: true }))}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+          >
+            + New Invite
+          </button>
+        </div>
+
+        {notification && (
+          <div className={`mb-4 px-4 py-3 rounded-lg text-sm ${notification.type === 'success' ? 'bg-green-50 text-green-800 border border-green-200' : 'bg-red-50 text-red-800 border border-red-200'}`}>
+            {notification.message}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-gray-500 py-8 text-center">Loading…</div>
+        ) : error ? (
+          <div className="text-red-600 py-8 text-center">{error}</div>
+        ) : (
+          <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Note / Email</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Uses</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Expires</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Roles</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {invites.map(inv => (
+                  <tr key={inv.id}>
+                    <td className="px-4 py-3">
+                      <div className="text-sm font-medium text-gray-900">{inv.note || <span className="text-gray-400 italic">No note</span>}</div>
+                      {inv.email && <div className="text-xs text-gray-500">Restricted to: {inv.email}</div>}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600">{inv.use_count} / {inv.max_uses}</td>
+                    <td className="px-4 py-3 text-sm text-gray-600">{new Date(inv.expires_at).toLocaleDateString()}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {inv.roles.length > 0
+                          ? inv.roles.map(r => (
+                              <span key={r} className="px-1.5 py-0.5 rounded text-xs bg-blue-50 text-blue-700">{r}</span>
+                            ))
+                          : <span className="text-xs text-gray-400">None</span>
+                        }
+                      </div>
+                    </td>
+                    <td className="px-4 py-3"><StatusBadge invite={inv} /></td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex justify-end gap-1">
+                        <button
+                          onClick={() => handleCopy(inv.id, inv.token)}
+                          className="px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                        >
+                          {copiedId === inv.id ? 'Copied!' : 'Copy Link'}
+                        </button>
+                        {!inv.revoked_at && (
+                          <button
+                            onClick={() => setRevokeConfirm(inv.id)}
+                            className="px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded transition-colors"
+                          >
+                            Revoke
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                {invites.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500">No invite links yet. Create one to get started.</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Create Modal */}
+      {createModal.open && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-md mx-4">
+            <div className="p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">New Invite Link</h2>
+              {createModal.error && (
+                <div className="mb-3 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700">{createModal.error}</div>
+              )}
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1">
+                    Restrict to email <span className="text-gray-400 font-normal">(optional — leave empty to allow any email)</span>
+                  </label>
+                  <input
+                    type="email"
+                    placeholder="student@example.com"
+                    value={createModal.email}
+                    onChange={e => setCreateModal(m => ({ ...m, email: e.target.value }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">Expires in (days)</label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={365}
+                      value={createModal.expiresInDays}
+                      onChange={e => setCreateModal(m => ({ ...m, expiresInDays: parseInt(e.target.value) || 7 }))}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">Max uses</label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={100}
+                      value={createModal.maxUses}
+                      onChange={e => setCreateModal(m => ({ ...m, maxUses: parseInt(e.target.value) || 1 }))}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1">Note <span className="text-gray-400 font-normal">(optional)</span></label>
+                  <input
+                    type="text"
+                    placeholder="e.g. WS2024 students"
+                    value={createModal.note}
+                    onChange={e => setCreateModal(m => ({ ...m, note: e.target.value }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-2">Auto-assign roles on acceptance</label>
+                  <div className="flex flex-wrap gap-2">
+                    {SYSTEM_ROLES.map(r => (
+                      <label key={r} className="flex items-center gap-1 text-xs cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={createModal.roles.includes(r)}
+                          onChange={e => setCreateModal(m => ({
+                            ...m,
+                            roles: e.target.checked ? [...m.roles, r] : m.roles.filter(x => x !== r),
+                          }))}
+                        />
+                        {r}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="px-6 py-4 bg-gray-50 rounded-b-xl flex justify-end gap-2">
+              <button
+                onClick={() => setCreateModal(m => ({ ...m, open: false, error: null }))}
+                className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleCreate}
+                disabled={createModal.saving}
+                className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              >
+                {createModal.saving ? 'Creating…' : 'Create Invite'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Revoke Confirm */}
+      {revokeConfirm && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">Revoke Invite?</h2>
+            <p className="text-sm text-gray-600 mb-4">This link will immediately stop working.</p>
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setRevokeConfirm(null)} className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">Cancel</button>
+              <button onClick={() => handleRevoke(revokeConfirm)} className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700">Revoke</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </AuthenticatedLayout>
+  );
+}

--- a/computor-web/app/admin/users/page.tsx
+++ b/computor-web/app/admin/users/page.tsx
@@ -54,6 +54,7 @@ export default function UsersPage() {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
   const [users, setUsers] = useState<UserList[]>([]);
   const [search, setSearch] = useState('');
+  const [showArchived, setShowArchived] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [notification, setNotification] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
@@ -74,11 +75,12 @@ export default function UsersPage() {
     user: UserList | null;
     accounts: AccountList[];
     loading: boolean;
-    addingProvider: string | null;  // provider id being added, or null
+    addingProvider: string | null;
+    providerUrl: string;
     accountId: string;
     saving: boolean;
     error: string | null;
-  }>({ open: false, user: null, accounts: [], loading: false, addingProvider: null, accountId: '', saving: false, error: null });
+  }>({ open: false, user: null, accounts: [], loading: false, addingProvider: null, providerUrl: '', accountId: '', saving: false, error: null });
 
   const [providers, setProviders] = useState<AccountProvider[]>([]);
 
@@ -95,6 +97,7 @@ export default function UsersPage() {
     try {
       const data = await usersClient.listUsersUsersGet({
         username: search || undefined,
+        archived: showArchived ? true : undefined,
         limit: 200,
       });
       setUsers(data);
@@ -104,7 +107,7 @@ export default function UsersPage() {
     } finally {
       setLoading(false);
     }
-  }, [search]);
+  }, [search, showArchived]);
 
   useEffect(() => {
     if (authLoading || !isAuthenticated) return;
@@ -221,7 +224,7 @@ export default function UsersPage() {
   };
 
   const openAccountsModal = async (u: UserList) => {
-    setAccountsModal(m => ({ ...m, open: true, user: u, accounts: [], loading: true, addingProvider: null, accountId: '', error: null }));
+    setAccountsModal(m => ({ ...m, open: true, user: u, accounts: [], loading: true, addingProvider: null, providerUrl: '', accountId: '', error: null }));
     try {
       const data = await accountsClient.listAccountsAccountsGet({ userId: u.id, limit: 100 });
       setAccountsModal(m => ({ ...m, accounts: data, loading: false }));
@@ -231,17 +234,17 @@ export default function UsersPage() {
   };
 
   const handleAddAccount = async () => {
-    const { user: u, addingProvider, accountId } = accountsModal;
-    if (!u || !addingProvider || !accountId.trim()) return;
+    const { user: u, addingProvider, providerUrl, accountId } = accountsModal;
+    if (!u || !addingProvider || !providerUrl.trim() || !accountId.trim()) return;
     const prov = providers.find(p => p.id === addingProvider);
     if (!prov) return;
     setAccountsModal(m => ({ ...m, saving: true, error: null }));
     try {
       await accountsClient.createAccountsAccountsPost({
-        body: { provider: prov.provider, type: prov.type, provider_account_id: accountId.trim(), user_id: u.id },
+        body: { provider: providerUrl.trim(), type: prov.type, provider_account_id: accountId.trim(), user_id: u.id },
       });
       const data = await accountsClient.listAccountsAccountsGet({ userId: u.id, limit: 100 });
-      setAccountsModal(m => ({ ...m, accounts: data, addingProvider: null, accountId: '', saving: false }));
+      setAccountsModal(m => ({ ...m, accounts: data, addingProvider: null, providerUrl: '', accountId: '', saving: false }));
       notify('Account linked', 'success');
     } catch (e) {
       setAccountsModal(m => ({ ...m, error: e instanceof Error ? e.message : 'Failed to add account', saving: false }));
@@ -290,8 +293,8 @@ export default function UsersPage() {
           </div>
         )}
 
-        {/* Search */}
-        <div className="mb-4">
+        {/* Search + filters */}
+        <div className="mb-4 flex items-center gap-3">
           <input
             type="text"
             placeholder="Search by username or email…"
@@ -299,6 +302,15 @@ export default function UsersPage() {
             onChange={e => setSearch(e.target.value)}
             className="w-full max-w-md px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           />
+          <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none whitespace-nowrap">
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={e => setShowArchived(e.target.checked)}
+              className="rounded"
+            />
+            Show archived
+          </label>
         </div>
 
         {/* Table */}
@@ -564,7 +576,7 @@ export default function UsersPage() {
                     {providers.map(p => (
                       <button
                         key={p.id}
-                        onClick={() => setAccountsModal(m => ({ ...m, addingProvider: p.id, accountId: '', error: null }))}
+                        onClick={() => setAccountsModal(m => ({ ...m, addingProvider: p.id, providerUrl: p.provider, accountId: '', error: null }))}
                         className="px-3 py-1.5 text-xs border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
                       >
                         + {p.display_name}
@@ -575,28 +587,40 @@ export default function UsersPage() {
                   const prov = providers.find(p => p.id === accountsModal.addingProvider)!;
                   return (
                     <div className="space-y-2">
-                      <label className="block text-xs font-medium text-gray-700">{prov.field_label}</label>
-                      <div className="flex gap-2">
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">Provider URL</label>
+                        <input
+                          type="text"
+                          placeholder="e.g. gitlab.com or gitlab.mycompany.com"
+                          value={accountsModal.providerUrl}
+                          onChange={e => setAccountsModal(m => ({ ...m, providerUrl: e.target.value }))}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                          autoFocus
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 mb-1">{prov.field_label}</label>
                         <input
                           type="text"
                           placeholder={prov.placeholder}
                           value={accountsModal.accountId}
                           onChange={e => setAccountsModal(m => ({ ...m, accountId: e.target.value }))}
-                          className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-                          autoFocus
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
                         />
+                      </div>
+                      <div className="flex justify-end gap-2 pt-1">
                         <button
-                          onClick={handleAddAccount}
-                          disabled={accountsModal.saving || !accountsModal.accountId.trim()}
-                          className="px-3 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
-                        >
-                          {accountsModal.saving ? '…' : 'Add'}
-                        </button>
-                        <button
-                          onClick={() => setAccountsModal(m => ({ ...m, addingProvider: null, accountId: '' }))}
+                          onClick={() => setAccountsModal(m => ({ ...m, addingProvider: null, providerUrl: '', accountId: '' }))}
                           className="px-3 py-2 text-sm text-gray-500 hover:bg-gray-100 rounded-lg"
                         >
                           Cancel
+                        </button>
+                        <button
+                          onClick={handleAddAccount}
+                          disabled={accountsModal.saving || !accountsModal.providerUrl.trim() || !accountsModal.accountId.trim()}
+                          className="px-3 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+                        >
+                          {accountsModal.saving ? '…' : 'Add'}
                         </button>
                       </div>
                     </div>

--- a/computor-web/app/admin/users/page.tsx
+++ b/computor-web/app/admin/users/page.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import AuthenticatedLayout from '@/src/components/AuthenticatedLayout';
+import { useAuth } from '@/src/contexts/AuthContext';
+import { UsersClient } from '@/src/generated/clients/UsersClient';
+import { RolesClient } from '@/src/generated/clients/RolesClient';
+import type { UserList, UserGet, UserCreate, RoleList } from 'types/generated';
+
+const usersClient = new UsersClient();
+const rolesClient = new RolesClient();
+
+const SYSTEM_ROLES = ['_admin', '_user_manager', '_organization_manager', '_workspace_user', '_workspace_maintainer'];
+
+function RoleBadge({ roleId }: { roleId: string }) {
+  const colors: Record<string, string> = {
+    '_admin': 'bg-red-100 text-red-800',
+    '_user_manager': 'bg-purple-100 text-purple-800',
+    '_organization_manager': 'bg-blue-100 text-blue-800',
+    '_workspace_maintainer': 'bg-orange-100 text-orange-800',
+    '_workspace_user': 'bg-green-100 text-green-800',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${colors[roleId] ?? 'bg-gray-100 text-gray-700'}`}>
+      {roleId}
+    </span>
+  );
+}
+
+interface CreateUserModal {
+  open: boolean;
+  username: string;
+  email: string;
+  givenName: string;
+  familyName: string;
+  roles: string[];
+  error: string | null;
+  saving: boolean;
+}
+
+interface RolesModal {
+  open: boolean;
+  user: UserGet | null;
+  selectedRoles: string[];
+  saving: boolean;
+  error: string | null;
+}
+
+export default function UsersPage() {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const [users, setUsers] = useState<UserList[]>([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notification, setNotification] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+  const [allRoles, setAllRoles] = useState<RoleList[]>([]);
+
+  const [createModal, setCreateModal] = useState<CreateUserModal>({
+    open: false, username: '', email: '', givenName: '', familyName: '', roles: [], error: null, saving: false,
+  });
+
+  const [rolesModal, setRolesModal] = useState<RolesModal>({
+    open: false, user: null, selectedRoles: [], saving: false, error: null,
+  });
+
+  const [resetConfirm, setResetConfirm] = useState<{ open: boolean; userId: string; username: string } | null>(null);
+
+  const isAdmin = user?.role === 'admin';
+  const isUserManager = isAdmin || (user?.systemRoles?.includes('_user_manager') ?? false);
+
+  const notify = (message: string, type: 'success' | 'error') => {
+    setNotification({ message, type });
+    setTimeout(() => setNotification(null), 4000);
+  };
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await usersClient.listUsersUsersGet({
+        username: search || undefined,
+        limit: 200,
+      });
+      setUsers(data);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load users');
+    } finally {
+      setLoading(false);
+    }
+  }, [search]);
+
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) return;
+    if (!isUserManager) return;
+    fetchUsers();
+    rolesClient.listRolesRolesGet({ builtin: true }).then(setAllRoles).catch(() => {});
+  }, [authLoading, isAuthenticated, isUserManager, fetchUsers]);
+
+  // Guard
+  if (authLoading) return <AuthenticatedLayout><div className="p-8 text-gray-500">Loading…</div></AuthenticatedLayout>;
+  if (!isAuthenticated || !isUserManager) {
+    return (
+      <AuthenticatedLayout>
+        <div className="p-8 text-red-600 font-medium">Access denied. Requires admin or _user_manager role.</div>
+      </AuthenticatedLayout>
+    );
+  }
+
+  const handleCreateUser = async () => {
+    setCreateModal(m => ({ ...m, error: null, saving: true }));
+    try {
+      const payload: UserCreate = {
+        username: createModal.username,
+        email: createModal.email,
+        given_name: createModal.givenName || undefined,
+        family_name: createModal.familyName || undefined,
+      };
+      const created = await usersClient.createUsersUsersPost({ body: payload });
+
+      // Assign roles
+      for (const roleId of createModal.roles) {
+        await fetch(`/api/user-roles-proxy?user_id=${created.id}&role_id=${roleId}`, { method: 'POST' }).catch(() => {});
+      }
+
+      setCreateModal(m => ({ ...m, open: false, username: '', email: '', givenName: '', familyName: '', roles: [], saving: false }));
+      notify(`User ${created.username} created`, 'success');
+      fetchUsers();
+    } catch (e) {
+      setCreateModal(m => ({ ...m, error: e instanceof Error ? e.message : 'Failed to create user', saving: false }));
+    }
+  };
+
+  const handleArchiveToggle = async (u: UserList) => {
+    try {
+      if (u.archived_at) {
+        await usersClient.unarchiveUsersUsersIdUnarchivePatch({ id: u.id });
+        notify(`${u.username} unarchived`, 'success');
+      } else {
+        await usersClient.routeUsersUsersIdArchivePatch({ id: u.id });
+        notify(`${u.username} archived`, 'success');
+      }
+      fetchUsers();
+    } catch (e) {
+      notify(e instanceof Error ? e.message : 'Operation failed', 'error');
+    }
+  };
+
+  const openRolesModal = async (u: UserList) => {
+    try {
+      const full = await usersClient.getUsersUsersIdGet({ id: u.id });
+      const currentRoleIds = (full.user_roles ?? []).map(r => r.role_id);
+      setRolesModal({ open: true, user: full, selectedRoles: currentRoleIds, saving: false, error: null });
+    } catch (e) {
+      notify('Failed to load user roles', 'error');
+    }
+  };
+
+  const handleSaveRoles = async () => {
+    if (!rolesModal.user) return;
+    setRolesModal(m => ({ ...m, saving: true, error: null }));
+    const userId = rolesModal.user.id;
+    const current = (rolesModal.user.user_roles ?? []).map(r => r.role_id);
+    const toAdd = rolesModal.selectedRoles.filter(r => !current.includes(r));
+    const toRemove = current.filter(r => !rolesModal.selectedRoles.includes(r));
+    try {
+      for (const roleId of toAdd) {
+        await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/user-roles`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ user_id: userId, role_id: roleId }),
+        });
+      }
+      for (const roleId of toRemove) {
+        await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/user-roles/users/${userId}/roles/${roleId}`, {
+          method: 'DELETE',
+          credentials: 'include',
+        });
+      }
+      setRolesModal(m => ({ ...m, open: false, user: null, saving: false }));
+      notify('Roles updated', 'success');
+      fetchUsers();
+    } catch (e) {
+      setRolesModal(m => ({ ...m, error: e instanceof Error ? e.message : 'Failed to update roles', saving: false }));
+    }
+  };
+
+  const handleResetPassword = async (userId: string) => {
+    try {
+      const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+      const res = await fetch(`${API}/password/reset`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: userId, manager_password: '' }),
+      });
+      if (!res.ok) throw new Error('Failed');
+      notify('Password reset — user must set a new password', 'success');
+    } catch {
+      notify('Failed to reset password', 'error');
+    }
+    setResetConfirm(null);
+  };
+
+  const filtered = users.filter(u =>
+    !search ||
+    u.username?.toLowerCase().includes(search.toLowerCase()) ||
+    u.email?.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <AuthenticatedLayout>
+      <div className="p-6">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+            <p className="text-sm text-gray-500 mt-1">{users.length} total</p>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setCreateModal(m => ({ ...m, open: true }))}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+            >
+              + Create User
+            </button>
+          </div>
+        </div>
+
+        {/* Notification */}
+        {notification && (
+          <div className={`mb-4 px-4 py-3 rounded-lg text-sm ${notification.type === 'success' ? 'bg-green-50 text-green-800 border border-green-200' : 'bg-red-50 text-red-800 border border-red-200'}`}>
+            {notification.message}
+          </div>
+        )}
+
+        {/* Search */}
+        <div className="mb-4">
+          <input
+            type="text"
+            placeholder="Search by username or email…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="w-full max-w-md px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+
+        {/* Table */}
+        {loading ? (
+          <div className="text-gray-500 py-8 text-center">Loading users…</div>
+        ) : error ? (
+          <div className="text-red-600 py-8 text-center">{error}</div>
+        ) : (
+          <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {filtered.map(u => (
+                  <tr key={u.id} className={u.archived_at ? 'opacity-50' : ''}>
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-gray-900 text-sm">{u.username}</div>
+                      <div className="text-xs text-gray-500">{u.given_name} {u.family_name}</div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600">{u.email ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${u.archived_at ? 'bg-gray-100 text-gray-600' : 'bg-green-100 text-green-800'}`}>
+                        {u.archived_at ? 'Archived' : 'Active'}
+                      </span>
+                      {u.is_service && (
+                        <span className="ml-1 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800">Service</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-500">
+                      {u.created_at ? new Date(u.created_at).toLocaleDateString() : '—'}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex justify-end gap-1">
+                        <button
+                          onClick={() => openRolesModal(u)}
+                          className="px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                        >
+                          Roles
+                        </button>
+                        <button
+                          onClick={() => handleArchiveToggle(u)}
+                          className="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded transition-colors"
+                        >
+                          {u.archived_at ? 'Unarchive' : 'Archive'}
+                        </button>
+                        {isAdmin && (
+                          <button
+                            onClick={() => setResetConfirm({ open: true, userId: u.id, username: u.username ?? '' })}
+                            className="px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded transition-colors"
+                          >
+                            Reset PW
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                {filtered.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">No users found</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Create User Modal */}
+      {createModal.open && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-md mx-4">
+            <div className="p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">Create User</h2>
+              {createModal.error && (
+                <div className="mb-3 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700">{createModal.error}</div>
+              )}
+              <div className="space-y-3">
+                {[
+                  { label: 'Username *', key: 'username', placeholder: 'john.doe' },
+                  { label: 'Email *', key: 'email', placeholder: 'john@example.com' },
+                  { label: 'Given Name', key: 'givenName', placeholder: 'John' },
+                  { label: 'Family Name', key: 'familyName', placeholder: 'Doe' },
+                ].map(f => (
+                  <div key={f.key}>
+                    <label className="block text-xs font-medium text-gray-700 mb-1">{f.label}</label>
+                    <input
+                      type="text"
+                      placeholder={f.placeholder}
+                      value={(createModal as any)[f.key]}
+                      onChange={e => setCreateModal(m => ({ ...m, [f.key]: e.target.value }))}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    />
+                  </div>
+                ))}
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1">Roles</label>
+                  <div className="flex flex-wrap gap-2">
+                    {SYSTEM_ROLES.map(r => (
+                      <label key={r} className="flex items-center gap-1 text-xs cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={createModal.roles.includes(r)}
+                          onChange={e => setCreateModal(m => ({
+                            ...m,
+                            roles: e.target.checked ? [...m.roles, r] : m.roles.filter(x => x !== r),
+                          }))}
+                        />
+                        {r}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-gray-500">User will have no password set. Send them an invite link to let them set one.</p>
+            </div>
+            <div className="px-6 py-4 bg-gray-50 rounded-b-xl flex justify-end gap-2">
+              <button
+                onClick={() => setCreateModal(m => ({ ...m, open: false, error: null }))}
+                className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleCreateUser}
+                disabled={createModal.saving || !createModal.username || !createModal.email}
+                className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"
+              >
+                {createModal.saving ? 'Creating…' : 'Create'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Roles Modal */}
+      {rolesModal.open && rolesModal.user && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-md mx-4">
+            <div className="p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-1">Roles for {rolesModal.user.username}</h2>
+              <p className="text-xs text-gray-500 mb-4">{rolesModal.user.email}</p>
+              {rolesModal.error && (
+                <div className="mb-3 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700">{rolesModal.error}</div>
+              )}
+              <div className="space-y-2">
+                {SYSTEM_ROLES.map(r => (
+                  <label key={r} className="flex items-center gap-2 text-sm cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={rolesModal.selectedRoles.includes(r)}
+                      onChange={e => setRolesModal(m => ({
+                        ...m,
+                        selectedRoles: e.target.checked
+                          ? [...m.selectedRoles, r]
+                          : m.selectedRoles.filter(x => x !== r),
+                      }))}
+                    />
+                    <RoleBadge roleId={r} />
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div className="px-6 py-4 bg-gray-50 rounded-b-xl flex justify-end gap-2">
+              <button
+                onClick={() => setRolesModal(m => ({ ...m, open: false, user: null }))}
+                className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSaveRoles}
+                disabled={rolesModal.saving}
+                className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"
+              >
+                {rolesModal.saving ? 'Saving…' : 'Save Roles'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Reset Password Confirm */}
+      {resetConfirm?.open && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">Reset Password?</h2>
+            <p className="text-sm text-gray-600 mb-4">
+              This will clear <strong>{resetConfirm.username}</strong>'s password. They will need to set a new one via invite link or admin.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setResetConfirm(null)} className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">Cancel</button>
+              <button
+                onClick={() => handleResetPassword(resetConfirm.userId)}
+                className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700"
+              >
+                Reset Password
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </AuthenticatedLayout>
+  );
+}

--- a/computor-web/app/admin/users/page.tsx
+++ b/computor-web/app/admin/users/page.tsx
@@ -68,7 +68,7 @@ export default function UsersPage() {
     open: false, user: null, selectedRoles: [], saving: false, error: null,
   });
 
-  const [resetConfirm, setResetConfirm] = useState<{ open: boolean; userId: string; username: string } | null>(null);
+  const [resetConfirm, setResetConfirm] = useState<{ open: boolean; userId: string; username: string; managerPassword: string } | null>(null);
   const [archiveConfirm, setArchiveConfirm] = useState<{ open: boolean; user: UserList } | null>(null);
 
   const [accountsModal, setAccountsModal] = useState<{
@@ -207,19 +207,22 @@ export default function UsersPage() {
     }
   };
 
-  const handleResetPassword = async (userId: string) => {
+  const handleResetPassword = async (userId: string, managerPassword: string) => {
     try {
       const API = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
       const res = await fetch(`${API}/password/reset`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ user_id: userId, manager_password: '' }),
+        body: JSON.stringify({ user_id: userId, manager_password: managerPassword }),
       });
-      if (!res.ok) throw new Error('Failed');
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message || 'Failed to reset password');
+      }
       notify('Password reset — user must set a new password', 'success');
-    } catch {
-      notify('Failed to reset password', 'error');
+    } catch (e) {
+      notify(e instanceof Error ? e.message : 'Failed to reset password', 'error');
     }
     setResetConfirm(null);
   };
@@ -372,7 +375,7 @@ export default function UsersPage() {
                         </button>
                         {isAdmin && (
                           <button
-                            onClick={() => setResetConfirm({ open: true, userId: u.id, username: u.username ?? '' })}
+                            onClick={() => setResetConfirm({ open: true, userId: u.id, username: u.username ?? '', managerPassword: '' })}
                             className="px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded transition-colors"
                           >
                             Reset PW
@@ -541,11 +544,24 @@ export default function UsersPage() {
             <p className="text-sm text-gray-600 mb-4">
               This will clear <strong>{resetConfirm.username}</strong>'s password. They will need to set a new one via invite link or admin.
             </p>
+            <div className="mb-4">
+              <label className="block text-xs font-medium text-gray-700 mb-1">Your password (to confirm)</label>
+              <input
+                type="password"
+                autoFocus
+                value={resetConfirm.managerPassword}
+                onChange={e => setResetConfirm(r => r ? { ...r, managerPassword: e.target.value } : r)}
+                onKeyDown={e => { if (e.key === 'Enter' && resetConfirm.managerPassword) handleResetPassword(resetConfirm.userId, resetConfirm.managerPassword); }}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                placeholder="Enter your password"
+              />
+            </div>
             <div className="flex justify-end gap-2">
               <button onClick={() => setResetConfirm(null)} className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">Cancel</button>
               <button
-                onClick={() => handleResetPassword(resetConfirm.userId)}
-                className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700"
+                onClick={() => handleResetPassword(resetConfirm.userId, resetConfirm.managerPassword)}
+                disabled={!resetConfirm.managerPassword}
+                className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
               >
                 Reset Password
               </button>

--- a/computor-web/app/admin/users/page.tsx
+++ b/computor-web/app/admin/users/page.tsx
@@ -5,10 +5,14 @@ import AuthenticatedLayout from '@/src/components/AuthenticatedLayout';
 import { useAuth } from '@/src/contexts/AuthContext';
 import { UsersClient } from '@/src/generated/clients/UsersClient';
 import { RolesClient } from '@/src/generated/clients/RolesClient';
-import type { UserList, UserGet, UserCreate, RoleList } from 'types/generated';
+import { AccountsClient } from '@/src/generated/clients/AccountsClient';
+import { AccountProvidersClient, AccountProvider } from '@/src/generated/clients/AccountProvidersClient';
+import type { UserList, UserGet, UserCreate, RoleList, AccountList } from 'types/generated';
 
 const usersClient = new UsersClient();
 const rolesClient = new RolesClient();
+const accountsClient = new AccountsClient();
+const accountProvidersClient = new AccountProvidersClient();
 
 const SYSTEM_ROLES = ['_admin', '_user_manager', '_organization_manager', '_workspace_user', '_workspace_maintainer'];
 
@@ -65,6 +69,19 @@ export default function UsersPage() {
 
   const [resetConfirm, setResetConfirm] = useState<{ open: boolean; userId: string; username: string } | null>(null);
 
+  const [accountsModal, setAccountsModal] = useState<{
+    open: boolean;
+    user: UserList | null;
+    accounts: AccountList[];
+    loading: boolean;
+    addingProvider: string | null;  // provider id being added, or null
+    accountId: string;
+    saving: boolean;
+    error: string | null;
+  }>({ open: false, user: null, accounts: [], loading: false, addingProvider: null, accountId: '', saving: false, error: null });
+
+  const [providers, setProviders] = useState<AccountProvider[]>([]);
+
   const isAdmin = user?.role === 'admin';
   const isUserManager = isAdmin || (user?.systemRoles?.includes('_user_manager') ?? false);
 
@@ -94,6 +111,7 @@ export default function UsersPage() {
     if (!isUserManager) return;
     fetchUsers();
     rolesClient.listRolesRolesGet({ builtin: true }).then(setAllRoles).catch(() => {});
+    accountProvidersClient.listProviders().then(setProviders).catch(() => {});
   }, [authLoading, isAuthenticated, isUserManager, fetchUsers]);
 
   // Guard
@@ -202,6 +220,44 @@ export default function UsersPage() {
     setResetConfirm(null);
   };
 
+  const openAccountsModal = async (u: UserList) => {
+    setAccountsModal(m => ({ ...m, open: true, user: u, accounts: [], loading: true, addingProvider: null, accountId: '', error: null }));
+    try {
+      const data = await accountsClient.listAccountsAccountsGet({ userId: u.id, limit: 100 });
+      setAccountsModal(m => ({ ...m, accounts: data, loading: false }));
+    } catch {
+      setAccountsModal(m => ({ ...m, loading: false, error: 'Failed to load accounts' }));
+    }
+  };
+
+  const handleAddAccount = async () => {
+    const { user: u, addingProvider, accountId } = accountsModal;
+    if (!u || !addingProvider || !accountId.trim()) return;
+    const prov = providers.find(p => p.id === addingProvider);
+    if (!prov) return;
+    setAccountsModal(m => ({ ...m, saving: true, error: null }));
+    try {
+      await accountsClient.createAccountsAccountsPost({
+        body: { provider: prov.provider, type: prov.type, provider_account_id: accountId.trim(), user_id: u.id },
+      });
+      const data = await accountsClient.listAccountsAccountsGet({ userId: u.id, limit: 100 });
+      setAccountsModal(m => ({ ...m, accounts: data, addingProvider: null, accountId: '', saving: false }));
+      notify('Account linked', 'success');
+    } catch (e) {
+      setAccountsModal(m => ({ ...m, error: e instanceof Error ? e.message : 'Failed to add account', saving: false }));
+    }
+  };
+
+  const handleDeleteAccount = async (accountId: string) => {
+    try {
+      await accountsClient.deleteAccountsAccountsIdDelete({ id: accountId });
+      setAccountsModal(m => ({ ...m, accounts: m.accounts.filter(a => a.id !== accountId) }));
+      notify('Account removed', 'success');
+    } catch {
+      notify('Failed to remove account', 'error');
+    }
+  };
+
   const filtered = users.filter(u =>
     !search ||
     u.username?.toLowerCase().includes(search.toLowerCase()) ||
@@ -288,6 +344,12 @@ export default function UsersPage() {
                           className="px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 rounded transition-colors"
                         >
                           Roles
+                        </button>
+                        <button
+                          onClick={() => openAccountsModal(u)}
+                          className="px-2 py-1 text-xs text-indigo-600 hover:bg-indigo-50 rounded transition-colors"
+                        >
+                          Accounts
                         </button>
                         <button
                           onClick={() => handleArchiveToggle(u)}
@@ -447,6 +509,108 @@ export default function UsersPage() {
                 className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700"
               >
                 Reset Password
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {/* Accounts Modal */}
+      {accountsModal.open && accountsModal.user && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-lg mx-4 flex flex-col max-h-[80vh]">
+            <div className="p-6 border-b border-gray-100">
+              <h2 className="text-lg font-semibold text-gray-900">Accounts — {accountsModal.user.username}</h2>
+              <p className="text-xs text-gray-500 mt-0.5">{accountsModal.user.email}</p>
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-6 space-y-4">
+              {accountsModal.error && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700">{accountsModal.error}</div>
+              )}
+
+              {/* Existing accounts */}
+              {accountsModal.loading ? (
+                <div className="text-sm text-gray-500">Loading accounts…</div>
+              ) : accountsModal.accounts.length === 0 ? (
+                <div className="text-sm text-gray-400 italic">No linked accounts yet.</div>
+              ) : (
+                <div className="space-y-2">
+                  {accountsModal.accounts.map(acc => {
+                    const prov = providers.find(p => p.provider === acc.provider && p.type === acc.type);
+                    return (
+                      <div key={acc.id} className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg border border-gray-200">
+                        <div>
+                          <span className="text-sm font-medium text-gray-900">{prov?.display_name ?? acc.provider}</span>
+                          <span className="mx-2 text-gray-300">·</span>
+                          <span className="text-sm text-gray-600">{acc.provider_account_id}</span>
+                        </div>
+                        <button
+                          onClick={() => handleDeleteAccount(acc.id)}
+                          className="text-xs text-red-500 hover:text-red-700 transition-colors"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Add account form */}
+              <div className="border-t border-gray-100 pt-4">
+                <p className="text-xs font-medium text-gray-700 mb-2">Link new account</p>
+                {accountsModal.addingProvider === null ? (
+                  <div className="flex flex-wrap gap-2">
+                    {providers.map(p => (
+                      <button
+                        key={p.id}
+                        onClick={() => setAccountsModal(m => ({ ...m, addingProvider: p.id, accountId: '', error: null }))}
+                        className="px-3 py-1.5 text-xs border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+                      >
+                        + {p.display_name}
+                      </button>
+                    ))}
+                  </div>
+                ) : (() => {
+                  const prov = providers.find(p => p.id === accountsModal.addingProvider)!;
+                  return (
+                    <div className="space-y-2">
+                      <label className="block text-xs font-medium text-gray-700">{prov.field_label}</label>
+                      <div className="flex gap-2">
+                        <input
+                          type="text"
+                          placeholder={prov.placeholder}
+                          value={accountsModal.accountId}
+                          onChange={e => setAccountsModal(m => ({ ...m, accountId: e.target.value }))}
+                          className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                          autoFocus
+                        />
+                        <button
+                          onClick={handleAddAccount}
+                          disabled={accountsModal.saving || !accountsModal.accountId.trim()}
+                          className="px-3 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+                        >
+                          {accountsModal.saving ? '…' : 'Add'}
+                        </button>
+                        <button
+                          onClick={() => setAccountsModal(m => ({ ...m, addingProvider: null, accountId: '' }))}
+                          className="px-3 py-2 text-sm text-gray-500 hover:bg-gray-100 rounded-lg"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })()}
+              </div>
+            </div>
+
+            <div className="px-6 py-4 bg-gray-50 rounded-b-xl flex justify-end">
+              <button
+                onClick={() => setAccountsModal(m => ({ ...m, open: false, user: null }))}
+                className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg"
+              >
+                Close
               </button>
             </div>
           </div>

--- a/computor-web/app/admin/users/page.tsx
+++ b/computor-web/app/admin/users/page.tsx
@@ -69,6 +69,7 @@ export default function UsersPage() {
   });
 
   const [resetConfirm, setResetConfirm] = useState<{ open: boolean; userId: string; username: string } | null>(null);
+  const [archiveConfirm, setArchiveConfirm] = useState<{ open: boolean; user: UserList } | null>(null);
 
   const [accountsModal, setAccountsModal] = useState<{
     open: boolean;
@@ -364,7 +365,7 @@ export default function UsersPage() {
                           Accounts
                         </button>
                         <button
-                          onClick={() => handleArchiveToggle(u)}
+                          onClick={() => setArchiveConfirm({ open: true, user: u })}
                           className="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded transition-colors"
                         >
                           {u.archived_at ? 'Unarchive' : 'Archive'}
@@ -500,6 +501,32 @@ export default function UsersPage() {
                 className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"
               >
                 {rolesModal.saving ? 'Saving…' : 'Save Roles'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Archive / Unarchive Confirm */}
+      {archiveConfirm?.open && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+              {archiveConfirm.user.archived_at ? 'Unarchive user?' : 'Archive user?'}
+            </h2>
+            <p className="text-sm text-gray-600 mb-4">
+              {archiveConfirm.user.archived_at
+                ? <>Restore <strong>{archiveConfirm.user.username}</strong> so they can log in again?</>
+                : <>Archive <strong>{archiveConfirm.user.username}</strong>? They will no longer be able to log in.</>
+              }
+            </p>
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setArchiveConfirm(null)} className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">Cancel</button>
+              <button
+                onClick={() => { handleArchiveToggle(archiveConfirm.user); setArchiveConfirm(null); }}
+                className="px-4 py-2 text-sm bg-gray-800 text-white rounded-lg hover:bg-gray-900"
+              >
+                {archiveConfirm.user.archived_at ? 'Unarchive' : 'Archive'}
               </button>
             </div>
           </div>

--- a/computor-web/app/admin/users/roles/page.tsx
+++ b/computor-web/app/admin/users/roles/page.tsx
@@ -1,0 +1,420 @@
+'use client';
+
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import AuthenticatedLayout from '@/src/components/AuthenticatedLayout';
+import { useAuth } from '@/src/contexts/AuthContext';
+import { RolesClient } from '@/src/generated/clients/RolesClient';
+import { RoleClaimsClient } from '@/src/generated/clients/RoleClaimsClient';
+import { UserClient } from '@/src/generated/clients/UserClient';
+import { UsersClient } from '@/src/generated/clients/UsersClient';
+import type { RoleList, RoleGet, RoleClaimList, UserRoleList, UserList } from 'types/generated';
+
+const rolesClient = new RolesClient();
+const roleClaimsClient = new RoleClaimsClient();
+const userRolesClient = new UserClient();
+const usersClient = new UsersClient();
+
+// Readable label per claim_value prefix
+const CLAIM_COLORS: Record<string, string> = {
+  user: 'bg-purple-100 text-purple-800',
+  account: 'bg-indigo-100 text-indigo-800',
+  role: 'bg-red-100 text-red-800',
+  user_role: 'bg-red-100 text-red-800',
+  role_claim: 'bg-red-100 text-red-800',
+  workspace: 'bg-teal-100 text-teal-800',
+  course: 'bg-blue-100 text-blue-800',
+  organization: 'bg-orange-100 text-orange-800',
+  course_family: 'bg-yellow-100 text-yellow-800',
+};
+
+function claimColor(value: string) {
+  const resource = value.split(':')[0];
+  return CLAIM_COLORS[resource] ?? 'bg-gray-100 text-gray-700';
+}
+
+function ClaimChip({ claim }: { claim: RoleClaimList }) {
+  return (
+    <span
+      title={`${claim.claim_type}: ${claim.claim_value}`}
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-mono font-medium ${claimColor(claim.claim_value)}`}
+    >
+      {claim.claim_value}
+    </span>
+  );
+}
+
+function RoleBadge({ role }: { role: RoleList | RoleGet }) {
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${role.builtin ? 'bg-slate-200 text-slate-700' : 'bg-green-100 text-green-800'}`}>
+      {role.id}
+    </span>
+  );
+}
+
+export default function RolesPage() {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+
+  const isAdmin = user?.role === 'admin';
+  const isUserManager = isAdmin || (user?.systemRoles?.includes('_user_manager') ?? false);
+
+  const [roles, setRoles] = useState<RoleList[]>([]);
+  const [rolesLoading, setRolesLoading] = useState(true);
+  const [rolesError, setRolesError] = useState<string | null>(null);
+
+  const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
+  const [roleDetail, setRoleDetail] = useState<RoleGet | null>(null);
+  const [claims, setClaims] = useState<RoleClaimList[]>([]);
+  const [members, setMembers] = useState<UserRoleList[]>([]);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  const [allUsers, setAllUsers] = useState<UserList[]>([]);
+  const [addSearch, setAddSearch] = useState('');
+  const [addUserId, setAddUserId] = useState('');
+  const [addingMember, setAddingMember] = useState(false);
+  const [removeConfirm, setRemoveConfirm] = useState<{ userId: string; username: string } | null>(null);
+
+  const [notification, setNotification] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  const notify = (message: string, type: 'success' | 'error') => {
+    setNotification({ message, type });
+    setTimeout(() => setNotification(null), 4000);
+  };
+
+  // Load roles and all users on mount
+  useEffect(() => {
+    if (authLoading || !isAuthenticated || !isUserManager) return;
+
+    rolesClient.listRolesRolesGet({ limit: 200 })
+      .then(data => { setRoles(data); setRolesLoading(false); })
+      .catch(e => { setRolesError(e instanceof Error ? e.message : 'Failed to load roles'); setRolesLoading(false); });
+
+    usersClient.listUsersUsersGet({ limit: 500 })
+      .then(setAllUsers)
+      .catch(() => {});
+  }, [authLoading, isAuthenticated, isUserManager]);
+
+  const userMap = useMemo(() => {
+    const m = new Map<string, UserList>();
+    allUsers.forEach(u => m.set(u.id, u));
+    return m;
+  }, [allUsers]);
+
+  const loadRoleDetail = useCallback(async (roleId: string) => {
+    setDetailLoading(true);
+    setDetailError(null);
+    setRoleDetail(null);
+    setClaims([]);
+    setMembers([]);
+    setAddSearch('');
+    setAddUserId('');
+    try {
+      const [detail, roleClaims, userRoles] = await Promise.all([
+        rolesClient.getRolesRolesIdGet({ id: roleId }),
+        roleClaimsClient.listClaims({ roleId, limit: 500 }),
+        userRolesClient.listUserRolesUserRolesGet({ roleId, limit: 500 }),
+      ]);
+      setRoleDetail(detail);
+      setClaims(roleClaims);
+      setMembers(userRoles);
+    } catch (e) {
+      setDetailError(e instanceof Error ? e.message : 'Failed to load role detail');
+    } finally {
+      setDetailLoading(false);
+    }
+  }, []);
+
+  const handleSelectRole = (roleId: string) => {
+    setSelectedRoleId(roleId);
+    loadRoleDetail(roleId);
+  };
+
+  const handleAddMember = async () => {
+    if (!selectedRoleId || !addUserId) return;
+    setAddingMember(true);
+    try {
+      await userRolesClient.createUserRoleUserRolesPost({
+        body: { user_id: addUserId, role_id: selectedRoleId },
+      });
+      const updated = await userRolesClient.listUserRolesUserRolesGet({ roleId: selectedRoleId, limit: 500 });
+      setMembers(updated);
+      setAddSearch('');
+      setAddUserId('');
+      notify('User added to role', 'success');
+    } catch (e) {
+      notify(e instanceof Error ? e.message : 'Failed to add member', 'error');
+    } finally {
+      setAddingMember(false);
+    }
+  };
+
+  const handleRemoveMember = async (userId: string) => {
+    if (!selectedRoleId) return;
+    try {
+      await userRolesClient.deleteUserRoleEndpointUserRolesUsersUserIdRolesRoleIdDelete({
+        userId,
+        roleId: selectedRoleId,
+      });
+      setMembers(m => m.filter(x => x.user_id !== userId));
+      notify('User removed from role', 'success');
+    } catch (e) {
+      notify(e instanceof Error ? e.message : 'Failed to remove member', 'error');
+    }
+    setRemoveConfirm(null);
+  };
+
+  // Group claims by claim_type for display
+  const claimsByType = useMemo(() => {
+    const groups: Record<string, RoleClaimList[]> = {};
+    claims.forEach(c => {
+      if (!groups[c.claim_type]) groups[c.claim_type] = [];
+      groups[c.claim_type].push(c);
+    });
+    return groups;
+  }, [claims]);
+
+  const memberUserIds = useMemo(() => new Set(members.map(m => m.user_id)), [members]);
+
+  const addCandidates = useMemo(() => {
+    const q = addSearch.toLowerCase();
+    return allUsers.filter(u =>
+      !memberUserIds.has(u.id) &&
+      !u.archived_at &&
+      (u.username?.toLowerCase().includes(q) || u.email?.toLowerCase().includes(q))
+    ).slice(0, 8);
+  }, [allUsers, memberUserIds, addSearch]);
+
+  // Guard
+  if (authLoading) return <AuthenticatedLayout><div className="p-8 text-gray-500">Loading…</div></AuthenticatedLayout>;
+  if (!isAuthenticated || !isUserManager) {
+    return (
+      <AuthenticatedLayout>
+        <div className="p-8 text-red-600 font-medium">Access denied. Requires admin or _user_manager role.</div>
+      </AuthenticatedLayout>
+    );
+  }
+
+  return (
+    <AuthenticatedLayout>
+      <div className="flex h-[calc(100vh-4rem)] overflow-hidden">
+
+        {/* Left panel — role list */}
+        <div className="w-72 shrink-0 border-r border-gray-200 bg-gray-50 flex flex-col">
+          <div className="p-4 border-b border-gray-200">
+            <h1 className="text-base font-semibold text-gray-900">Roles & Claims</h1>
+            <p className="text-xs text-gray-500 mt-0.5">{roles.length} roles</p>
+          </div>
+
+          <div className="flex-1 overflow-y-auto">
+            {rolesLoading ? (
+              <div className="p-4 text-sm text-gray-400">Loading…</div>
+            ) : rolesError ? (
+              <div className="p-4 text-sm text-red-500">{rolesError}</div>
+            ) : (
+              <>
+                {/* Builtin roles */}
+                <div className="px-3 pt-3 pb-1">
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">System</p>
+                </div>
+                {roles.filter(r => r.builtin).map(r => (
+                  <RoleRow key={r.id} role={r} selected={r.id === selectedRoleId} onClick={() => handleSelectRole(r.id)} />
+                ))}
+
+                {/* Custom roles */}
+                {roles.some(r => !r.builtin) && (
+                  <>
+                    <div className="px-3 pt-4 pb-1">
+                      <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Custom</p>
+                    </div>
+                    {roles.filter(r => !r.builtin).map(r => (
+                      <RoleRow key={r.id} role={r} selected={r.id === selectedRoleId} onClick={() => handleSelectRole(r.id)} />
+                    ))}
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Right panel — role detail */}
+        <div className="flex-1 overflow-y-auto">
+          {!selectedRoleId ? (
+            <div className="flex items-center justify-center h-full text-gray-400 text-sm">
+              Select a role to view its claims and members
+            </div>
+          ) : detailLoading ? (
+            <div className="p-8 text-gray-400 text-sm">Loading…</div>
+          ) : detailError ? (
+            <div className="p-8 text-red-500 text-sm">{detailError}</div>
+          ) : roleDetail ? (
+            <div className="p-6 space-y-8 max-w-3xl">
+
+              {/* Notification */}
+              {notification && (
+                <div className={`px-4 py-3 rounded-lg text-sm ${notification.type === 'success' ? 'bg-green-50 text-green-800 border border-green-200' : 'bg-red-50 text-red-800 border border-red-200'}`}>
+                  {notification.message}
+                </div>
+              )}
+
+              {/* Role header */}
+              <div>
+                <div className="flex items-center gap-2 mb-1">
+                  <h2 className="text-xl font-semibold text-gray-900">{roleDetail.title ?? roleDetail.id}</h2>
+                  <RoleBadge role={roleDetail} />
+                  {roleDetail.builtin && (
+                    <span className="text-xs text-gray-400 italic">built-in</span>
+                  )}
+                </div>
+                {roleDetail.description && (
+                  <p className="text-sm text-gray-600">{roleDetail.description}</p>
+                )}
+              </div>
+
+              {/* Claims */}
+              <section>
+                <h3 className="text-sm font-semibold text-gray-700 mb-3">
+                  Claims
+                  <span className="ml-2 text-xs font-normal text-gray-400">({claims.length} total — read-only)</span>
+                </h3>
+                {claims.length === 0 ? (
+                  <p className="text-sm text-gray-400 italic">No claims defined for this role.</p>
+                ) : (
+                  <div className="space-y-3">
+                    {Object.entries(claimsByType).sort().map(([type, typeClaims]) => (
+                      <div key={type}>
+                        <p className="text-xs text-gray-400 mb-1.5">{type}</p>
+                        <div className="flex flex-wrap gap-1.5">
+                          {typeClaims
+                            .slice()
+                            .sort((a, b) => a.claim_value.localeCompare(b.claim_value))
+                            .map(c => (
+                              <ClaimChip key={`${c.claim_type}:${c.claim_value}`} claim={c} />
+                            ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </section>
+
+              {/* Members */}
+              <section>
+                <h3 className="text-sm font-semibold text-gray-700 mb-3">
+                  Members
+                  <span className="ml-2 text-xs font-normal text-gray-400">({members.length})</span>
+                </h3>
+
+                {members.length === 0 ? (
+                  <p className="text-sm text-gray-400 italic mb-3">No users have this role.</p>
+                ) : (
+                  <div className="mb-4 space-y-1">
+                    {members.map(m => {
+                      const u = userMap.get(m.user_id);
+                      const canRemove = isAdmin || roleDetail.id !== '_admin';
+                      return (
+                        <div key={m.user_id} className="flex items-center justify-between px-3 py-2 bg-white border border-gray-200 rounded-lg">
+                          <div>
+                            <span className="text-sm font-medium text-gray-900">{u?.username ?? m.user_id}</span>
+                            {u?.email && <span className="ml-2 text-xs text-gray-500">{u.email}</span>}
+                            {u?.given_name && <span className="ml-2 text-xs text-gray-400">{u.given_name} {u.family_name}</span>}
+                          </div>
+                          {canRemove && (
+                            <button
+                              onClick={() => setRemoveConfirm({ userId: m.user_id, username: u?.username ?? m.user_id })}
+                              className="text-xs text-red-500 hover:text-red-700 transition-colors ml-4"
+                            >
+                              Remove
+                            </button>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {/* Add member — blocked for _admin role for non-admins */}
+                {(isAdmin || roleDetail.id !== '_admin') && (
+                  <div className="relative">
+                    <p className="text-xs font-medium text-gray-600 mb-1.5">Add user to role</p>
+                    <input
+                      type="text"
+                      placeholder="Search by username or email…"
+                      value={addSearch}
+                      onChange={e => { setAddSearch(e.target.value); setAddUserId(''); }}
+                      className="w-full max-w-sm px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    />
+                    {addSearch && addCandidates.length > 0 && !addUserId && (
+                      <div className="absolute z-10 mt-1 w-full max-w-sm bg-white border border-gray-200 rounded-lg shadow-lg">
+                        {addCandidates.map(u => (
+                          <button
+                            key={u.id}
+                            onClick={() => { setAddUserId(u.id); setAddSearch(u.username ?? u.email ?? u.id); }}
+                            className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 flex items-center justify-between"
+                          >
+                            <span className="font-medium text-gray-900">{u.username}</span>
+                            <span className="text-xs text-gray-400">{u.email}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                    {addUserId && (
+                      <button
+                        onClick={handleAddMember}
+                        disabled={addingMember}
+                        className="mt-2 px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                      >
+                        {addingMember ? 'Adding…' : 'Add'}
+                      </button>
+                    )}
+                    {addSearch && addCandidates.length === 0 && !addUserId && (
+                      <p className="mt-1 text-xs text-gray-400">No matching users found.</p>
+                    )}
+                  </div>
+                )}
+                {!isAdmin && roleDetail.id === '_admin' && (
+                  <p className="text-xs text-gray-400 italic">Only admins can modify _admin role membership.</p>
+                )}
+              </section>
+
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Remove member confirm */}
+      {removeConfirm && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">Remove from role?</h2>
+            <p className="text-sm text-gray-600 mb-4">
+              Remove <strong>{removeConfirm.username}</strong> from <strong>{selectedRoleId}</strong>?
+            </p>
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setRemoveConfirm(null)} className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">Cancel</button>
+              <button
+                onClick={() => handleRemoveMember(removeConfirm.userId)}
+                className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700"
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </AuthenticatedLayout>
+  );
+}
+
+function RoleRow({ role, selected, onClick }: { role: RoleList; selected: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full text-left px-3 py-2.5 flex items-start gap-2 transition-colors ${selected ? 'bg-blue-50 border-r-2 border-blue-500' : 'hover:bg-gray-100'}`}
+    >
+      <div className="min-w-0">
+        <div className="text-xs font-mono font-medium text-gray-800 truncate">{role.id}</div>
+        {role.title && <div className="text-xs text-gray-500 truncate mt-0.5">{role.title}</div>}
+      </div>
+    </button>
+  );
+}

--- a/computor-web/app/invite/[token]/page.tsx
+++ b/computor-web/app/invite/[token]/page.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { PublicInvitesClient, InviteLinkPublic } from '@/src/generated/clients/InvitesClient';
+
+const client = new PublicInvitesClient();
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export default function InvitePage() {
+  const { token } = useParams<{ token: string }>();
+  const router = useRouter();
+
+  const [invite, setInvite] = useState<InviteLinkPublic | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [form, setForm] = useState({
+    username: '',
+    givenName: '',
+    familyName: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    client.getInvitePublic(token)
+      .then(data => { setInvite(data); setForm(f => ({ ...f, email: data.email ?? '' })); })
+      .catch(e => setLoadError(e instanceof Error ? e.message : 'Invalid or expired invite link'))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitError(null);
+
+    if (form.password !== form.confirmPassword) {
+      setSubmitError('Passwords do not match');
+      return;
+    }
+    if (form.password.length < 8) {
+      setSubmitError('Password must be at least 8 characters');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await client.acceptInvite(token, {
+        username: form.username,
+        given_name: form.givenName,
+        family_name: form.familyName,
+        email: form.email,
+        password: form.password,
+        confirm_password: form.confirmPassword,
+      });
+
+      // Cookies are now set — redirect to dashboard
+      router.replace('/dashboard');
+    } catch (e: any) {
+      const msg = e?.response
+        ? (await e.response.json().catch(() => null))?.detail ?? e.message
+        : (e instanceof Error ? e.message : 'Registration failed');
+      setSubmitError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-500">Loading invite…</div>
+      </div>
+    );
+  }
+
+  if (loadError || !invite) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 w-full max-w-md p-8 text-center">
+          <div className="text-4xl mb-4">🔗</div>
+          <h1 className="text-xl font-semibold text-gray-900 mb-2">Invite Not Found</h1>
+          <p className="text-sm text-gray-500">{loadError ?? 'This invite link is invalid or has expired.'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 w-full max-w-md">
+        {/* Header */}
+        <div className="p-8 pb-0">
+          <div className="flex items-center gap-3 mb-6">
+            <img src="/computor_logo.png" alt="Computor" className="h-8 w-8" />
+            <span className="text-lg font-semibold text-gray-900">Computor</span>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-1">Create your account</h1>
+          <p className="text-sm text-gray-500 mb-2">You've been invited to join Computor.</p>
+
+          {/* Invite metadata */}
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mb-6 text-xs text-blue-800 space-y-1">
+            <div>Expires: <strong>{formatDate(invite.expires_at)}</strong></div>
+            {invite.email && <div>This invite is restricted to <strong>{invite.email}</strong></div>}
+            {invite.roles.length > 0 && (
+              <div>Roles granted: <strong>{invite.roles.join(', ')}</strong></div>
+            )}
+            {invite.note && <div>Note: {invite.note}</div>}
+          </div>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="p-8 pt-0 space-y-4">
+          {submitError && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">{submitError}</div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">First name *</label>
+              <input
+                type="text"
+                required
+                value={form.givenName}
+                onChange={e => setForm(f => ({ ...f, givenName: e.target.value }))}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Last name *</label>
+              <input
+                type="text"
+                required
+                value={form.familyName}
+                onChange={e => setForm(f => ({ ...f, familyName: e.target.value }))}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Email *</label>
+            <input
+              type="email"
+              required
+              value={form.email}
+              readOnly={!!invite.email}
+              onChange={e => setForm(f => ({ ...f, email: e.target.value }))}
+              className={`w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent ${invite.email ? 'bg-gray-50 cursor-not-allowed' : ''}`}
+            />
+            {invite.email && <p className="mt-1 text-xs text-gray-500">Email is fixed by the invite restriction.</p>}
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Username *</label>
+            <input
+              type="text"
+              required
+              pattern="[a-zA-Z0-9_\-\.]+"
+              value={form.username}
+              onChange={e => setForm(f => ({ ...f, username: e.target.value }))}
+              placeholder="Letters, digits, _ - ."
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Password *</label>
+            <input
+              type="password"
+              required
+              minLength={8}
+              value={form.password}
+              onChange={e => setForm(f => ({ ...f, password: e.target.value }))}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Confirm password *</label>
+            <input
+              type="password"
+              required
+              value={form.confirmPassword}
+              onChange={e => setForm(f => ({ ...f, confirmPassword: e.target.value }))}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full py-2.5 px-4 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 mt-2"
+          >
+            {submitting ? 'Creating account…' : 'Create account & sign in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/computor-web/src/components/Sidebar.tsx
+++ b/computor-web/src/components/Sidebar.tsx
@@ -56,6 +56,20 @@ const adminNavigation: NavItem[] = [
   },
 ];
 
+// User management navigation (admin or _user_manager)
+const userMgmtNavigation: NavItem[] = [
+  {
+    id: 'user-management',
+    label: 'User Management',
+    path: '/admin/users',
+    icon: 'users',
+    subItems: [
+      { id: 'um-users', label: 'Users', path: '/admin/users' },
+      { id: 'um-invites', label: 'Invite Links', path: '/admin/users/invites' },
+    ],
+  },
+];
+
 // Navigation structure for view-based navigation (when in course context)
 const getViewNavigation = (courseId: string): NavItem[] => [
   {
@@ -144,6 +158,11 @@ const icons: Record<string, React.ReactElement> = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
     </svg>
   ),
+  users: (
+    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+    </svg>
+  ),
   chevronDown: (
     <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
@@ -156,13 +175,14 @@ export default function Sidebar() {
   const { user, views } = useAuth();
   const [collapsed, setCollapsed] = useState(false);
   const isAdmin = user?.role === 'admin';
+  const isUserManager = isAdmin || (user?.systemRoles?.includes('_user_manager') ?? false);
 
   const [expandedViews, setExpandedViews] = useState<Record<string, boolean>>(() => {
     const cMatch = pathname.match(/^\/courses\/([^/]+)/);
     const cId = cMatch ? cMatch[1] : null;
     const items = cId
       ? getViewNavigation(cId)
-      : [...defaultNavigation, ...adminNavigation];
+      : [...defaultNavigation, ...adminNavigation, ...userMgmtNavigation];
     return computeAutoExpanded(items, pathname);
   });
   const [courseViews, setCourseViews] = useState<string[]>([]);
@@ -204,7 +224,7 @@ export default function Sidebar() {
   useEffect(() => {
     const items = currentCourseId
       ? getViewNavigation(currentCourseId)
-      : [...defaultNavigation, ...(isAdmin ? adminNavigation : [])];
+      : [...defaultNavigation, ...(isAdmin ? adminNavigation : []), ...(isUserManager ? userMgmtNavigation : [])];
 
     const autoExpanded = computeAutoExpanded(items, pathname);
 
@@ -410,6 +430,7 @@ export default function Sidebar() {
       <nav className="flex-1 p-2 space-y-1 overflow-y-auto">
         {renderNavItems(defaultNavigation)}
         {isAdmin && renderNavItems(adminNavigation)}
+        {isUserManager && renderNavItems(userMgmtNavigation)}
       </nav>
 
       {/* Footer - Logo & Version */}

--- a/computor-web/src/components/Sidebar.tsx
+++ b/computor-web/src/components/Sidebar.tsx
@@ -66,6 +66,7 @@ const userMgmtNavigation: NavItem[] = [
     subItems: [
       { id: 'um-users', label: 'Users', path: '/admin/users' },
       { id: 'um-invites', label: 'Invite Links', path: '/admin/users/invites' },
+      { id: 'um-roles', label: 'Roles & Claims', path: '/admin/users/roles' },
     ],
   },
 ];

--- a/computor-web/src/generated/clients/AccountProvidersClient.ts
+++ b/computor-web/src/generated/clients/AccountProvidersClient.ts
@@ -1,0 +1,27 @@
+/**
+ * Client for GET /accounts/providers
+ * Returns the list of supported account providers (public, no auth required).
+ */
+
+import { APIClient, apiClient } from 'api/client';
+import { BaseEndpointClient } from './baseClient';
+
+export interface AccountProvider {
+  id: string;
+  display_name: string;
+  description: string;
+  provider: string;
+  type: string;
+  field_label: string;
+  placeholder: string;
+}
+
+export class AccountProvidersClient extends BaseEndpointClient {
+  constructor(client: APIClient = apiClient) {
+    super(client, '/accounts/providers');
+  }
+
+  async listProviders(): Promise<AccountProvider[]> {
+    return this.client.get<AccountProvider[]>(this.basePath);
+  }
+}

--- a/computor-web/src/generated/clients/InvitesClient.ts
+++ b/computor-web/src/generated/clients/InvitesClient.ts
@@ -1,0 +1,104 @@
+/**
+ * Client for invite link management endpoints.
+ * Admin/user-manager: /admin/invites
+ * Public: /invites/{token}
+ */
+
+import { APIClient, apiClient } from 'api/client';
+import { BaseEndpointClient } from './baseClient';
+
+export interface InviteLinkCreate {
+  email?: string | null;
+  max_uses?: number;
+  expires_in_days?: number;
+  roles?: string[];
+  note?: string | null;
+}
+
+export interface InviteLinkGet {
+  id: string;
+  token: string;
+  created_by?: string | null;
+  email?: string | null;
+  max_uses: number;
+  use_count: number;
+  expires_at: string;
+  roles: string[];
+  note?: string | null;
+  revoked_at?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface InviteLinkList {
+  id: string;
+  token: string;
+  email?: string | null;
+  max_uses: number;
+  use_count: number;
+  expires_at: string;
+  roles: string[];
+  note?: string | null;
+  revoked_at?: string | null;
+  created_at?: string | null;
+}
+
+export interface InviteLinkPublic {
+  id: string;
+  email?: string | null;
+  roles: string[];
+  expires_at: string;
+  note?: string | null;
+}
+
+export interface InviteAccept {
+  username: string;
+  given_name: string;
+  family_name: string;
+  email: string;
+  password: string;
+  confirm_password: string;
+}
+
+export interface InviteAcceptResponse {
+  user_id: string;
+  username: string;
+  access_token: string;
+}
+
+export class InvitesClient extends BaseEndpointClient {
+  constructor(client: APIClient = apiClient) {
+    super(client, '/admin/invites');
+  }
+
+  async createInvite(body: InviteLinkCreate): Promise<InviteLinkGet> {
+    return this.client.post<InviteLinkGet>(this.basePath, body);
+  }
+
+  async listInvites(): Promise<InviteLinkList[]> {
+    return this.client.get<InviteLinkList[]>(this.basePath);
+  }
+
+  async getInvite(id: string): Promise<InviteLinkGet> {
+    return this.client.get<InviteLinkGet>(this.buildPath(id));
+  }
+
+  async revokeInvite(id: string): Promise<void> {
+    return this.client.delete<void>(this.buildPath(id));
+  }
+}
+
+/** Public client (no authentication required) */
+export class PublicInvitesClient extends BaseEndpointClient {
+  constructor(client: APIClient = apiClient) {
+    super(client, '/invites');
+  }
+
+  async getInvitePublic(token: string): Promise<InviteLinkPublic> {
+    return this.client.get<InviteLinkPublic>(this.buildPath(token));
+  }
+
+  async acceptInvite(token: string, body: InviteAccept): Promise<InviteAcceptResponse> {
+    return this.client.post<InviteAcceptResponse>(this.buildPath(token, 'accept'), body);
+  }
+}

--- a/computor-web/src/generated/clients/RoleClaimsClient.ts
+++ b/computor-web/src/generated/clients/RoleClaimsClient.ts
@@ -1,0 +1,26 @@
+/**
+ * Client for GET /role-claims
+ * Role claims are read-only (list only — no create/update/delete endpoint).
+ */
+
+import type { RoleClaimList } from 'types/generated';
+import { APIClient, apiClient } from 'api/client';
+import { BaseEndpointClient } from './baseClient';
+
+export class RoleClaimsClient extends BaseEndpointClient {
+  constructor(client: APIClient = apiClient) {
+    super(client, '/role-claims');
+  }
+
+  async listClaims({ roleId, claimType, claimValue, limit, skip }: {
+    roleId?: string;
+    claimType?: string;
+    claimValue?: string;
+    limit?: number;
+    skip?: number;
+  } = {}): Promise<RoleClaimList[]> {
+    return this.client.get<RoleClaimList[]>(this.basePath, {
+      params: { role_id: roleId, claim_type: claimType, claim_value: claimValue, limit, skip },
+    });
+  }
+}

--- a/computor-web/src/interfaces/IAuthProvider.ts
+++ b/computor-web/src/interfaces/IAuthProvider.ts
@@ -15,6 +15,7 @@ export interface AuthUser {
   givenName?: string;
   familyName?: string;
   role: 'admin' | 'lecturer' | 'student';
+  systemRoles: string[];
   permissions: string[];
   courses: string[];
 }

--- a/computor-web/src/services/authService.ts
+++ b/computor-web/src/services/authService.ts
@@ -224,8 +224,9 @@ export class AuthService implements IAuthProviderWithLogin {
       givenName: userInfo.given_name || userInfo.user?.given_name,
       familyName: userInfo.family_name || userInfo.user?.family_name,
       role,
+      systemRoles: globalRoles,
       permissions: this.mapViewsToPermissions(views || [], globalRoles),
-      courses: [], // TODO: Fetch from user's course enrollments
+      courses: [],
     };
   }
 

--- a/computor-web/src/services/ssoAuthService.ts
+++ b/computor-web/src/services/ssoAuthService.ts
@@ -120,8 +120,9 @@ export class SSOAuthService implements ISSOAuthProvider {
         givenName: userInfo.user.given_name,
         familyName: userInfo.user.family_name,
         role: this.mapRolesToFrontend(userInfo.roles),
+        systemRoles: Array.isArray(userInfo.roles) ? userInfo.roles : [],
         permissions: this.mapPermissions(userInfo.roles),
-        courses: [], // TODO: Fetch from user's course enrollments
+        courses: [],
       };
 
       // Store ONLY user data (not tokens!)
@@ -241,6 +242,7 @@ export class SSOAuthService implements ISSOAuthProvider {
         givenName: userInfo.user.given_name,
         familyName: userInfo.user.family_name,
         role: this.mapRolesToFrontend(userInfo.roles),
+        systemRoles: Array.isArray(userInfo.roles) ? userInfo.roles : [],
         permissions: this.mapPermissions(userInfo.roles),
         courses: [],
       };

--- a/computor-web/src/types/auth.ts
+++ b/computor-web/src/types/auth.ts
@@ -32,6 +32,7 @@ export interface AuthUser {
   givenName?: string;
   familyName?: string;
   role: 'admin' | 'lecturer' | 'student';
+  systemRoles: string[];
   permissions: string[];
   courses: string[];
 }


### PR DESCRIPTION
## Summary

Replaces the fragile GitLab PAT onboarding flow with invite links and adds a full User Management section to computor-web, gated behind `_admin` / `_user_manager`.

**Invite links**
- `InviteLink` model + Alembic migration
- `POST /admin/invites` create, `GET /admin/invites` list, `DELETE /admin/invites/{id}` revoke
- `GET /invites/{token}` public metadata, `POST /invites/{token}/accept` self-registration with auto-login (sets `ct_access_token` / `ct_refresh_token` cookies)
- `/invite/[token]` standalone Next.js page (outside `AuthenticatedLayout`)

**User management UI** (`/admin/users`)
- Users table with search and "show archived" toggle
- Create user modal with role pre-assignment
- Roles modal per user (checkbox list of system roles)
- Accounts modal: view / link / remove provider accounts — provider URL is user-editable (supports self-hosted GitLab)
- Archive / Unarchive with confirmation dialog
- Reset password with manager-password confirmation

**Invite Links UI** (`/admin/users/invites`)
- Table with status badge (Active / Expired / Used / Revoked), copy-link button, revoke with confirm
- New invite modal: email restriction, expiry, max uses, note, role pre-assignment

**Roles & Claims UI** (`/admin/users/roles`)
- Two-panel layout: role list (System / Custom) + role detail
- Claims displayed as read-only chips grouped by `claim_type`, colored by resource
- Members list with add-by-search and remove-with-confirm
- `_admin` membership locked to admins only

**Backend additions**
- `GET /accounts/providers` — public endpoint listing supported account providers (currently GitLab); registered before `CrudRouter(AccountInterface)` to avoid route shadowing
- `pre_archive` hook on `CrudRouter`; blocks archiving any user who holds `_admin`
- `systemRoles: string[]` added to `AuthUser` so the frontend can gate UI elements

## Test plan
- [x] Invite link creation, copy, accept (new user auto-logged in)
- [x] Invite expiry / revoke / email restriction enforced
- [x] User create / archive / unarchive (confirm dialogs)
- [x] Role assignment add / remove per user
- [x] Account link / remove (editable provider URL)
- [x] `GET /accounts/providers` returns 200 without auth
- [x] Archiving `_admin` user blocked with 403
- [x] Reset password requires manager's own password
- [x] Roles & Claims tab: claims render, members add/remove, `_admin` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)