### PR TITLE
fix: allow admins through coder ForwardAuth (admin-owned workspaces reachable)

### DIFF
--- a/computor-backend/src/computor_backend/api/auth.py
+++ b/computor-backend/src/computor_backend/api/auth.py
@@ -542,9 +542,11 @@ async def verify_coder_access(
             logger.info(f"  {header_name}: {header_value}")
     logger.info("=========================")
 
-    # Extract username from URL path: /coder/u{user_id}/{workspace}/...
-    # Pattern: /coder/u<uuid>/<workspace>/*
-    pattern = r"/coder/u([a-f0-9\-]+)/([^/]+)"
+    # Extract owner + workspace from the URL path: /coder/{owner}/{workspace}/...
+    # Regular users get a Coder username of u{backend_uuid}; the shared admin/service
+    # account keeps its plain username (e.g. "admin"), which is not the u{uuid} form.
+    # Accept any owner segment here and decide authorization below.
+    pattern = r"/coder/([^/]+)/([^/]+)"
     match = re.match(pattern, original_uri)
 
     if not match:
@@ -554,23 +556,33 @@ async def verify_coder_access(
             content={"detail": "Invalid workspace URL format"}
         )
 
-    url_user_id = match.group(1)  # Extract user ID without 'u' prefix
+    url_owner = match.group(1)  # e.g. "u0232de59-..." (regular user) or "admin"
     workspace_name = match.group(2)
 
-    logger.debug(f"URL user_id: {url_user_id}, workspace: {workspace_name}")
+    logger.debug(f"URL owner: {url_owner}, workspace: {workspace_name}")
 
-    # Check if the authenticated user matches the workspace owner
-    # Note: Coder may truncate usernames due to length limits, so we check if the
-    # authenticated user ID starts with the URL user ID (which may be truncated)
-    if not principal.user_id.startswith(url_user_id):
+    # Admins may access any workspace. This also covers the admin/service account,
+    # whose Coder username is not the u{uuid} form and so would never match the
+    # owner check below. Consistent with the system-wide is_admin bypass.
+    if principal.is_admin:
+        logger.info(f"Admin {principal.user_id} authorized for workspace {url_owner}/{workspace_name}")
+        return JSONResponse(
+            status_code=200,
+            content={"status": "authorized", "user_id": principal.user_id, "workspace": workspace_name}
+        )
+
+    # Regular users: the owner segment must be the u{backend_uuid} form and resolve to
+    # the authenticated principal. Coder may truncate the username, so compare by prefix.
+    url_user_id = url_owner[1:] if url_owner.startswith("u") else url_owner
+    if not (url_owner.startswith("u") and principal.user_id.startswith(url_user_id)):
         logger.warning(
-            f"User {principal.user_id} attempted to access workspace belonging to {url_user_id}"
+            f"User {principal.user_id} attempted to access workspace belonging to {url_owner}"
         )
         return JSONResponse(
             status_code=403,
             content={
                 "detail": "You are not authorized to access this workspace",
-                "workspace_owner": url_user_id,
+                "workspace_owner": url_owner,
                 "authenticated_user": principal.user_id
             }
         )

--- a/computor-backend/src/computor_backend/tests/test_coder_forwardauth.py
+++ b/computor-backend/src/computor_backend/tests/test_coder_forwardauth.py
@@ -1,0 +1,96 @@
+"""Unit tests for the Coder ForwardAuth endpoint (verify_coder_access).
+
+Covers the workspace-access authorization gate Traefik calls before forwarding to a
+code-server workspace, including the admin bypass that lets the shared admin/service
+account (Coder username "admin", not the u{uuid} form) reach its workspace.
+"""
+
+import json
+
+import pytest
+
+from computor_backend.api.auth import verify_coder_access
+from computor_backend.permissions.principal import Principal
+
+
+class _FakeURL:
+    def __init__(self, path):
+        self.path = path
+
+
+class _FakeRequest:
+    """Minimal stand-in for starlette Request: only .headers and .url are used."""
+
+    def __init__(self, forwarded_uri, path="/"):
+        self.headers = {"X-Forwarded-Uri": forwarded_uri}
+        self.url = _FakeURL(path)
+
+
+# A backend user UUID and the Coder username derived from it (u + uuid).
+USER_UUID = "0232de59-e05d-4bc2-898f-b879c06abcde"
+USER_OWNER = "u" + USER_UUID
+
+
+def _admin():
+    return Principal(user_id="admin-backend-uuid", roles=["_admin"])
+
+
+def _user(uuid=USER_UUID):
+    return Principal(user_id=uuid)  # is_admin stays False
+
+
+def _body(resp):
+    return json.loads(resp.body)
+
+
+@pytest.mark.asyncio
+async def test_admin_can_access_admin_owned_workspace():
+    # The case that used to 403 with "Invalid workspace URL format".
+    resp = await verify_coder_access(_FakeRequest("/coder/admin/workspace/"), _admin())
+    assert resp.status_code == 200
+    assert _body(resp)["status"] == "authorized"
+
+
+@pytest.mark.asyncio
+async def test_admin_can_access_any_user_workspace():
+    resp = await verify_coder_access(_FakeRequest("/coder/%s/workspace/" % USER_OWNER), _admin())
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_user_can_access_own_workspace():
+    resp = await verify_coder_access(_FakeRequest("/coder/%s/workspace/" % USER_OWNER), _user())
+    assert resp.status_code == 200
+    assert _body(resp)["workspace"] == "workspace"
+
+
+@pytest.mark.asyncio
+async def test_user_can_access_own_workspace_when_coder_truncates_username():
+    # Coder truncates long usernames; the URL owner is a prefix of the real UUID.
+    truncated = "u" + USER_UUID[:20]
+    resp = await verify_coder_access(_FakeRequest("/coder/%s/workspace/" % truncated), _user())
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_access_other_users_workspace():
+    other = "u" + "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    resp = await verify_coder_access(_FakeRequest("/coder/%s/workspace/" % other), _user())
+    assert resp.status_code == 403
+    assert "not authorized" in _body(resp)["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_access_admin_workspace():
+    # Non-admin hitting /coder/admin/...: owner is not the u{uuid} form -> denied.
+    resp = await verify_coder_access(_FakeRequest("/coder/admin/workspace/"), _user())
+    assert resp.status_code == 403
+    assert "not authorized" in _body(resp)["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_malformed_url_is_rejected():
+    # No workspace segment -> doesn't match the path shape.
+    resp = await verify_coder_access(_FakeRequest("/coder/onlyowner"), _user())
+    assert resp.status_code == 403
+    assert _body(resp)["detail"] == "Invalid workspace URL format"


### PR DESCRIPTION
## Problem
`verify-coder-access` (the Traefik ForwardAuth gate) only accepted URLs of the form `/coder/u{uuid}/{workspace}` and authorized by matching that UUID against the principal. This works for real users because the backend sets their Coder **username = `u{backend_uuid}`**. But the shared **admin/service account** has Coder username `admin`, so `/coder/admin/workspace` fails the regex → `"Invalid workspace URL format"`, and the admin can never open a workspace.

## Change
- Broaden the path regex to accept any owner segment (`/coder/{owner}/{workspace}`).
- Add an **admin bypass**: `if principal.is_admin → authorize` (consistent with the system-wide admin bypass).
- Regular users unchanged: owner must be the `u{uuid}` form and prefix-match the principal (Coder username truncation still handled).

## Tests (`test_coder_forwardauth.py`, 7/7)
admin→admin workspace 200 · admin→any workspace 200 · user→own 200 (incl. truncated username) · user→other user 403 · **non-admin→/coder/admin 403** · malformed URL 403.

Security preserved: non-admins still can't reach `/coder/admin/...` or other users' workspaces.

> Base: **release/2026.10**, not main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)