### PR TITLE
fix: /students/courses 500 — make student course repository optional

### DIFF
--- a/computor-backend/src/computor_backend/tests/test_student_courses_dto.py
+++ b/computor-backend/src/computor_backend/tests/test_student_courses_dto.py
@@ -1,0 +1,34 @@
+"""Regression tests for the student-courses DTOs.
+
+`GET /students/courses` 500'd because `CourseStudentList.repository` was required
+while `list_courses` passes `repository=None` for courses with no legacy
+`properties.gitlab` (now the norm under the Forgejo git binding). The field is
+optional; these tests pin that.
+"""
+
+from computor_types.student_courses import (
+    CourseStudentList,
+    CourseStudentGet,
+    CourseStudentRepository,
+)
+
+
+def test_course_student_list_allows_null_repository():
+    item = CourseStudentList(id="c1", path="org.fam.course", repository=None)
+    assert item.repository is None
+
+
+def test_course_student_list_defaults_repository_to_none():
+    item = CourseStudentList(id="c1", path="org.fam.course")
+    assert item.repository is None
+
+
+def test_course_student_list_accepts_a_repository():
+    repo = CourseStudentRepository(provider_url="https://git.example", full_path="org/course")
+    item = CourseStudentList(id="c1", path="org.fam.course", repository=repo)
+    assert item.repository.full_path == "org/course"
+
+
+def test_course_student_get_allows_null_repository():
+    item = CourseStudentGet(id="c1", path="org.fam.course", course_content_types=[], repository=None)
+    assert item.repository is None

--- a/computor-types/src/computor_types/student_courses.py
+++ b/computor-types/src/computor_types/student_courses.py
@@ -16,7 +16,9 @@ class CourseStudentGet(BaseModel):
     course_content_types: list[CourseContentTypeGet]
     path: str
 
-    repository: CourseStudentRepository
+    # Optional: a course may have no git binding exposed to the student (e.g. courses
+    # using the managed Forgejo binding rather than legacy `properties.gitlab`).
+    repository: Optional[CourseStudentRepository] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -32,7 +34,8 @@ class CourseStudentList(BaseModel):
     organization_id: Optional[str] = None
     path: str
 
-    repository: CourseStudentRepository
+    # Optional: see CourseStudentGet.repository.
+    repository: Optional[CourseStudentRepository] = None
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
## Problem
`GET /students/courses` returned **500** for every request:

```
ValidationError: 1 validation error for CourseStudentList
repository
  Input should be a valid dictionary or instance of CourseStudentRepository [input_value=None]
```

`CourseStudentList.repository` (and `CourseStudentGet.repository`) were **required**, but `student_view.list_courses` intentionally passes `repository=None` for courses without a legacy `properties.gitlab` block — which is now the norm since courses use the **Forgejo git binding**, not GitLab properties. So any student with a non-GitLab course crashed the endpoint.

## Fix
Make `repository` optional (`Optional[CourseStudentRepository] = None`) on both `CourseStudentList` and `CourseStudentGet`. `CourseStudentRepository`'s own fields were already optional, so this matches the producer's intent and the post-migration data.

## Tests (`test_student_courses_dto.py`, 4/4)
null repository · default-to-None · accepts a populated repository · `CourseStudentGet` null repository.

## Follow-up (not in this PR)
Populating the student's repo URL from the Forgejo binding (so `repository` is non-null again for managed-git courses) is a separate enhancement — this PR only stops the crash.

> Base: **release/2026.10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)