### PR TITLE
Add analytics API authorization layer

### DIFF
--- a/computor-backend/src/computor_backend/analytics/__init__.py
+++ b/computor-backend/src/computor_backend/analytics/__init__.py
@@ -2,6 +2,7 @@
 
 from .config import ANALYTICS_TABLES, AnalyticsCutoffs, AnalyticsStorageConfig
 from .grading_repository import AnalyticsDuckDbGradingRepository
+from .report_repository import AnalyticsDuckDbReportRepository
 from .source import PostgresAnalyticsSource
 from .store import AnalyticsDuckDbStore
 
@@ -9,6 +10,7 @@ __all__ = [
     "ANALYTICS_TABLES",
     "AnalyticsCutoffs",
     "AnalyticsDuckDbGradingRepository",
+    "AnalyticsDuckDbReportRepository",
     "AnalyticsDuckDbStore",
     "AnalyticsStorageConfig",
     "PostgresAnalyticsSource",

--- a/computor-backend/src/computor_backend/analytics/job_store.py
+++ b/computor-backend/src/computor_backend/analytics/job_store.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+from computor_backend.exceptions import BadRequestException
+from computor_types.analytics import AnalyticsJobStatus
+
+
+class AnalyticsJobStore:
+    def __init__(self, root: Path | str):
+        self.root = Path(root) / "jobs"
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def save(self, job: AnalyticsJobStatus) -> AnalyticsJobStatus:
+        path = self._path(job.job_id)
+        path.write_text(
+            json.dumps(job.model_dump(mode="json"), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        return job
+
+    def get(self, job_id: str) -> AnalyticsJobStatus | None:
+        path = self._path(job_id)
+        if not path.exists():
+            return None
+        return AnalyticsJobStatus.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def list(self, course_id: str | None = None, limit: int = 20) -> list[AnalyticsJobStatus]:
+        jobs = []
+        for path in self.root.glob("*.json"):
+            job = AnalyticsJobStatus.model_validate_json(path.read_text(encoding="utf-8"))
+            if course_id is None or job.course_id == str(course_id):
+                jobs.append(job)
+        jobs.sort(key=lambda job: job.created_at, reverse=True)
+        return jobs[:limit]
+
+    def latest_for_course(self, course_id: str) -> AnalyticsJobStatus | None:
+        jobs = self.list(course_id=course_id, limit=1)
+        return jobs[0] if jobs else None
+
+    def _path(self, job_id: str) -> Path:
+        if not re.fullmatch(r"[a-f0-9]{32}", job_id):
+            raise BadRequestException("Invalid analytics job id")
+        return self.root / f"{job_id}.json"

--- a/computor-backend/src/computor_backend/analytics/report_repository.py
+++ b/computor-backend/src/computor_backend/analytics/report_repository.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from typing import Any
+
+import duckdb
+
+from .config import AnalyticsCutoffs
+from .grading_repository import AnalyticsDuckDbGradingRepository
+
+
+class AnalyticsDuckDbReportRepository(AnalyticsDuckDbGradingRepository):
+    def __init__(
+        self,
+        connection: duckdb.DuckDBPyConnection,
+        cutoffs: AnalyticsCutoffs | None = None,
+    ):
+        super().__init__(connection, cutoffs=cutoffs)
+
+    def get_student_checkpoint_rows(self, course_id: str) -> list[dict[str, Any]]:
+        submittable_filter, submittable_params = self._submittable_filter(course_id)
+        profile_join, profile_params = self._student_profile_join(course_id)
+        time_column = self._submission_time_column()
+
+        submitted_params: list[Any] = []
+        submission_cutoff = self._cutoff_filter(
+            f"sa.{time_column}",
+            self.cutoffs.submission,
+            submitted_params,
+        )
+        late_params: list[Any] = []
+        late_submission_filter = self._after_cutoff_filter(
+            f"sa.{time_column}",
+            self.cutoffs.submission,
+            late_params,
+        )
+        grade_params: list[Any] = []
+        grade_submission_cutoff = self._cutoff_filter(
+            f"sa.{time_column}",
+            self.cutoffs.submission,
+            grade_params,
+        )
+        grading_cutoff = self._cutoff_filter(
+            "sgd.graded_at",
+            self.cutoffs.grading,
+            grade_params,
+        )
+
+        return self._rows(
+            f"""
+            WITH submittable_contents AS (
+                SELECT cc.id AS content_id
+                FROM course_content cc
+                JOIN course_content_type cct ON cct.id = cc.course_content_type_id
+                JOIN course_content_kind cck ON cck.id = cct.course_content_kind_id
+                WHERE {submittable_filter}
+            ),
+            all_students AS (
+                SELECT
+                    cm.id AS course_member_id,
+                    cm.user_id,
+                    u.email AS username,
+                    u.given_name,
+                    u.family_name,
+                    sp.student_id
+                FROM course_member cm
+                JOIN "user" u ON u.id = cm.user_id
+                {profile_join}
+                WHERE cm.course_id = ?
+                  AND cm.course_role_id = '_student'
+            ),
+            submitted_slots AS (
+                SELECT
+                    sgm.course_member_id,
+                    sg.course_content_id,
+                    MAX(sa.{time_column}) AS latest_submission_at
+                FROM submittable_contents sc
+                JOIN submission_group sg ON sg.course_content_id = sc.content_id
+                JOIN submission_group_member sgm ON sgm.submission_group_id = sg.id
+                JOIN submission_artifact sa ON sa.submission_group_id = sg.id
+                WHERE sa.submit = true
+                  {submission_cutoff}
+                GROUP BY sgm.course_member_id, sg.course_content_id
+            ),
+            late_official_submissions AS (
+                SELECT
+                    sgm.course_member_id,
+                    COUNT(DISTINCT sg.course_content_id) AS late_submission_count
+                FROM submittable_contents sc
+                JOIN submission_group sg ON sg.course_content_id = sc.content_id
+                JOIN submission_group_member sgm ON sgm.submission_group_id = sg.id
+                JOIN submission_artifact sa ON sa.submission_group_id = sg.id
+                WHERE sa.submit = true
+                  {late_submission_filter}
+                GROUP BY sgm.course_member_id
+            ),
+            latest_grade_rows AS (
+                SELECT *
+                FROM (
+                    SELECT
+                        sgm.course_member_id,
+                        sg.course_content_id,
+                        sgd.grade,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY sgm.course_member_id, sg.course_content_id
+                            ORDER BY sgd.graded_at DESC
+                        ) AS rn
+                    FROM submittable_contents sc
+                    JOIN submission_group sg ON sg.course_content_id = sc.content_id
+                    JOIN submission_group_member sgm ON sgm.submission_group_id = sg.id
+                    JOIN submission_artifact sa ON sa.submission_group_id = sg.id
+                    JOIN submission_grade sgd ON sgd.artifact_id = sa.id
+                    WHERE sa.submit = true
+                      {grade_submission_cutoff}
+                      {grading_cutoff}
+                ) ranked
+                WHERE rn = 1
+            )
+            SELECT
+                s.course_member_id,
+                s.user_id,
+                s.username,
+                s.given_name,
+                s.family_name,
+                s.student_id,
+                COUNT(sc.content_id) AS total_max_assignments,
+                COUNT(sub.course_content_id) AS total_submitted_assignments,
+                COUNT(grd.course_content_id) AS total_graded_assignments,
+                AVG(grd.grade) AS average_grading,
+                MAX(sub.latest_submission_at) AS latest_submission_at,
+                COALESCE(MAX(late.late_submission_count), 0) AS late_submission_count
+            FROM all_students s
+            CROSS JOIN submittable_contents sc
+            LEFT JOIN submitted_slots sub
+                ON sub.course_member_id = s.course_member_id
+                AND sub.course_content_id = sc.content_id
+            LEFT JOIN latest_grade_rows grd
+                ON grd.course_member_id = s.course_member_id
+                AND grd.course_content_id = sc.content_id
+            LEFT JOIN late_official_submissions late
+                ON late.course_member_id = s.course_member_id
+            GROUP BY
+                s.course_member_id,
+                s.user_id,
+                s.username,
+                s.given_name,
+                s.family_name,
+                s.student_id
+            ORDER BY s.family_name, s.given_name
+            """,
+            [
+                *submittable_params,
+                *profile_params,
+                str(course_id),
+                *submitted_params,
+                *late_params,
+                *grade_params,
+            ],
+        )
+
+    def get_timeline_events(
+        self,
+        course_id: str,
+        course_member_id: str,
+    ) -> list[dict[str, Any]]:
+        events = [
+            *self._artifact_events(course_id, course_member_id),
+            *self._result_events(course_id, course_member_id),
+            *self._grading_events(course_id, course_member_id),
+        ]
+        for event in events:
+            event["relation_to_submission_cutoff"] = self._cutoff_relation(
+                event.get("occurred_at")
+            )
+        return sorted(events, key=lambda event: event["occurred_at"])
+
+    def _artifact_events(
+        self,
+        course_id: str,
+        course_member_id: str,
+    ) -> list[dict[str, Any]]:
+        time_column = self._submission_time_column()
+        return self._rows(
+            f"""
+            SELECT
+                sa.{time_column} AS occurred_at,
+                CASE
+                    WHEN sa.submit = true THEN 'official_submission'
+                    ELSE 'test_submission'
+                END AS event_type,
+                cc.id AS course_content_id,
+                CAST(cc.path AS VARCHAR) AS path,
+                cc.title,
+                sa.id AS artifact_id,
+                NULL AS result_id,
+                NULL AS grade,
+                NULL AS status,
+                sa.submit,
+                sa.version_identifier
+            FROM submission_artifact sa
+            JOIN submission_group sg ON sg.id = sa.submission_group_id
+            JOIN submission_group_member sgm ON sgm.submission_group_id = sg.id
+            JOIN course_content cc ON cc.id = sg.course_content_id
+            WHERE sg.course_id = ?
+              AND sgm.course_member_id = ?
+            """,
+            [str(course_id), str(course_member_id)],
+        )
+
+    def _result_events(
+        self,
+        course_id: str,
+        course_member_id: str,
+    ) -> list[dict[str, Any]]:
+        result_grade_column = "result" if self._has_column("result", "result") else "grade"
+        return self._rows(
+            f"""
+            SELECT
+                r.created_at AS occurred_at,
+                'test_result' AS event_type,
+                cc.id AS course_content_id,
+                CAST(cc.path AS VARCHAR) AS path,
+                cc.title,
+                r.submission_artifact_id AS artifact_id,
+                r.id AS result_id,
+                r.{result_grade_column} AS grade,
+                r.status,
+                false AS submit,
+                r.version_identifier
+            FROM result r
+            JOIN course_content cc ON cc.id = r.course_content_id
+            WHERE cc.course_id = ?
+              AND r.course_member_id = ?
+            """,
+            [str(course_id), str(course_member_id)],
+        )
+
+    def _grading_events(
+        self,
+        course_id: str,
+        course_member_id: str,
+    ) -> list[dict[str, Any]]:
+        return self._rows(
+            """
+            SELECT
+                sgd.graded_at AS occurred_at,
+                'grading' AS event_type,
+                cc.id AS course_content_id,
+                CAST(cc.path AS VARCHAR) AS path,
+                cc.title,
+                sa.id AS artifact_id,
+                NULL AS result_id,
+                sgd.grade,
+                sgd.status,
+                sa.submit,
+                sa.version_identifier
+            FROM submission_grade sgd
+            JOIN submission_artifact sa ON sa.id = sgd.artifact_id
+            JOIN submission_group sg ON sg.id = sa.submission_group_id
+            JOIN submission_group_member sgm ON sgm.submission_group_id = sg.id
+            JOIN course_content cc ON cc.id = sg.course_content_id
+            WHERE sg.course_id = ?
+              AND sgm.course_member_id = ?
+            """,
+            [str(course_id), str(course_member_id)],
+        )
+
+    def _after_cutoff_filter(
+        self,
+        column: str,
+        cutoff: Any,
+        params: list[Any],
+    ) -> str:
+        if cutoff is None:
+            return "AND false"
+        params.append(cutoff)
+        return f"AND {column} > ?"
+
+    def _cutoff_relation(self, occurred_at: Any) -> str | None:
+        if self.cutoffs.submission is None or occurred_at is None:
+            return None
+        if occurred_at <= self.cutoffs.submission:
+            return "before_submission_cutoff"
+        return "after_submission_cutoff"

--- a/computor-backend/src/computor_backend/analytics/service.py
+++ b/computor-backend/src/computor_backend/analytics/service.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import re
+from uuid import uuid4
+
+from fastapi import BackgroundTasks
+import duckdb
+
+from computor_backend.exceptions import (
+    BadRequestException,
+    ConfigurationException,
+    NotFoundException,
+)
+from computor_backend.settings import settings
+from computor_types.analytics import (
+    AnalyticsCourseSummary,
+    AnalyticsJobStatus,
+    AnalyticsRefreshRequest,
+    AnalyticsStudentCheckpoint,
+    AnalyticsStudentList,
+    AnalyticsStudentReport,
+    AnalyticsStudentTimeline,
+    AnalyticsTimelineEvent,
+)
+
+from .config import ANALYTICS_TABLES, AnalyticsCutoffs, AnalyticsStorageConfig
+from .grading_repository import AnalyticsDuckDbGradingRepository
+from .job_store import AnalyticsJobStore
+from .report_repository import AnalyticsDuckDbReportRepository
+from .source import PostgresAnalyticsSource
+from .store import AnalyticsDuckDbStore
+from ..services.course_member_grading_read import (
+    build_course_member_grading_list_response,
+    build_course_member_grading_response,
+)
+
+
+class AnalyticsService:
+    def __init__(
+        self,
+        storage_config: AnalyticsStorageConfig,
+        source_database_url: str | None = None,
+        export_chunk_size: int = 100_000,
+    ):
+        self.storage_config = storage_config
+        self.source_database_url = source_database_url
+        self.export_chunk_size = export_chunk_size
+        self.job_store = AnalyticsJobStore(storage_config.root)
+
+    @classmethod
+    def from_settings(cls, source_name: str | None = None) -> "AnalyticsService":
+        return cls(
+            AnalyticsStorageConfig(
+                root=Path(settings.ANALYTICS_ROOT),
+                source_name=source_name or settings.ANALYTICS_SOURCE_NAME,
+            ),
+            source_database_url=settings.ANALYTICS_SOURCE_DATABASE_URL,
+            export_chunk_size=settings.ANALYTICS_EXPORT_CHUNK_SIZE,
+        )
+
+    def trigger_refresh(
+        self,
+        course_id: str,
+        request: AnalyticsRefreshRequest,
+        requested_by_user_id: str | None,
+        background_tasks: BackgroundTasks,
+    ) -> AnalyticsJobStatus:
+        if not self.source_database_url:
+            raise ConfigurationException("Analytics source database is not configured")
+        _validate_slug(request.source_name)
+        if request.run_id is not None:
+            _validate_slug(request.run_id)
+        for table in request.tables or ():
+            if table not in ANALYTICS_TABLES:
+                raise BadRequestException("Unknown analytics source table")
+
+        now = _utc_now()
+        job = AnalyticsJobStatus(
+            job_id=uuid4().hex,
+            course_id=str(course_id),
+            source_name=request.source_name,
+            requested_by_user_id=requested_by_user_id,
+            status="queued",
+            progress={"stage": "queued"},
+            submission_cutoff=request.submission_cutoff,
+            grading_cutoff=request.grading_cutoff,
+            created_at=now,
+        )
+        self.job_store.save(job)
+        background_tasks.add_task(self.run_refresh_job, job.job_id, request)
+        return job
+
+    def run_refresh_job(
+        self,
+        job_id: str,
+        request: AnalyticsRefreshRequest,
+    ) -> None:
+        job = self._require_job(job_id)
+        job.status = "running"
+        job.started_at = _utc_now()
+        job.progress = {"stage": "exporting"}
+        self.job_store.save(job)
+
+        source_config = AnalyticsStorageConfig(
+            root=self.storage_config.root,
+            source_name=request.source_name,
+        )
+        store = AnalyticsDuckDbStore(source_config.duckdb_path)
+        try:
+            source = PostgresAnalyticsSource(
+                self.source_database_url or "",
+                application_name="computor_analytics_blue",
+                chunk_size=self.export_chunk_size,
+            )
+            snapshot_path = source.export_snapshot(
+                store,
+                source_config.raw_root,
+                run_id=request.run_id,
+                tables=tuple(request.tables or ANALYTICS_TABLES),
+            )
+            row_counts, high_water_marks = _read_manifest(snapshot_path)
+            job.status = "succeeded"
+            job.progress = {"stage": "complete"}
+            job.snapshot_path = str(snapshot_path)
+            job.row_counts = row_counts
+            job.high_water_marks = high_water_marks
+            job.finished_at = _utc_now()
+            self.job_store.save(job)
+        except Exception as exc:
+            job.status = "failed"
+            job.progress = {"stage": "failed"}
+            job.error = f"{exc.__class__.__name__}: refresh failed"
+            job.finished_at = _utc_now()
+            self.job_store.save(job)
+        finally:
+            store.close()
+
+    def get_job(self, job_id: str) -> AnalyticsJobStatus:
+        return self._require_job(job_id)
+
+    def list_jobs(self, course_id: str, limit: int = 20) -> list[AnalyticsJobStatus]:
+        return self.job_store.list(course_id=str(course_id), limit=limit)
+
+    def course_summary(
+        self,
+        course_id: str,
+        cutoffs: AnalyticsCutoffs,
+    ) -> AnalyticsCourseSummary:
+        students = self.student_checkpoints(course_id, cutoffs)
+        total_students = len(students)
+        total_max = sum(student.total_max_assignments for student in students)
+        total_submitted = sum(
+            student.total_submitted_assignments for student in students
+        )
+        total_graded = sum(student.total_graded_assignments for student in students)
+        grade_sum = sum(
+            (student.average_grading or 0) * student.total_graded_assignments
+            for student in students
+        )
+        latest_submission_at = None
+        for student in students:
+            latest_at = student.latest_submission_at
+            if latest_at and (
+                latest_submission_at is None or latest_at > latest_submission_at
+            ):
+                latest_submission_at = latest_at
+
+        return AnalyticsCourseSummary(
+            course_id=str(course_id),
+            total_students=total_students,
+            total_max_assignments=total_max,
+            total_submitted_assignments=total_submitted,
+            submitted_percentage=_percentage(total_submitted, total_max),
+            total_graded_assignments=total_graded,
+            graded_percentage=_percentage(total_graded, total_max),
+            average_grading=_average(grade_sum, total_graded),
+            latest_submission_at=latest_submission_at,
+            submission_cutoff=cutoffs.submission,
+            grading_cutoff=cutoffs.grading,
+            latest_job=self.job_store.latest_for_course(str(course_id)),
+        )
+
+    def student_list(
+        self,
+        course_id: str,
+        cutoffs: AnalyticsCutoffs,
+    ) -> AnalyticsStudentList:
+        connection = self._read_connection()
+        try:
+            grading_repo = AnalyticsDuckDbGradingRepository(connection, cutoffs)
+            return AnalyticsStudentList(
+                students=self._student_checkpoints_from_connection(
+                    connection,
+                    course_id,
+                    cutoffs,
+                ),
+                gradings=build_course_member_grading_list_response(
+                    grading_repo,
+                    course_id,
+                ),
+            )
+        finally:
+            connection.close()
+
+    def student_checkpoints(
+        self,
+        course_id: str,
+        cutoffs: AnalyticsCutoffs,
+    ) -> list[AnalyticsStudentCheckpoint]:
+        connection = self._read_connection()
+        try:
+            return self._student_checkpoints_from_connection(
+                connection,
+                course_id,
+                cutoffs,
+            )
+        finally:
+            connection.close()
+
+    def student_report(
+        self,
+        course_id: str,
+        course_member_id: str,
+        cutoffs: AnalyticsCutoffs,
+    ) -> AnalyticsStudentReport:
+        connection = self._read_connection()
+        try:
+            report_repo = AnalyticsDuckDbReportRepository(connection, cutoffs)
+            grading_repo = AnalyticsDuckDbGradingRepository(connection, cutoffs)
+            checkpoint_rows = report_repo.get_student_checkpoint_rows(course_id)
+            checkpoint = next(
+                (
+                    _checkpoint_from_row(course_id, row)
+                    for row in checkpoint_rows
+                    if row["course_member_id"] == str(course_member_id)
+                ),
+                None,
+            )
+            if checkpoint is None:
+                raise NotFoundException("Analytics course member not found")
+
+            grading = build_course_member_grading_response(
+                grading_repo,
+                course_member_id,
+                course_id,
+                checkpoint.model_dump(),
+            )
+            timeline = AnalyticsStudentTimeline(
+                course_id=str(course_id),
+                course_member_id=str(course_member_id),
+                submission_cutoff=cutoffs.submission,
+                grading_cutoff=cutoffs.grading,
+                events=[
+                    AnalyticsTimelineEvent(**event)
+                    for event in report_repo.get_timeline_events(
+                        course_id,
+                        course_member_id,
+                    )
+                ],
+            )
+            return AnalyticsStudentReport(
+                checkpoint=checkpoint,
+                grading=grading,
+                timeline=timeline,
+            )
+        finally:
+            connection.close()
+
+    def student_timeline(
+        self,
+        course_id: str,
+        course_member_id: str,
+        cutoffs: AnalyticsCutoffs,
+    ) -> AnalyticsStudentTimeline:
+        connection = self._read_connection()
+        try:
+            repo = AnalyticsDuckDbReportRepository(connection, cutoffs)
+            return AnalyticsStudentTimeline(
+                course_id=str(course_id),
+                course_member_id=str(course_member_id),
+                submission_cutoff=cutoffs.submission,
+                grading_cutoff=cutoffs.grading,
+                events=[
+                    AnalyticsTimelineEvent(**event)
+                    for event in repo.get_timeline_events(course_id, course_member_id)
+                ],
+            )
+        finally:
+            connection.close()
+
+    def _student_checkpoints_from_connection(
+        self,
+        connection: duckdb.DuckDBPyConnection,
+        course_id: str,
+        cutoffs: AnalyticsCutoffs,
+    ) -> list[AnalyticsStudentCheckpoint]:
+        repo = AnalyticsDuckDbReportRepository(connection, cutoffs)
+        return [
+            _checkpoint_from_row(course_id, row)
+            for row in repo.get_student_checkpoint_rows(course_id)
+        ]
+
+    def _read_connection(self) -> duckdb.DuckDBPyConnection:
+        path = self.storage_config.duckdb_path
+        if not path.exists():
+            raise NotFoundException("Analytics database has not been built")
+        return duckdb.connect(str(path), read_only=True)
+
+    def _require_job(self, job_id: str) -> AnalyticsJobStatus:
+        job = self.job_store.get(job_id)
+        if job is None:
+            raise NotFoundException("Analytics job not found")
+        return job
+
+
+def _checkpoint_from_row(
+    course_id: str,
+    row: dict[str, object],
+) -> AnalyticsStudentCheckpoint:
+    total_max = int(row["total_max_assignments"] or 0)
+    submitted = int(row["total_submitted_assignments"] or 0)
+    graded = int(row["total_graded_assignments"] or 0)
+    average = row.get("average_grading")
+    return AnalyticsStudentCheckpoint(
+        course_member_id=str(row["course_member_id"]),
+        course_id=str(course_id),
+        user_id=str(row["user_id"]) if row.get("user_id") else None,
+        username=row.get("username"),
+        given_name=row.get("given_name"),
+        family_name=row.get("family_name"),
+        student_id=row.get("student_id"),
+        total_max_assignments=total_max,
+        total_submitted_assignments=submitted,
+        submitted_percentage=_percentage(submitted, total_max),
+        total_graded_assignments=graded,
+        graded_percentage=_percentage(graded, total_max),
+        average_grading=round(float(average), 4) if average is not None else None,
+        latest_submission_at=row.get("latest_submission_at"),
+        late_submission_count=int(row.get("late_submission_count") or 0),
+    )
+
+
+def _read_manifest(snapshot_path: Path) -> tuple[dict[str, int], dict[str, dict[str, str]]]:
+    manifest_path = snapshot_path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    row_counts = {}
+    high_water_marks = {}
+    for table, table_manifest in manifest.get("tables", {}).items():
+        row_counts[table] = int(table_manifest.get("rows", 0))
+        high_water_marks[table] = table_manifest.get("high_water_marks", {})
+    return row_counts, high_water_marks
+
+
+def _validate_slug(value: str) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9_.=-]+", value):
+        raise BadRequestException("Invalid analytics identifier")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _percentage(value: int, total: int) -> float:
+    return round((value / total * 100) if total > 0 else 0.0, 2)
+
+
+def _average(value: float, count: int) -> float | None:
+    return round(value / count, 4) if count > 0 else None

--- a/computor-backend/src/computor_backend/api/analytics.py
+++ b/computor-backend/src/computor_backend/api/analytics.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Query
+from sqlalchemy.orm import Session
+
+from computor_backend.analytics import AnalyticsCutoffs
+from computor_backend.analytics.service import AnalyticsService
+from computor_backend.database import get_db
+from computor_backend.exceptions import ForbiddenException
+from computor_backend.model.course import CourseMember
+from computor_backend.permissions.auth import get_current_principal
+from computor_backend.permissions.core import check_course_permissions
+from computor_backend.permissions.principal import Principal
+from computor_types.analytics import (
+    AnalyticsCourseSummary,
+    AnalyticsJobStatus,
+    AnalyticsRefreshRequest,
+    AnalyticsStudentList,
+    AnalyticsStudentReport,
+    AnalyticsStudentTimeline,
+)
+
+
+analytics_router = APIRouter(prefix="/analytics")
+ANALYTICS_READ_ROLE = "_tutor"
+ANALYTICS_REFRESH_ROLE = "_lecturer"
+
+
+@analytics_router.post(
+    "/courses/{course_id}/refresh",
+    response_model=AnalyticsJobStatus,
+)
+async def refresh_course_analytics(
+    course_id: str,
+    request: AnalyticsRefreshRequest,
+    background_tasks: BackgroundTasks,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> AnalyticsJobStatus:
+    _require_course_role(permissions, db, course_id, ANALYTICS_REFRESH_ROLE)
+    service = AnalyticsService.from_settings(source_name=request.source_name)
+    return service.trigger_refresh(
+        course_id=course_id,
+        request=request,
+        requested_by_user_id=permissions.get_user_id(),
+        background_tasks=background_tasks,
+    )
+
+
+@analytics_router.get(
+    "/courses/{course_id}/jobs",
+    response_model=list[AnalyticsJobStatus],
+)
+async def list_course_analytics_jobs(
+    course_id: str,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+    limit: int = Query(20, ge=1, le=100),
+) -> list[AnalyticsJobStatus]:
+    _require_course_role(permissions, db, course_id, ANALYTICS_READ_ROLE)
+    return AnalyticsService.from_settings().list_jobs(course_id, limit=limit)
+
+
+@analytics_router.get(
+    "/jobs/{job_id}",
+    response_model=AnalyticsJobStatus,
+)
+async def get_analytics_job(
+    job_id: str,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> AnalyticsJobStatus:
+    job = AnalyticsService.from_settings().get_job(job_id)
+    _require_course_role(permissions, db, job.course_id, ANALYTICS_READ_ROLE)
+    return job
+
+
+@analytics_router.get(
+    "/courses/{course_id}/summary",
+    response_model=AnalyticsCourseSummary,
+)
+async def get_course_analytics_summary(
+    course_id: str,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+    submission_cutoff: datetime | None = None,
+    grading_cutoff: datetime | None = None,
+) -> AnalyticsCourseSummary:
+    _require_course_role(permissions, db, course_id, ANALYTICS_READ_ROLE)
+    return AnalyticsService.from_settings().course_summary(
+        course_id,
+        _cutoffs(submission_cutoff, grading_cutoff),
+    )
+
+
+@analytics_router.get(
+    "/courses/{course_id}/students",
+    response_model=AnalyticsStudentList,
+)
+async def list_course_analytics_students(
+    course_id: str,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+    submission_cutoff: datetime | None = None,
+    grading_cutoff: datetime | None = None,
+) -> AnalyticsStudentList:
+    _require_course_role(permissions, db, course_id, ANALYTICS_READ_ROLE)
+    return AnalyticsService.from_settings().student_list(
+        course_id,
+        _cutoffs(submission_cutoff, grading_cutoff),
+    )
+
+
+@analytics_router.get(
+    "/courses/{course_id}/students/{course_member_id}",
+    response_model=AnalyticsStudentReport,
+)
+async def get_course_analytics_student_report(
+    course_id: str,
+    course_member_id: str,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+    submission_cutoff: datetime | None = None,
+    grading_cutoff: datetime | None = None,
+) -> AnalyticsStudentReport:
+    _require_course_role(permissions, db, course_id, ANALYTICS_READ_ROLE)
+    return AnalyticsService.from_settings().student_report(
+        course_id,
+        course_member_id,
+        _cutoffs(submission_cutoff, grading_cutoff),
+    )
+
+
+@analytics_router.get(
+    "/courses/{course_id}/students/{course_member_id}/timeline",
+    response_model=AnalyticsStudentTimeline,
+)
+async def get_course_analytics_student_timeline(
+    course_id: str,
+    course_member_id: str,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+    submission_cutoff: datetime | None = None,
+    grading_cutoff: datetime | None = None,
+) -> AnalyticsStudentTimeline:
+    _require_course_role(permissions, db, course_id, ANALYTICS_READ_ROLE)
+    return AnalyticsService.from_settings().student_timeline(
+        course_id,
+        course_member_id,
+        _cutoffs(submission_cutoff, grading_cutoff),
+    )
+
+
+def _require_course_role(
+    permissions: Principal,
+    db: Session,
+    course_id: str,
+    minimum_role: str,
+) -> None:
+    if permissions.is_admin:
+        return
+    has_course_role = check_course_permissions(
+        permissions,
+        CourseMember,
+        minimum_role,
+        db,
+    ).filter(
+        CourseMember.course_id == course_id,
+        CourseMember.user_id == permissions.get_user_id(),
+    ).first()
+    if not has_course_role:
+        raise ForbiddenException("Analytics access requires course staff role")
+
+
+def _cutoffs(
+    submission_cutoff: datetime | None,
+    grading_cutoff: datetime | None,
+) -> AnalyticsCutoffs:
+    return AnalyticsCutoffs(
+        submission=submission_cutoff,
+        grading=grading_cutoff,
+    ).normalized()

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -74,6 +74,7 @@ from computor_backend.api.git_servers import git_servers_router
 from computor_backend.api.course_git import course_git_router
 from computor_backend.api.course_member_import import course_member_import_router
 from computor_backend.api.course_member_gradings import course_member_gradings_router
+from computor_backend.api.analytics import analytics_router
 from computor_backend.api.workspace_roles import workspace_roles_router
 from computor_backend.api.maintenance import maintenance_router
 from computor_backend.api.invites import invites_router
@@ -527,6 +528,12 @@ app.include_router(
     course_member_gradings_router,
     prefix="/course-member-gradings",
     tags=["course-member-gradings", "progress"],
+    dependencies=[Depends(get_current_principal)]
+)
+
+app.include_router(
+    analytics_router,
+    tags=["analytics"],
     dependencies=[Depends(get_current_principal)]
 )
 

--- a/computor-backend/src/computor_backend/settings.py
+++ b/computor-backend/src/computor_backend/settings.py
@@ -40,6 +40,22 @@ class BackendSettings:
         self.WS_PING_INTERVAL = int(os.environ.get("WS_PING_INTERVAL", "25"))  # client-side ping interval
         self.WS_SEND_TIMEOUT = int(os.environ.get("WS_SEND_TIMEOUT", "10"))  # seconds for send operations
 
+        self.ANALYTICS_ROOT = os.environ.get(
+            "ANALYTICS_ROOT",
+            "/srv/computor/analytics",
+        )
+        self.ANALYTICS_SOURCE_NAME = os.environ.get(
+            "ANALYTICS_SOURCE_NAME",
+            "green",
+        )
+        self.ANALYTICS_SOURCE_DATABASE_URL = os.environ.get(
+            "ANALYTICS_SOURCE_DATABASE_URL",
+            None,
+        )
+        self.ANALYTICS_EXPORT_CHUNK_SIZE = int(
+            os.environ.get("ANALYTICS_EXPORT_CHUNK_SIZE", "100000")
+        )
+
     def __new__(cls):
         if cls._instance is None:
             with cls._lock:

--- a/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
+++ b/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
@@ -2,12 +2,25 @@ from datetime import datetime, timezone
 
 import duckdb
 import pandas as pd
+import pytest
+from fastapi import BackgroundTasks
 
 from computor_backend.analytics import (
     AnalyticsCutoffs,
     AnalyticsDuckDbGradingRepository,
+    AnalyticsDuckDbReportRepository,
     AnalyticsDuckDbStore,
+    AnalyticsStorageConfig,
 )
+from computor_backend.analytics.service import AnalyticsService
+from computor_backend.api.analytics import (
+    ANALYTICS_READ_ROLE,
+    ANALYTICS_REFRESH_ROLE,
+    _require_course_role,
+)
+from computor_backend.exceptions import BadRequestException, ForbiddenException
+from computor_backend.permissions.principal import Principal
+from computor_types.analytics import AnalyticsRefreshRequest
 from computor_backend.services.course_member_grading_read import (
     build_course_member_grading_list_response,
     build_course_member_grading_response,
@@ -98,6 +111,136 @@ def test_duckdb_store_round_trips_parquet_snapshot(tmp_path):
         store.close()
 
 
+def test_report_repository_tracks_actual_grading_checkpoint_counts():
+    repo = _report_repo_with_fixture(
+        submission_cutoff=datetime(2026, 6, 18, 22, 1, tzinfo=timezone.utc),
+        grading_cutoff=datetime(2026, 6, 19, 12, 0, tzinfo=timezone.utc),
+    )
+
+    rows = repo.get_student_checkpoint_rows(COURSE_ID)
+    by_member = {row["course_member_id"]: row for row in rows}
+
+    alice = by_member[ALICE_MEMBER_ID]
+    assert alice["total_max_assignments"] == 2
+    assert alice["total_submitted_assignments"] == 2
+    assert alice["total_graded_assignments"] == 1
+    assert alice["average_grading"] == 0.85
+
+    bob = by_member[BOB_MEMBER_ID]
+    assert bob["total_max_assignments"] == 2
+    assert bob["total_submitted_assignments"] == 1
+    assert bob["total_graded_assignments"] == 1
+    assert bob["late_submission_count"] == 1
+    assert bob["average_grading"] == 0.70
+
+
+def test_analytics_service_reads_summary_and_timeline_from_duckdb(tmp_path):
+    config = AnalyticsStorageConfig(root=tmp_path)
+    config.duckdb_path.parent.mkdir(parents=True)
+    conn = duckdb.connect(str(config.duckdb_path))
+    _create_schema(conn)
+    _insert_fixture(conn)
+    conn.close()
+
+    service = AnalyticsService(config)
+    cutoffs = AnalyticsCutoffs(
+        submission=datetime(2026, 6, 18, 22, 1, tzinfo=timezone.utc),
+        grading=datetime(2026, 6, 19, 12, 0, tzinfo=timezone.utc),
+    ).normalized()
+
+    summary = service.course_summary(COURSE_ID, cutoffs)
+    assert summary.total_students == 2
+    assert summary.total_max_assignments == 4
+    assert summary.total_submitted_assignments == 3
+    assert summary.submitted_percentage == 75.0
+    assert summary.total_graded_assignments == 2
+    assert summary.graded_percentage == 50.0
+    assert summary.average_grading == 0.775
+
+    timeline = service.student_timeline(COURSE_ID, BOB_MEMBER_ID, cutoffs)
+    event_types = [event.event_type for event in timeline.events]
+    assert "official_submission" in event_types
+    assert "test_submission" in event_types
+    assert "test_result" in event_types
+    assert "grading" in event_types
+    assert timeline.events[-1].relation_to_submission_cutoff == "after_submission_cutoff"
+
+
+def test_analytics_access_is_denied_for_default_registered_user(monkeypatch):
+    def deny_all(*args):
+        return _FakeCoursePermissionQuery(None)
+
+    monkeypatch.setattr("computor_backend.api.analytics.check_course_permissions", deny_all)
+
+    with pytest.raises(ForbiddenException):
+        _require_course_role(
+            Principal(user_id="10000000-0000-4000-8000-000000000901"),
+            object(),
+            COURSE_ID,
+            ANALYTICS_READ_ROLE,
+        )
+
+
+def test_analytics_access_allows_admin_without_course_query(monkeypatch):
+    def fail_if_called(*args):
+        raise AssertionError("admin should bypass course query")
+
+    monkeypatch.setattr(
+        "computor_backend.api.analytics.check_course_permissions",
+        fail_if_called,
+    )
+
+    _require_course_role(
+        Principal(is_admin=True, user_id="10000000-0000-4000-8000-000000000001"),
+        object(),
+        COURSE_ID,
+        ANALYTICS_READ_ROLE,
+    )
+
+
+def test_analytics_access_uses_separate_read_and_refresh_roles(monkeypatch):
+    calls = []
+
+    def allow_course_role(_permissions, _entity, course_role_id, _db):
+        calls.append(course_role_id)
+        return _FakeCoursePermissionQuery(object())
+
+    monkeypatch.setattr(
+        "computor_backend.api.analytics.check_course_permissions",
+        allow_course_role,
+    )
+
+    principal = Principal(user_id="10000000-0000-4000-8000-000000000002")
+    _require_course_role(principal, object(), COURSE_ID, ANALYTICS_READ_ROLE)
+    _require_course_role(principal, object(), COURSE_ID, ANALYTICS_REFRESH_ROLE)
+
+    assert calls == [ANALYTICS_READ_ROLE, ANALYTICS_REFRESH_ROLE]
+    assert ANALYTICS_READ_ROLE == "_tutor"
+    assert ANALYTICS_REFRESH_ROLE == "_lecturer"
+
+
+def test_analytics_rejects_invalid_job_id(tmp_path):
+    service = AnalyticsService(AnalyticsStorageConfig(root=tmp_path))
+
+    with pytest.raises(BadRequestException):
+        service.get_job("../secret")
+
+
+def test_analytics_refresh_rejects_unknown_tables(tmp_path):
+    service = AnalyticsService(
+        AnalyticsStorageConfig(root=tmp_path),
+        source_database_url="postgresql+psycopg2://user:pass@example.invalid/db",
+    )
+
+    with pytest.raises(BadRequestException):
+        service.trigger_refresh(
+            course_id=COURSE_ID,
+            request=AnalyticsRefreshRequest(tables=["submission_artifact;drop"]),
+            requested_by_user_id="10000000-0000-4000-8000-000000000001",
+            background_tasks=BackgroundTasks(),
+        )
+
+
 def _repo_with_fixture(
     submission_cutoff: datetime | None,
     grading_cutoff: datetime | None,
@@ -106,6 +249,33 @@ def _repo_with_fixture(
     _create_schema(conn)
     _insert_fixture(conn)
     return AnalyticsDuckDbGradingRepository(
+        conn,
+        cutoffs=AnalyticsCutoffs(
+            submission=submission_cutoff,
+            grading=grading_cutoff,
+        ),
+    )
+
+
+class _FakeCoursePermissionQuery:
+    def __init__(self, result):
+        self.result = result
+
+    def filter(self, *args):
+        return self
+
+    def first(self):
+        return self.result
+
+
+def _report_repo_with_fixture(
+    submission_cutoff: datetime | None,
+    grading_cutoff: datetime | None,
+) -> AnalyticsDuckDbReportRepository:
+    conn = duckdb.connect(":memory:")
+    _create_schema(conn)
+    _insert_fixture(conn)
+    return AnalyticsDuckDbReportRepository(
         conn,
         cutoffs=AnalyticsCutoffs(
             submission=submission_cutoff,

--- a/computor-types/src/computor_types/analytics.py
+++ b/computor-types/src/computor_types/analytics.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from computor_types.course_member_gradings import (
+    CourseMemberGradingsGet,
+    CourseMemberGradingsList,
+)
+
+
+class AnalyticsRefreshRequest(BaseModel):
+    source_name: str = "green"
+    submission_cutoff: datetime | None = None
+    grading_cutoff: datetime | None = None
+    run_id: str | None = None
+    tables: list[str] | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsJobStatus(BaseModel):
+    job_id: str
+    course_id: str
+    source_name: str
+    requested_by_user_id: str | None = None
+    status: str
+    progress: dict[str, Any] = Field(default_factory=dict)
+    submission_cutoff: datetime | None = None
+    grading_cutoff: datetime | None = None
+    created_at: datetime
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    snapshot_path: str | None = None
+    row_counts: dict[str, int] = Field(default_factory=dict)
+    high_water_marks: dict[str, dict[str, str]] = Field(default_factory=dict)
+    error: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsCourseSummary(BaseModel):
+    course_id: str
+    total_students: int
+    total_max_assignments: int
+    total_submitted_assignments: int
+    submitted_percentage: float
+    total_graded_assignments: int
+    graded_percentage: float
+    average_grading: float | None = None
+    latest_submission_at: datetime | None = None
+    submission_cutoff: datetime | None = None
+    grading_cutoff: datetime | None = None
+    latest_job: AnalyticsJobStatus | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsStudentCheckpoint(BaseModel):
+    course_member_id: str
+    course_id: str
+    user_id: str | None = None
+    username: str | None = None
+    given_name: str | None = None
+    family_name: str | None = None
+    student_id: str | None = None
+    total_max_assignments: int
+    total_submitted_assignments: int
+    submitted_percentage: float
+    total_graded_assignments: int
+    graded_percentage: float
+    average_grading: float | None = None
+    latest_submission_at: datetime | None = None
+    late_submission_count: int = 0
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsTimelineEvent(BaseModel):
+    occurred_at: datetime
+    event_type: str
+    course_content_id: str | None = None
+    path: str | None = None
+    title: str | None = None
+    artifact_id: str | None = None
+    result_id: str | None = None
+    grade: float | None = None
+    status: int | None = None
+    submit: bool | None = None
+    version_identifier: str | None = None
+    relation_to_submission_cutoff: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsStudentTimeline(BaseModel):
+    course_id: str
+    course_member_id: str
+    submission_cutoff: datetime | None = None
+    grading_cutoff: datetime | None = None
+    events: list[AnalyticsTimelineEvent] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsStudentReport(BaseModel):
+    checkpoint: AnalyticsStudentCheckpoint
+    grading: CourseMemberGradingsGet
+    timeline: AnalyticsStudentTimeline
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsStudentList(BaseModel):
+    students: list[AnalyticsStudentCheckpoint]
+    gradings: list[CourseMemberGradingsList] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
Stacked on #151. Review after the analytics grading read backend lands, or rebase this branch onto `release/2026.10` after #150 and #151 merge.

## Summary
- Add `/analytics/...` backend endpoints for refresh jobs, job status, course summary, student list, per-student report, and per-student timeline.
- Add analytics DTOs for checkpoint summaries, actual submitted/graded percentages, refresh jobs, and timeline events.
- Add a service layer that reads reports from DuckDB and runs source refreshes only through an explicit refresh job.
- Add a file-backed job store under the analytics data root.
- Add report queries for actual graded counts, late official submissions, and timeline events.
- Register the analytics router in the backend app.

## Security
- Analytics is deny-by-default for ordinary registered users.
- Read endpoints require `_tutor` or higher on the requested course.
- Refresh/export requires `_lecturer` or higher on the requested course.
- `_admin` can read and refresh all courses.
- Every report query is scoped by `course_id`; student report lookup also requires the requested `course_member_id` to appear in that course checkpoint set.
- Refresh request table names and job ids are validated before use.
- Browser/report reads never connect to the source database; only refresh jobs use the configured source DSN.

## Verification
Passing after this change:

```bash
python -m py_compile computor-types/src/computor_types/analytics.py computor-backend/src/computor_backend/api/analytics.py computor-backend/src/computor_backend/analytics/*.py computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py computor-backend/src/computor_backend/settings.py computor-backend/src/computor_backend/server.py
# exit 0
```

```bash
git diff --check
# exit 0
```

```bash
PYTHONPATH=computor-backend/src:computor-types/src uv run --python 3.11 --with duckdb==1.5.4 --with pytest==8.3.4 --with pydantic==2.11.0 --with SQLAlchemy==1.4.54 --with sqlalchemy_utils==0.41.2 --with pandas==2.1.3 --with fastapi==0.109.0 --with email-validator==2.1.0 --with PyYAML==6.0.1 --with pydantic_yaml==1.2.1 --with text-unidecode==1.3 --with psycopg2-binary==2.9.9 --with python-gitlab==5.0.0 --with redis==5.0.1 pytest computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py -q
# 10 passed, 5 warnings in 0.99s
```

```bash
PYTHONPATH=computor-backend/src:computor-types/src uv run --python 3.11 --project computor-backend ruff check computor-types/src/computor_types/analytics.py computor-backend/src/computor_backend/api/analytics.py computor-backend/src/computor_backend/analytics computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py computor-backend/src/computor_backend/settings.py
# All checks passed!
```

Broader backend collection still fails before tests run due existing local test environment gaps:

```bash
PYTHONPATH=computor-backend/src:computor-types/src uv run --python 3.11 --project computor-backend pytest computor-backend/src/computor_backend/tests -q
# collected 710 items / 6 errors
# ModuleNotFoundError: No module named 'computor_client'
# ImportError: cannot import name 'import_course_members' from 'computor_backend.business_logic.course_member_import'
# ImportError: cannot import name 'CourseExecutionBackend' from 'computor_backend.model'
```
