### PR TITLE
fix: coder provision NameError (HTTPException undefined) masking real errors

### DIFF
--- a/computor-backend/src/computor_backend/api/coder.py
+++ b/computor-backend/src/computor_backend/api/coder.py
@@ -219,7 +219,10 @@ async def provision_workspace(
             computor_auth_token=workspace_token,
         )
         return result
-    except HTTPException:
+    except ComputorException:
+        # Typed exceptions (ServiceUnavailableException, NotFoundException, …) already
+        # carry the right status — let them propagate untouched. (The old clause named
+        # an unimported HTTPException, which raised NameError and masked these.)
         raise
     except Exception as e:
         raise _handle_coder_error(e) from e

--- a/computor-backend/src/computor_backend/tests/test_coder_provision_errors.py
+++ b/computor-backend/src/computor_backend/tests/test_coder_provision_errors.py
@@ -1,0 +1,52 @@
+"""Regression tests for error handling in the Coder workspace-provision endpoint.
+
+Production hit `NameError: name 'HTTPException' is not defined` from the endpoint's
+`except HTTPException:` clause (HTTPException was never imported), which masked the
+real 503 ("template not yet available"). The clause now catches ComputorException —
+typed exceptions propagate untouched; unexpected ones are mapped by _handle_coder_error.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from computor_backend.api.coder import provision_workspace
+from computor_backend.coder.exceptions import (
+    CoderTemplateNotFoundError,
+    CoderConnectionError,
+)
+from computor_backend.exceptions import ServiceUnavailableException
+from computor_backend.permissions.principal import Principal
+from computor_types.workspace_roles import WorkspaceProvisionRequest
+
+
+def _admin():
+    return Principal(user_id="u1", roles=["_admin"])
+
+
+@pytest.mark.asyncio
+async def test_template_not_found_propagates_as_service_unavailable():
+    request = WorkspaceProvisionRequest()  # default template = python-workspace
+    client = MagicMock()
+    client.get_template_id = AsyncMock(side_effect=CoderTemplateNotFoundError("python-workspace"))
+
+    with patch("computor_backend.api.coder._check_workspace_access"):
+        with pytest.raises(ServiceUnavailableException) as exc:
+            await provision_workspace(request, _admin(), MagicMock(), client, MagicMock(), MagicMock())
+
+    # The typed 503 (not a NameError, not a generic 500) reaches the caller intact.
+    assert "not yet available" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_coder_error_is_mapped_not_nameerror():
+    request = WorkspaceProvisionRequest()
+    client = MagicMock()
+    client.get_template_id = AsyncMock(side_effect=CoderConnectionError("down"))
+
+    with patch("computor_backend.api.coder._check_workspace_access"):
+        with pytest.raises(ServiceUnavailableException) as exc:
+            await provision_workspace(request, _admin(), MagicMock(), client, MagicMock(), MagicMock())
+
+    # Mapped by _handle_coder_error (the `except Exception` path), not a NameError.
+    assert "connect to Coder" in str(exc.value)


### PR DESCRIPTION
## Problem (production)
`POST /api/coder/workspaces/provision` 500'd with:
```
File ".../api/coder.py", line 222, in provision_workspace
    except HTTPException:
NameError: name 'HTTPException' is not defined
```
The endpoint's `except HTTPException: raise` clause names `HTTPException`, which is **not imported** in `api/coder.py`. So whenever the try-block raised (here the intended `ServiceUnavailableException` "template not yet available"), evaluating the `except` clause itself threw `NameError` → a generic 500 that masked the real 503. And `_handle_coder_error`'s fallback wraps anything unexpected into `InternalServerException`, so even without the NameError the typed status would have been lost.

## Fix
Catch **`ComputorException`** (the codebase's typed base — `ServiceUnavailableException`, `NotFoundException`, … — already imported) instead of the unimported `HTTPException`. Typed exceptions now propagate with their correct status; only genuinely-unexpected errors are mapped by `_handle_coder_error`. (This was the only broken `except HTTPException` in the backend — `crud.py`'s imports it correctly.)

## Tests (`test_coder_provision_errors.py`, 2/2)
- template-not-found → `ServiceUnavailableException` (503, "not yet available") propagates — no NameError.
- unexpected `CoderConnectionError` → mapped to `ServiceUnavailableException` ("connect to Coder") via `_handle_coder_error`.

## Note — the underlying production symptom
With this fix you'll now get the **correct 503**: *"Template 'python-workspace' is not yet available."* That's the real issue behind "no workspaces" — **the prod Coder has no templates pushed** (same setup step as dev: build images + push templates to the prod Coder). That's an environment/deployment step, separate from this code fix.

> Base: **release/2026.10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)