### PR TITLE
fix(web): refresh within Keycloak SSO idle window (stop ~30-min logout)

### DIFF
--- a/computor-web/src/contexts/AuthContext.tsx
+++ b/computor-web/src/contexts/AuthContext.tsx
@@ -100,12 +100,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     initAuth();
   }, []);
 
-  // Proactive token refresh: refresh every 50 minutes (before 1-hour expiration)
+  // Proactive token refresh. This MUST fire well within Keycloak's SSO Session
+  // Idle (30 min on the computor realm): only /auth/refresh resets that idle timer
+  // — ordinary API calls hit the backend's own session, not Keycloak — so if we
+  // wait longer than the idle window the Keycloak session expires and the refresh
+  // (and thus the user's session) dies. 15 min gives two attempts per idle window.
   useEffect(() => {
     if (!user) return;
 
-    // Refresh interval: 50 minutes (3000000 ms)
-    const REFRESH_INTERVAL = 50 * 60 * 1000;
+    // Refresh interval: 15 minutes — comfortably under the 30-min Keycloak SSO idle.
+    const REFRESH_INTERVAL = 15 * 60 * 1000;
 
     // Set up interval to refresh token periodically
     const refreshInterval = setInterval(async () => {


### PR DESCRIPTION
## Problem
Even after the `/auth/refresh` cookie fix (#147), users are logged out after ~30 min. The live `computor` Keycloak realm has **`ssoSessionIdleTimeout = 30 min`**, but the web UI's proactive refresh fired only every **50 min**. Ordinary API calls hit the backend's own (sliding) session and never touch Keycloak, so nothing resets the Keycloak idle timer except `/auth/refresh`. Firing it at 50 min — after the 30-min idle — means the Keycloak SSO session has already expired, the refresh token is dead, `/auth/refresh` fails, and the web UI hard-logs-out.

## Fix
Lower the proactive refresh interval from 50 → **15 min**, comfortably under the 30-min idle (two attempts per window). Each refresh now both resets the Keycloak idle timer and renews the HttpOnly cookies (via #147), keeping active users logged in indefinitely.

## Realm facts (for reference)
`accessTokenLifespan=5m`, `ssoSessionIdleTimeout=30m`, `ssoSessionMaxLifespan=10h`, `revokeRefreshToken=false`.

## Alternatives considered
- Raising `ssoSessionIdleTimeout` on the realm — weakens the idle-security posture; refreshing in-time is the correct client behavior. Left as-is.
- Making `refreshSession` tolerate a failed refresh while the backend session is still valid — a useful resilience follow-up, but out of scope here.

> Base: **release/2026.10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)