### PR TITLE
fix: Keycloak token refresh discards rotated tokens (re-exchanges empty auth code)

### DIFF
--- a/computor-backend/src/computor_backend/auth/keycloak.py
+++ b/computor-backend/src/computor_backend/auth/keycloak.py
@@ -219,55 +219,7 @@ class KeycloakAuthPlugin(AuthenticationPlugin):
             tokens = await self._exchange_code_for_tokens(code, redirect_uri)
             print(f"[DEBUG] Token exchange completed")
             
-            # Parse ID token to get user info
-            id_token = tokens.get("id_token")
-            print(f"[DEBUG] ID token present: {bool(id_token)}")
-            if not id_token:
-                return AuthResult(
-                    status=AuthStatus.FAILED,
-                    error_message="No ID token received from Keycloak"
-                )
-            
-            # Decode and verify ID token
-            claims = await self._verify_and_decode_token(id_token)
-            
-            # Extract user info from claims
-            user_info = UserInfo(
-                provider_id=claims.get("sub", ""),
-                email=claims.get("email"),
-                username=claims.get("preferred_username", claims.get("email", "").split("@")[0]),
-                given_name=claims.get("given_name"),
-                family_name=claims.get("family_name"),
-                full_name=claims.get("name"),
-                picture=claims.get("picture"),
-                groups=claims.get("groups", []),
-                attributes={
-                    "email_verified": claims.get("email_verified", False),
-                    "realm_access": claims.get("realm_access", {}),
-                    "resource_access": claims.get("resource_access", {})
-                }
-            )
-            
-            # Calculate token expiration
-            expires_at = None
-            if "exp" in claims:
-                expires_at = datetime.fromtimestamp(claims["exp"], tz=timezone.utc)
-            
-            return AuthResult(
-                status=AuthStatus.SUCCESS,
-                user_info=user_info,
-                access_token=tokens.get("access_token"),
-                refresh_token=tokens.get("refresh_token"),
-                expires_at=expires_at,
-                session_data={
-                    "token_type": tokens.get("token_type", "Bearer"),
-                    "expires_in": tokens.get("expires_in"),
-                    "scope": tokens.get("scope", ""),
-                    # Kept so logout can pass id_token_hint to Keycloak's
-                    # end_session_endpoint and skip the logout confirmation page.
-                    "id_token": id_token,
-                }
-            )
+            return await self._build_auth_result_from_tokens(tokens)
             
         except Exception as e:
             logger.error(f"Failed to handle Keycloak callback: {e}")
@@ -276,6 +228,62 @@ class KeycloakAuthPlugin(AuthenticationPlugin):
                 error_message=str(e)
             )
     
+    async def _build_auth_result_from_tokens(self, tokens: Dict[str, Any]) -> AuthResult:
+        """Build an ``AuthResult`` from a Keycloak token response.
+
+        Shared by the authorization-code, password, and refresh-token grants:
+        each obtains the token dict its own way, then defers ID-token verification,
+        user-info extraction, and ``AuthResult`` assembly to here.
+        """
+        # Parse ID token to get user info
+        id_token = tokens.get("id_token")
+        if not id_token:
+            return AuthResult(
+                status=AuthStatus.FAILED,
+                error_message="No ID token received from Keycloak"
+            )
+
+        # Decode and verify ID token
+        claims = await self._verify_and_decode_token(id_token)
+
+        # Extract user info from claims
+        user_info = UserInfo(
+            provider_id=claims.get("sub", ""),
+            email=claims.get("email"),
+            username=claims.get("preferred_username", claims.get("email", "").split("@")[0]),
+            given_name=claims.get("given_name"),
+            family_name=claims.get("family_name"),
+            full_name=claims.get("name"),
+            picture=claims.get("picture"),
+            groups=claims.get("groups", []),
+            attributes={
+                "email_verified": claims.get("email_verified", False),
+                "realm_access": claims.get("realm_access", {}),
+                "resource_access": claims.get("resource_access", {})
+            }
+        )
+
+        # Calculate token expiration
+        expires_at = None
+        if "exp" in claims:
+            expires_at = datetime.fromtimestamp(claims["exp"], tz=timezone.utc)
+
+        return AuthResult(
+            status=AuthStatus.SUCCESS,
+            user_info=user_info,
+            access_token=tokens.get("access_token"),
+            refresh_token=tokens.get("refresh_token"),
+            expires_at=expires_at,
+            session_data={
+                "token_type": tokens.get("token_type", "Bearer"),
+                "expires_in": tokens.get("expires_in"),
+                "scope": tokens.get("scope", ""),
+                # Kept so logout can pass id_token_hint to Keycloak's
+                # end_session_endpoint and skip the logout confirmation page.
+                "id_token": id_token,
+            }
+        )
+
     async def _exchange_code_for_tokens(self, code: str, redirect_uri: Optional[str] = None) -> Dict[str, Any]:
         """Exchange authorization code for tokens."""
         if not self._oidc_config:
@@ -428,9 +436,9 @@ class KeycloakAuthPlugin(AuthenticationPlugin):
                 
                 response.raise_for_status()
                 tokens = response.json()
