### PR TITLE
fix: /auth/refresh cookie renewal (stop forced logout)

### DIFF
--- a/computor-backend/src/computor_backend/api/auth.py
+++ b/computor-backend/src/computor_backend/api/auth.py
@@ -477,26 +477,55 @@ async def refresh_local_token(
 
 @auth_router.post("/refresh", response_model=TokenRefreshResponse)
 async def refresh_token(
-    request: TokenRefreshRequest,
+    body: TokenRefreshRequest,
+    request: Request,
+    response: Response,
     principal: Principal = Depends(get_current_principal),
     db: Session = Depends(get_db)
 ) -> TokenRefreshResponse:
     """
     Refresh SSO access token using refresh token.
 
-    This endpoint allows users to refresh their session token using
-    the refresh token obtained during initial SSO authentication.
+    Cookie-based clients (the web UI) omit ``refresh_token`` from the body and
+    send the HttpOnly ``ct_refresh_token`` cookie instead — JS cannot read that
+    cookie, so we read it server-side. On success we re-set both HttpOnly cookies
+    so the browser session is renewed (otherwise the original ``ct_access_token``
+    max_age expires ~1h after login regardless of activity and the user is logged
+    out, and the rotated refresh token never reaches the client).
 
     Requires authentication to ensure only the token owner can refresh it.
     """
     from computor_backend.business_logic.auth import refresh_sso_token
 
+    refresh_token_value = body.refresh_token or request.cookies.get("ct_refresh_token")
+    if not refresh_token_value:
+        raise UnauthorizedException("No refresh token provided")
+
     result = await refresh_sso_token(
-        refresh_token=request.refresh_token,
-        provider=request.provider,
+        refresh_token=refresh_token_value,
+        provider=body.provider,
         principal=principal,
         db=db
     )
+
+    # Renew the HttpOnly cookies so cookie-based clients stay logged in.
+    response.set_cookie(
+        key="ct_access_token",
+        value=result["access_token"],
+        httponly=True,
+        secure=_COOKIE_SECURE,
+        samesite="lax",
+        max_age=3600,
+    )
+    if result.get("refresh_token"):
+        response.set_cookie(
+            key="ct_refresh_token",
+            value=result["refresh_token"],
+            httponly=True,
+            secure=_COOKIE_SECURE,
+            samesite="lax",
+            max_age=604800,
+        )
 
     return TokenRefreshResponse(**result)
 

--- a/computor-backend/src/computor_backend/tests/test_auth_refresh_cookie.py
+++ b/computor-backend/src/computor_backend/tests/test_auth_refresh_cookie.py
@@ -1,0 +1,80 @@
+"""Tests for the /auth/refresh cookie behavior.
+
+The web UI calls /auth/refresh with no refresh_token in the body, relying on the
+HttpOnly ct_refresh_token cookie, and expects the backend to renew the HttpOnly
+cookies. These tests pin both: cookie fallback for the refresh token, and
+re-setting ct_access_token / ct_refresh_token on success.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Response
+
+from computor_backend.api.auth import refresh_token
+from computor_backend.exceptions import UnauthorizedException
+from computor_backend.permissions.principal import Principal
+from computor_types.auth import TokenRefreshRequest
+
+
+class _Req:
+    def __init__(self, cookies):
+        self.cookies = cookies
+
+
+def _set_cookies(response):
+    return [v.decode() for (k, v) in response.raw_headers if k == b"set-cookie"]
+
+
+REFRESH_RESULT = {
+    "access_token": "new-session-token",
+    "expires_in": 86400,
+    "refresh_token": "rotated-refresh-token",
+}
+
+
+@pytest.mark.asyncio
+async def test_refresh_falls_back_to_cookie_and_renews_cookies():
+    body = TokenRefreshRequest(provider="keycloak")  # no refresh_token in body
+    request = _Req({"ct_refresh_token": "cookie-refresh-token"})
+    response = Response()
+    principal = Principal(user_id="u1")
+
+    with patch("computor_backend.business_logic.auth.refresh_sso_token",
+               new=AsyncMock(return_value=REFRESH_RESULT)) as mock_refresh:
+        result = await refresh_token(body, request, response, principal, MagicMock())
+
+    # Used the cookie's refresh token, not the (absent) body value.
+    assert mock_refresh.await_args.kwargs["refresh_token"] == "cookie-refresh-token"
+    # Renewed both HttpOnly cookies.
+    cookies = _set_cookies(response)
+    assert any(c.startswith("ct_access_token=new-session-token") for c in cookies)
+    assert any(c.startswith("ct_refresh_token=rotated-refresh-token") for c in cookies)
+    assert all("HttpOnly" in c for c in cookies)
+    assert result.access_token == "new-session-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_prefers_body_token_when_present():
+    body = TokenRefreshRequest(refresh_token="body-refresh-token", provider="keycloak")
+    request = _Req({"ct_refresh_token": "cookie-refresh-token"})
+    response = Response()
+
+    with patch("computor_backend.business_logic.auth.refresh_sso_token",
+               new=AsyncMock(return_value=REFRESH_RESULT)) as mock_refresh:
+        await refresh_token(body, request, response, Principal(user_id="u1"), MagicMock())
+
+    assert mock_refresh.await_args.kwargs["refresh_token"] == "body-refresh-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_without_any_token_is_unauthorized():
+    body = TokenRefreshRequest(provider="keycloak")
+    request = _Req({})  # no cookie either
+    response = Response()
+
+    with patch("computor_backend.business_logic.auth.refresh_sso_token",
+               new=AsyncMock(return_value=REFRESH_RESULT)) as mock_refresh:
+        with pytest.raises(UnauthorizedException):
+            await refresh_token(body, request, response, Principal(user_id="u1"), MagicMock())
+        mock_refresh.assert_not_awaited()

--- a/computor-types/src/computor_types/auth.py
+++ b/computor-types/src/computor_types/auth.py
@@ -70,7 +70,9 @@ class UserRegistrationResponse(BaseModel):
 
 class TokenRefreshRequest(BaseModel):
     """Token refresh request for SSO."""
-    refresh_token: str = Field(..., description="Refresh token from initial authentication")
+    # Optional: cookie-based clients (web UI) omit this and rely on the HttpOnly
+    # ct_refresh_token cookie, which the endpoint reads as a fallback.
+    refresh_token: Optional[str] = Field(None, description="Refresh token from initial authentication; falls back to the ct_refresh_token cookie")
     provider: str = Field("keycloak", description="Authentication provider")
 
 

--- a/computor-web/src/generated/clients/AuthenticationClient.ts
+++ b/computor-web/src/generated/clients/AuthenticationClient.ts
@@ -88,8 +88,12 @@ export class AuthenticationClient extends BaseEndpointClient {
   /**
    * Refresh Token
    * Refresh SSO access token using refresh token.
-   * This endpoint allows users to refresh their session token using
-   * the refresh token obtained during initial SSO authentication.
+   * Cookie-based clients (the web UI) omit ``refresh_token`` from the body and
+   * send the HttpOnly ``ct_refresh_token`` cookie instead — JS cannot read that
+   * cookie, so we read it server-side. On success we re-set both HttpOnly cookies
+   * so the browser session is renewed (otherwise the original ``ct_access_token``
+   * max_age expires ~1h after login regardless of activity and the user is logged
+   * out, and the rotated refresh token never reaches the client).
    * Requires authentication to ensure only the token owner can refresh it.
    */
   async refreshTokenAuthRefreshPost({ userId, body }: { userId?: string | null; body: TokenRefreshRequest }): Promise<TokenRefreshResponse> {

--- a/computor-web/src/generated/types/auth.ts
+++ b/computor-web/src/generated/types/auth.ts
@@ -150,8 +150,8 @@ export interface UserRegistrationResponse {
  * Token refresh request for SSO.
  */
 export interface TokenRefreshRequest {
-  /** Refresh token from initial authentication */
-  refresh_token: string;
+  /** Refresh token from initial authentication; falls back to the ct_refresh_token cookie */
+  refresh_token?: string | null;
   /** Authentication provider */
   provider?: string;
 }


### PR DESCRIPTION
## Problem
Users get logged out (`{"detail":"Unauthorized"}`) after a short time. The web UI is cookie-based: `ssoAuthService.refreshSession()` calls `POST /auth/refresh` with `credentials:'include'` and **no `refresh_token` in the body**, expecting the backend to (a) read the refresh token from the HttpOnly `ct_refresh_token` cookie and (b) renew the HttpOnly cookies (`IAuthProvider.ts`: *"Backend will refresh HttpOnly cookies automatically"*).

But the backend `/auth/refresh`:
- required `refresh_token` in the **body** (`TokenRefreshRequest.refresh_token = Field(...)`) → the web UI's body-less call was rejected, and
- returned JSON with **no `Set-Cookie`** → the `ct_access_token` cookie (`max_age=3600`) was never renewed and the browser dropped it ~1h after login regardless of activity; the rotated refresh token never reached the client.

So refresh could never actually keep the cookie session alive → forced logout.

## Fix
- `TokenRefreshRequest.refresh_token` → optional; `/auth/refresh` falls back to the `ct_refresh_token` cookie when the body omits it.
- On success, re-`Set-Cookie` `ct_access_token` (+ rotated `ct_refresh_token`) with the same attrs/max_age as login — renewing the browser session. The extension (which sends the token in the body and reads JSON) is unaffected.

## Tests (`test_auth_refresh_cookie.py`, 3/3)
cookie fallback + both cookies renewed (HttpOnly) · body token preferred when present · 401 when neither body nor cookie has a token.

Regenerated the TS client for the now-optional field (`AuthenticationClient.ts`, `types/auth.ts`).

## Note on timing
This fixes the broken refresh→cookie-renewal path (the ~1h cookie-expiry logout). If short (~30 min) logouts persist, the likely remaining factor is **Keycloak realm session config** (default *SSO Session Idle* = 30 min) expiring the refresh token before the web UI's **50-min** proactive refresh fires — a realm-settings / refresh-interval mismatch, not code. Happy to investigate that next.

> Base: **release/2026.10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)