### PR TITLE
fix: harden coder workspace auto-login token (bounded TTL + rotation)

### DIFF
--- a/computor-backend/src/computor_backend/api/coder.py
+++ b/computor-backend/src/computor_backend/api/coder.py
@@ -169,7 +169,7 @@ async def list_templates(
 async def provision_workspace(
     request: WorkspaceProvisionRequest,
     permissions: Annotated[Principal, Depends(get_current_principal)],
-    _settings: Annotated[CoderSettings, Depends(require_coder_enabled)],
+    settings: Annotated[CoderSettings, Depends(require_coder_enabled)],
     client: Annotated[CoderClient, Depends(get_coder_client)],
     db: Annotated[Session, Depends(get_db)],
     cache: Annotated[object, Depends(get_cache)],
@@ -200,8 +200,11 @@ async def provision_workspace(
         else:
             target_user = get_user_by_id(db, cache, str(permissions.user_id))
 
-        # Mint workspace token
-        workspace_token = mint_workspace_token(db, cache, str(target_user.id), str(permissions.user_id))
+        # Mint workspace token (bounded lifetime; rotated on each provision)
+        workspace_token = mint_workspace_token(
+            db, cache, str(target_user.id), str(permissions.user_id),
+            ttl_days=settings.workspace_token_ttl_days,
+        )
         if workspace_token:
             logger.info(f"Token minted (prefix: {workspace_token[:15]}..., length: {len(workspace_token)})")
         else:

--- a/computor-backend/src/computor_backend/coder/config.py
+++ b/computor-backend/src/computor_backend/coder/config.py
@@ -97,6 +97,14 @@ class CoderSettings(BaseSettings):
         description="Docker registry host for workspace images"
     )
 
+    # Workspace auto-login token (the COMPUTOR_AUTH_TOKEN injected into the workspace)
+    workspace_token_ttl_days: int = Field(
+        default=30,
+        description="Lifetime in days of the auto-minted workspace API token "
+                    "(COMPUTOR_AUTH_TOKEN). Re-minted (rotated) on each provision; "
+                    "set <= 0 to never expire."
+    )
+
 
 # Singleton instance
 _settings: Optional[CoderSettings] = None

--- a/computor-backend/src/computor_backend/coder/service.py
+++ b/computor-backend/src/computor_backend/coder/service.py
@@ -6,6 +6,7 @@ require access to backend repositories and utilities.
 """
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -22,18 +23,25 @@ def mint_workspace_token(
     cache,
     target_user_id: str,
     created_by: str,
+    ttl_days: Optional[int] = 30,
 ) -> Optional[str]:
     """
     Mint an API token for workspace auto-login.
 
     This creates a singleton token named "workspace-auto-login" for the user.
-    If a token with this name already exists, it is revoked first.
+    If a token with this name already exists, it is revoked first (rotation), so
+    each provision hands the workspace a fresh token and invalidates the old one.
+
+    The token is given a bounded lifetime (``ttl_days``) so a leaked
+    COMPUTOR_AUTH_TOKEN cannot be used indefinitely; an actively-used workspace
+    is re-provisioned (and thus re-minted) well within that window.
 
     Args:
         db: Database session
         cache: Redis cache instance
         target_user_id: User ID to create the token for
         created_by: User ID of the admin creating the token
+        ttl_days: Token lifetime in days; ``None`` or <= 0 means never expire
 
     Returns:
         The full token string if successful, None if failed
@@ -51,6 +59,9 @@ def mint_workspace_token(
 
         # Generate and create new token
         full_token, token_prefix, token_hash = generate_api_token()
+        expires_at = None
+        if ttl_days and ttl_days > 0:
+            expires_at = datetime.now(timezone.utc) + timedelta(days=ttl_days)
         api_token = ApiToken(
             name=token_name,
             description="Auto-generated token for VSCode extension in workspace",
@@ -58,6 +69,7 @@ def mint_workspace_token(
             token_hash=token_hash,
             token_prefix=token_prefix,
             scopes=[],
+            expires_at=expires_at,
             created_by=created_by,
         )
         db.add(api_token)

--- a/computor-backend/src/computor_backend/tests/test_workspace_token_ttl.py
+++ b/computor-backend/src/computor_backend/tests/test_workspace_token_ttl.py
@@ -1,0 +1,66 @@
+"""Unit tests for the hardened workspace auto-login token (mint_workspace_token).
+
+The COMPUTOR_AUTH_TOKEN injected into a Coder workspace is a ctp_ API token. To
+limit the blast radius of a leak it is now minted with a bounded lifetime and
+rotated (old one revoked) on each provision. These tests pin that behavior with a
+mocked DB/repo — no live database needed.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from computor_backend.coder.service import mint_workspace_token
+
+
+@patch("computor_backend.coder.service.ApiTokenRepository")
+def test_mint_sets_bounded_expiry(mock_repo_cls):
+    mock_repo_cls.return_value.find_all_active_by_name.return_value = []
+    db = MagicMock()
+
+    token = mint_workspace_token(db, MagicMock(), "user-uuid", "admin-uuid", ttl_days=30)
+
+    assert token and token.startswith("ctp_")
+    api_token = db.add.call_args[0][0]
+    assert api_token.expires_at is not None
+    delta = api_token.expires_at - datetime.now(timezone.utc)
+    assert timedelta(days=29) < delta <= timedelta(days=30)
+    db.commit.assert_called_once()
+
+
+@patch("computor_backend.coder.service.ApiTokenRepository")
+def test_mint_never_expires_when_ttl_non_positive(mock_repo_cls):
+    mock_repo_cls.return_value.find_all_active_by_name.return_value = []
+    db = MagicMock()
+
+    for ttl in (0, None):
+        db.reset_mock()
+        mint_workspace_token(db, MagicMock(), "user-uuid", "admin-uuid", ttl_days=ttl)
+        api_token = db.add.call_args[0][0]
+        assert api_token.expires_at is None
+
+
+@patch("computor_backend.coder.service.ApiTokenRepository")
+def test_mint_rotates_existing_singleton(mock_repo_cls):
+    repo = mock_repo_cls.return_value
+    existing = MagicMock()
+    existing.id = "old-token-id"
+    repo.find_all_active_by_name.return_value = [existing]
+    db = MagicMock()
+
+    mint_workspace_token(db, MagicMock(), "user-uuid", "admin-uuid", ttl_days=30)
+
+    # The previous workspace token is revoked before the new one is issued.
+    repo.revoke.assert_called_once()
+    assert repo.revoke.call_args[0][0] == "old-token-id"
+
+
+@patch("computor_backend.coder.service.ApiTokenRepository")
+def test_mint_token_is_named_workspace_auto_login(mock_repo_cls):
+    mock_repo_cls.return_value.find_all_active_by_name.return_value = []
+    db = MagicMock()
+
+    mint_workspace_token(db, MagicMock(), "user-uuid", "admin-uuid", ttl_days=30)
+
+    api_token = db.add.call_args[0][0]
+    assert api_token.name == "workspace-auto-login"
+    assert api_token.user_id == "user-uuid"


### PR DESCRIPTION
Hardens the `ctp_` API token injected into Coder workspaces as `COMPUTOR_AUTH_TOKEN` (Option A from the SSO-vs-token discussion — workspace *access* is already SSO-gated by ForwardAuth; this bounds the headless token's blast radius).

- `mint_workspace_token` now sets `expires_at` (default **30 days**, `CODER_WORKSPACE_TOKEN_TTL_DAYS`, `<=0` = never). `authenticate_api_token` already enforces expiry; `expires_at` already on the model → **no migration**.
- Rotation (already present) documented: each provision revokes the prior singleton `workspace-auto-login` token and mints a fresh one.
- Wired the provision endpoint's settings dep to pass the TTL.

Tests (`test_workspace_token_ttl.py`, 4/4): bounded expiry · never-expire when ttl<=0 · rotates existing singleton · name/owner.

> Base: **release/2026.10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)