-                
-                # Handle the tokens like in callback
-                return await self.handle_callback("", "")  # Reuse token processing logic
+
+                # Build the auth result from the password-grant tokens
+                return await self._build_auth_result_from_tokens(tokens)
                 
         except httpx.HTTPStatusError as e:
             logger.error(f"Authentication failed: {e}")
@@ -503,9 +511,9 @@ class KeycloakAuthPlugin(AuthenticationPlugin):
                 )
                 response.raise_for_status()
                 tokens = response.json()
-                
-                # Process the new tokens
-                return await self.handle_callback("", "")  # Reuse token processing logic
+
+                # Build the auth result from the freshly issued tokens
+                return await self._build_auth_result_from_tokens(tokens)
                 
         except Exception as e:
             logger.error(f"Token refresh failed: {e}")

--- a/computor-backend/src/computor_backend/tests/test_keycloak_token_refresh.py
+++ b/computor-backend/src/computor_backend/tests/test_keycloak_token_refresh.py
@@ -1,0 +1,194 @@
+"""Unit tests for KeycloakAuthPlugin token handling.
+
+Regression coverage for the bug where ``refresh_token()`` / ``authenticate()``
+discarded the tokens they had just fetched and instead re-ran an authorization-code
+exchange with an empty code (``handle_callback("", "")``). Keycloak always rejects an
+empty code, so every refresh returned FAILED and the provider's rotated refresh token
+never reached the caller.
+
+Fully mocked — no live Keycloak and no JWT signing. The HTTP layer and the JWKS-based
+ID-token verification are stubbed so the tests exercise only the plugin's control flow.
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from computor_backend.auth import keycloak as keycloak_module
+from computor_backend.auth.keycloak import KeycloakAuthPlugin
+from computor_backend.plugins.base import AuthStatus
+
+
+TOKEN_ENDPOINT = "https://keycloak.example/realms/computor/protocol/openid-connect/token"
+
+# Claims the (mocked) ID-token verification yields for every grant.
+FAKE_CLAIMS = {
+    "sub": "user-uuid-123",
+    "email": "ada@example.org",
+    "preferred_username": "ada",
+    "given_name": "Ada",
+    "family_name": "Lovelace",
+    "name": "Ada Lovelace",
+    "exp": 4102444800,  # 2100-01-01, comfortably in the future
+    "email_verified": True,
+    "realm_access": {"roles": ["user"]},
+    "resource_access": {},
+}
+
+
+class _FakeResponse:
+    def __init__(self, json_data, status_code=200):
+        self._json = json_data
+        self.status_code = status_code
+        self.text = json.dumps(json_data)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "error",
+                request=httpx.Request("POST", TOKEN_ENDPOINT),
+                response=httpx.Response(self.status_code),
+            )
+
+    def json(self):
+        return self._json
+
+
+class _FakeAsyncClient:
+    """Stand-in for httpx.AsyncClient: records the POST and returns a canned response."""
+
+    def __init__(self, response, capture):
+        self._response = response
+        self._capture = capture
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, data=None, headers=None):
+        self._capture["url"] = url
+        self._capture["data"] = data
+        return self._response
+
+
+@contextmanager
+def _mock_token_post(token_response):
+    """Patch httpx.AsyncClient so any token POST returns ``token_response``; yields the capture dict."""
+    capture = {}
+    fake_response = _FakeResponse(token_response)
+    with patch.object(
+        keycloak_module.httpx,
+        "AsyncClient",
+        lambda *a, **k: _FakeAsyncClient(fake_response, capture),
+    ):
+        yield capture
+
+
+def _make_plugin():
+    """A plugin wired for unit testing: OIDC config injected, network + JWT verify stubbed."""
+    plugin = KeycloakAuthPlugin()
+    plugin._available = True
+    plugin._oidc_config = {"token_endpoint": TOKEN_ENDPOINT}
+    # Stub JWKS-based verification — we don't mint real signed JWTs in a unit test.
+    plugin._verify_and_decode_token = AsyncMock(return_value=dict(FAKE_CLAIMS))
+    # The old bug routed refresh/password grants back through the auth-code exchange.
+    # Spy on it so we can assert it is never touched on those paths.
+    plugin._exchange_code_for_tokens = AsyncMock()
+    return plugin
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_returns_rotated_tokens_without_reexchanging_code():
+    plugin = _make_plugin()
+    token_response = {
+        "access_token": "new-access-token",
+        "refresh_token": "rotated-refresh-token",
+        "id_token": "new-id-token",
+        "token_type": "Bearer",
+        "expires_in": 300,
+        "scope": "openid",
+    }
+
+    with _mock_token_post(token_response) as capture:
+        result = await plugin.refresh_token("old-refresh-token")
+
+    # The grant succeeded and the rotated tokens are surfaced (the heart of the bug report).
+    assert result.status == AuthStatus.SUCCESS, result.error_message
+    assert result.access_token == "new-access-token"
+    assert result.refresh_token == "rotated-refresh-token"
+    assert result.user_info.provider_id == "user-uuid-123"
+
+    # It used the refresh_token grant carrying the supplied token...
+    assert capture["data"]["grant_type"] == "refresh_token"
+    assert capture["data"]["refresh_token"] == "old-refresh-token"
+    # ...and never re-ran an authorization-code exchange (the regression we fixed).
+    plugin._exchange_code_for_tokens.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_reports_failure_when_provider_rejects():
+    """A 4xx from the token endpoint surfaces as FAILED, not a silent success."""
+    plugin = _make_plugin()
+    fake_response = _FakeResponse({"error": "invalid_grant"}, status_code=400)
+    with patch.object(
+        keycloak_module.httpx,
+        "AsyncClient",
+        lambda *a, **k: _FakeAsyncClient(fake_response, {}),
+    ):
+        result = await plugin.refresh_token("expired-refresh-token")
+
+    assert result.status == AuthStatus.FAILED
+    plugin._exchange_code_for_tokens.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_authenticate_builds_result_from_password_grant_tokens():
+    plugin = _make_plugin()
+    token_response = {
+        "access_token": "pw-access-token",
+        "refresh_token": "pw-refresh-token",
+        "id_token": "pw-id-token",
+        "token_type": "Bearer",
+        "expires_in": 300,
+    }
+
+    with _mock_token_post(token_response) as capture:
+        result = await plugin.authenticate({"username": "ada", "password": "secret"})
+
+    assert result.status == AuthStatus.SUCCESS, result.error_message
+    assert result.access_token == "pw-access-token"
+    assert result.refresh_token == "pw-refresh-token"
+    assert capture["data"]["grant_type"] == "password"
+    plugin._exchange_code_for_tokens.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_builds_result_from_exchanged_tokens():
+    """The shared-helper refactor must not regress the login (authorization-code) path."""
+    plugin = KeycloakAuthPlugin()
+    plugin._available = True
+    plugin._oidc_config = {"token_endpoint": TOKEN_ENDPOINT}
+    plugin._verify_and_decode_token = AsyncMock(return_value=dict(FAKE_CLAIMS))
+    plugin._exchange_code_for_tokens = AsyncMock(
+        return_value={
+            "access_token": "cb-access-token",
+            "refresh_token": "cb-refresh-token",
+            "id_token": "cb-id-token",
+            "token_type": "Bearer",
+            "expires_in": 300,
+        }
+    )
+
+    result = await plugin.handle_callback("auth-code", "state", "https://app/callback")
+
+    assert result.status == AuthStatus.SUCCESS, result.error_message
+    assert result.access_token == "cb-access-token"
+    assert result.refresh_token == "cb-refresh-token"
+    # id_token is retained for logout's id_token_hint.
+    assert result.session_data["id_token"] == "cb-id-token"
+    plugin._exchange_code_for_tokens.assert_awaited_once_with("auth-code", "https://app/callback")


### PR DESCRIPTION
## Problem

`POST /auth/refresh` failed on **every** call against Keycloak, even with a valid refresh token. The extension masked this via sliding-TTL on its own session token, so true token rotation never happened.

Root cause in `KeycloakAuthPlugin` (`computor-backend/.../auth/keycloak.py`): `refresh_token()` successfully ran the `grant_type=refresh_token` exchange, captured the new tokens — then **threw them away** and called `return await self.handle_callback("", "")`. `handle_callback` is not a token-processing helper; it performs a *fresh authorization-code exchange from scratch*. With an empty `code`, Keycloak returns `400 invalid_grant`, which `handle_callback` swallows into `AuthResult(FAILED)`. So refresh always reported failure and the rotated refresh token was silently dropped.

`authenticate()` (ROPC password grant) had the identical `handle_callback("", "")` bug.

## Fix

- Extracted the post-exchange processing (ID-token verify → `UserInfo` → `AuthResult`) out of `handle_callback` into a shared `_build_auth_result_from_tokens(tokens)` helper.
- `refresh_token()` and `authenticate()` now build their result from the tokens they already fetched, instead of re-running an empty auth-code exchange.
- `handle_callback()` delegates to the same helper — login path behavior unchanged.

## Tests

New `test_keycloak_token_refresh.py` (fully mocked — no live Keycloak, no JWT signing):
- refresh returns `SUCCESS` with the **rotated** access + refresh tokens, uses `grant_type=refresh_token`, and **never** re-runs the auth-code exchange (the regression guard).
- refresh surfaces a provider 4xx as `FAILED`.
- `authenticate` builds its result from the password-grant tokens.
- `handle_callback` (login) still works through the shared helper.

Results: 4 new tests pass; existing `test_plugin_system.py` + `test_keycloak.py` = 19 passed, 1 skipped (live-Keycloak integration), no regressions.

## Not covered

No end-to-end run against a live dev Keycloak. The one runtime-only assumption (the refreshed `id_token` carries `aud == client_id` so `_verify_and_decode_token` accepts it) is stubbed in the unit tests by design.

> Base branch is **release/2026.10**, not main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)