### PR TITLE
Add analytics system test and deployment wiring

### DIFF
--- a/computor-backend/src/computor_backend/analytics/grading_repository.py
+++ b/computor-backend/src/computor_backend/analytics/grading_repository.py
@@ -395,6 +395,16 @@ class AnalyticsDuckDbGradingRepository:
         course_content_type_id: str | None = None,
     ) -> list[dict[str, Any]]:
         archived_filter = self._archived_filter()
+        max_test_runs_column = (
+            "cc.max_test_runs"
+            if self._has_column("course_content", "max_test_runs")
+            else "NULL"
+        )
+        max_submissions_column = (
+            "cc.max_submissions"
+            if self._has_column("course_content", "max_submissions")
+            else "NULL"
+        )
         params: list[Any] = [str(course_id)]
         filters = []
         if path_prefix:
@@ -416,8 +426,8 @@ class AnalyticsDuckDbGradingRepository:
                 cct.title AS content_type_title,
                 cct.color AS content_type_color,
                 cc.position,
-                cc.max_test_runs,
-                cc.max_submissions
+                {max_test_runs_column} AS max_test_runs,
+                {max_submissions_column} AS max_submissions
             FROM course_content cc
             JOIN course_content_type cct ON cct.id = cc.course_content_type_id
             JOIN course_content_kind cck ON cck.id = cct.course_content_kind_id

--- a/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
+++ b/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
@@ -85,6 +85,32 @@ def test_shared_builder_uses_duckdb_backend_for_member_detail():
     assert by_path["week1.assignment2"].latest_result_grade == 0.95
 
 
+def test_duckdb_assignment_details_use_submission_group_limits_without_content_columns():
+    conn = duckdb.connect(":memory:")
+    _create_schema(conn)
+    _insert_fixture(conn)
+    conn.execute("ALTER TABLE course_content DROP COLUMN max_test_runs")
+    conn.execute("ALTER TABLE course_content DROP COLUMN max_submissions")
+    repo = AnalyticsDuckDbGradingRepository(conn)
+
+    result = build_course_member_grading_response(
+        repo,
+        BOB_MEMBER_ID,
+        COURSE_ID,
+        {
+            "user_id": "10000000-0000-4000-8000-000000000102",
+            "username": "bob@example.test",
+            "given_name": "Bob",
+            "family_name": "Beta",
+            "student_id": "m102",
+        },
+    )
+
+    by_path = {node.path: node for node in result.nodes}
+    assert by_path["week1.assignment2"].max_test_runs == 20
+    assert by_path["week1.assignment2"].max_submissions == 3
+
+
 def test_duckdb_store_round_trips_parquet_snapshot(tmp_path):
     store = AnalyticsDuckDbStore(":memory:")
     try:

--- a/ops/docker/docker-compose.prod.yaml
+++ b/ops/docker/docker-compose.prod.yaml
@@ -62,6 +62,7 @@ services:
     command: ["sh", "startup.bash"]
     volumes:
       - ${SYSTEM_DEPLOYMENT_PATH}/shared:${API_ROOT_PATH}/shared
+      - ${ANALYTICS_HOST_ROOT:-${SYSTEM_DEPLOYMENT_PATH}/analytics}:${ANALYTICS_ROOT:-/srv/computor/analytics}
       # Documents tree shared with static-server (which mounts the same host
       # path read-only). Same path inside the container as outside so
       # ``settings.DOCUMENTS_ROOT`` resolves consistently in both processes.
@@ -75,6 +76,10 @@ services:
       API_ADMIN_PASSWORD: ${API_ADMIN_PASSWORD}
       DOCUMENTS_ROOT: ${DOCUMENTS_ROOT:-/opt/computor/shared/documents}
       DOCUMENTS_MAX_FILE_SIZE: ${DOCUMENTS_MAX_FILE_SIZE:-10485760}
+      ANALYTICS_ROOT: ${ANALYTICS_ROOT:-/srv/computor/analytics}
+      ANALYTICS_SOURCE_NAME: ${ANALYTICS_SOURCE_NAME:-green}
+      ANALYTICS_SOURCE_DATABASE_URL: ${ANALYTICS_SOURCE_DATABASE_URL:-}
+      ANALYTICS_EXPORT_CHUNK_SIZE: ${ANALYTICS_EXPORT_CHUNK_SIZE:-100000}
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5437
       POSTGRES_USER: ${POSTGRES_USER}

--- a/ops/docs/ANALYTICS.md
+++ b/ops/docs/ANALYTICS.md
@@ -1,0 +1,60 @@
+# Analytics
+
+Analytics runs on a separate reporting store. The backend refresh job reads a
+source database with a read-only SQL user, writes raw Parquet snapshots, and
+builds a DuckDB database for report reads.
+
+Browser requests only hit the backend API. Report endpoints read DuckDB. They
+do not connect to the source database.
+
+## Local System Test
+
+Run the full local cycle from the repository root:
+
+```bash
+bash scripts/analytics-local/run-system-test.sh
+```
+
+The command starts isolated source and analytics stacks, seeds the source,
+checks that the analytics SQL role cannot write, refreshes the analytics store,
+checks Parquet and DuckDB output, and removes the local data root.
+
+## Runtime Configuration
+
+Set these variables on the analytics host:
+
+```text
+ANALYTICS_ROOT=/srv/computor/analytics
+ANALYTICS_HOST_ROOT=/srv/computor/analytics
+ANALYTICS_SOURCE_NAME=green
+ANALYTICS_SOURCE_DATABASE_URL=
+ANALYTICS_EXPORT_CHUNK_SIZE=100000
+```
+
+`ANALYTICS_SOURCE_DATABASE_URL` must use a read-only source database account.
+Keep it server-side. Do not expose it to frontend builds, generated clients, or
+browser-visible configuration.
+
+`ANALYTICS_ROOT` is the path inside the backend container. `ANALYTICS_HOST_ROOT`
+is the host bind mount. In a single-host deployment they can point to the same
+directory.
+
+## Storage Layout
+
+```text
+/srv/computor/analytics/
+  raw/source=<source>/run=<run_id>/table=<table>/*.parquet
+  duckdb/analytics.duckdb
+  jobs/*.json
+```
+
+The refresh job writes a full snapshot for the selected tables and replaces the
+DuckDB tables from that snapshot. Job metadata records row counts and source
+high-water marks. Incremental import can use those marks later, but the current
+path is full-snapshot refresh.
+
+## Access Boundary
+
+Analytics access is denied by default. Course read endpoints require a staff
+role on that course. Refresh endpoints require lecturer-level course access.
+Administrators bypass the course filter.

--- a/ops/environments/.env.common.template
+++ b/ops/environments/.env.common.template
@@ -81,9 +81,9 @@ API_PORT=8000
 # Dev:  http://host.docker.internal:8000 (macOS) / http://172.17.0.1:8000 (Linux)
 # Prod: http://uvicorn:8000 (backend container on computor-network)
 API_URL=http://localhost:8000
-# Bootstrap admin — provisioned in Keycloak on backend startup (email is the
+# Bootstrap admin: provisioned in Keycloak on backend startup (email is the
 # username), added to the 'administrators' group; the _admin role follows on
-# first login. The password is applied only on initial creation — rotating it
+# first login. The password is applied only on initial creation; rotating it
 # later in Keycloak is preserved across restarts. Requires KEYCLOAK_ENABLED=true.
 API_ADMIN_EMAIL=admin@computor.local
 API_ADMIN_PASSWORD=CHANGE_ME_ADMIN_PASSWORD
@@ -91,7 +91,7 @@ API_ADMIN_PASSWORD=CHANGE_ME_ADMIN_PASSWORD
 # ============================================
 # PUBLIC URL (production single source of truth)
 # ============================================
-# The public base URL in production — scheme + host, NO trailing slash, NO path
+# The public base URL in production: scheme + host, NO trailing slash, NO path
 # (e.g. https://computor.example.com). startup.sh derives the per-service public
 # URLs from it at launch (prod only):
 #   NEXT_PUBLIC_API_URL = $PUBLIC_DOMAIN/api
@@ -107,7 +107,7 @@ PUBLIC_DOMAIN=
 # WEB FRONTEND (computor-web)
 # ============================================
 # Browser-facing backend API URL, baked into the web build.
-# Dev: http://localhost:8000.  Prod: leave EMPTY — derived as $PUBLIC_DOMAIN/api.
+# Dev: http://localhost:8000.  Prod: leave EMPTY; derived as $PUBLIC_DOMAIN/api.
 NEXT_PUBLIC_API_URL=http://localhost:8000
 
 # Docker build settings
@@ -137,7 +137,7 @@ TESTING_WORKER_TOKEN=CHANGE_ME_WORKER_TOKEN
 # MATLAB WORKER (Optional)
 # ============================================
 # Set to true to start the temporal-worker-matlab container (requires a
-# MATLAB base image — see docker/temporal-worker-matlab/Dockerfile).
+# MATLAB base image; see docker/temporal-worker-matlab/Dockerfile).
 # When enabled, also add to .env:
 #   MATLAB_BASE_IMAGE=matlab-base:latest
 #   MATLAB_TESTING_WORKER_REPLICAS=1
@@ -166,7 +166,7 @@ GIT_SERVER_URL=http://localhost:3030
 # GIT_SERVER_URL instead.
 GIT_SERVER_URL_INTERNAL=http://computor-forgejo:3030
 
-# Admin credentials — used by the backend API and (for Forgejo) also by the
+# Admin credentials: used by the backend API and (for Forgejo) also by the
 # bootstrap container to create the admin account on first start.
 # Forgejo: set to your chosen admin username/password.
 # GitLab:  username is always "root".
@@ -187,7 +187,7 @@ FORGEJO_DB_PORT=5441
 
 # Public hostname and root URL (used in clone URLs and OIDC redirect URIs).
 # Dev:  FORGEJO_DOMAIN=localhost, FORGEJO_ROOT_URL=http://localhost:3030
-# Prod: leave both EMPTY — derived from PUBLIC_DOMAIN as host($PUBLIC_DOMAIN) and
+# Prod: leave both EMPTY; derived from PUBLIC_DOMAIN as host($PUBLIC_DOMAIN) and
 #       $PUBLIC_DOMAIN/forgejo (Forgejo served under the /forgejo subpath).
 FORGEJO_DOMAIN=localhost
 FORGEJO_ROOT_URL=http://localhost:3030
@@ -211,7 +211,7 @@ CODER_ENABLED=false
 CODER_POSTGRES_USER=coder
 CODER_POSTGRES_PASSWORD=CHANGE_ME_CODER_DB_PASSWORD
 
-# Coder admin credentials — internal only (the backend uses them to reach the
+# Coder admin credentials: internal only (the backend uses them to reach the
 # Coder API; not a human login). setup-env.sh generates the password and mirrors
 # CODER_ADMIN_EMAIL to API_ADMIN_EMAIL when Coder is enabled.
 CODER_ADMIN_USERNAME=admin
@@ -230,7 +230,7 @@ CODER_ADMIN_API_SECRET=CHANGE_ME_GENERATE_WITH_OPENSSL
 DOCKER_GID=
 
 # Registry for workspace images.
-# Protected by docker-network isolation, not auth — see docker-compose.coder.yaml.
+# Protected by docker-network isolation, not auth; see docker-compose.coder.yaml.
 CODER_REGISTRY_PORT=5000
 
 # Coder security settings
@@ -263,6 +263,18 @@ EXTENSION_PUBLIC_DOWNLOAD_URL=
 EXTENSION_GETTING_STARTED_URL=
 
 # ============================================
+# ANALYTICS REPORTING
+# ============================================
+# Server-side analytics store for reporting snapshots. Use a read-only source
+# database URL only on the analytics host. Leave the source URL empty where
+# refresh should be disabled.
+ANALYTICS_ROOT=/srv/computor/analytics
+ANALYTICS_HOST_ROOT=/srv/computor/analytics
+ANALYTICS_SOURCE_NAME=green
+ANALYTICS_SOURCE_DATABASE_URL=
+ANALYTICS_EXPORT_CHUNK_SIZE=100000
+
+# ============================================
 # KEYCLOAK CONFIGURATION
 # ============================================
 # Keycloak is the standard identity provider: bearer-token (browser/SSO) auth
@@ -281,9 +293,9 @@ KEYCLOAK_REALM=computor
 KEYCLOAK_CLIENT_ID=computor-backend
 KEYCLOAK_CLIENT_SECRET=CHANGE_ME_KEYCLOAK_CLIENT_SECRET
 
-# Secret for the 'forgejo' Keycloak client (declared in the realm import and shared
+# Secret for the 'forgejo' Keycloak client (declared in the Keycloak import and shared
 # with Forgejo's OIDC login source). Only used when GIT_SERVER=forgejo. Must be hex
-# (substituted into the realm JSON via a /-delimited sed). setup-env.sh generates it.
+# (substituted into the Keycloak JSON via a /-delimited sed). setup-env.sh generates it.
 FORGEJO_KEYCLOAK_CLIENT_SECRET=CHANGE_ME_FORGEJO_KEYCLOAK_CLIENT_SECRET
 
 # URL the backend process uses to reach Keycloak.
@@ -291,13 +303,13 @@ FORGEJO_KEYCLOAK_CLIENT_SECRET=CHANGE_ME_FORGEJO_KEYCLOAK_CLIENT_SECRET
 # Prod (backend in Docker):      http://computor-keycloak:8080/auth  (= KEYCLOAK_SERVER_URL_INTERNAL)
 KEYCLOAK_SERVER_URL=http://localhost:8180/auth
 
-# Internal Docker-network URL — used by the backend container and the
+# Internal Docker-network URL: used by the backend container and the
 # forgejo-keycloak-setup service. Must be reachable from within computor-network.
 KEYCLOAK_SERVER_URL_INTERNAL=http://computor-keycloak:8080/auth
 
 # Public URL Keycloak uses for browser-facing redirect URIs and OIDC issuer.
 # Dev:  http://localhost:8180  (direct port, no Traefik)
-# Prod: leave EMPTY — derived from PUBLIC_DOMAIN as $PUBLIC_DOMAIN/auth
+# Prod: leave EMPTY; derived from PUBLIC_DOMAIN as $PUBLIC_DOMAIN/auth
 #       (behind Traefik with KEYCLOAK_HTTP_RELATIVE_PATH=/auth).
 KEYCLOAK_PUBLIC_URL=http://localhost:8180
 
@@ -309,13 +321,13 @@ KEYCLOAK_HTTP_RELATIVE_PATH=/
 KEYCLOAK_TRAEFIK_ENABLED=false
 
 # --------------------------------------------
-# EXTERNAL IDENTITY PROVIDERS (brokered through Keycloak) — OPTIONAL
+# EXTERNAL IDENTITY PROVIDERS (brokered through Keycloak) - OPTIONAL
 # --------------------------------------------
 # Define the providers themselves in a LOCAL, gitignored file:
 #   data/keycloak/identity-providers.json
 #   (copy data/keycloak/identity-providers.example.json and edit it).
 # That file holds non-secret structure only. For each provider's
-# "clientSecretEnv", add the matching secret HERE — one line per provider, e.g.:
+# "clientSecretEnv", add the matching secret HERE; one line per provider, e.g.:
 #   IDP_EXAMPLE_CLIENT_SECRET=...
 # Leave everything below unset if you don't broker any external IdP.
 #IDP_EXAMPLE_CLIENT_SECRET=CHANGE_ME_IDP_EXAMPLE_CLIENT_SECRET

--- a/scripts/analytics-local/README.md
+++ b/scripts/analytics-local/README.md
@@ -18,6 +18,12 @@ bash scripts/analytics-local/test.sh
 bash scripts/analytics-local/teardown.sh
 ```
 
+Run the complete setup, seed, test, and teardown cycle with:
+
+```bash
+bash scripts/analytics-local/run-system-test.sh
+```
+
 Default local ports:
 
 | Instance | Postgres | Redis | MinIO API | MinIO Console |
@@ -42,3 +48,8 @@ password: analytics_reader_secret
 ```
 
 These credentials are local test credentials only.
+
+`test.sh` checks the read-only source role, exports the seeded source snapshot
+through the analytics service, writes Parquet and DuckDB files under the local
+blue data root, and validates the summary, student list, timeline, and report
+read models.

--- a/scripts/analytics-local/run-system-test.sh
+++ b/scripts/analytics-local/run-system-test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cleanup() {
+    bash "${SCRIPT_DIR}/teardown.sh"
+}
+
+trap cleanup EXIT
+
+bash "${SCRIPT_DIR}/setup.sh"
+bash "${SCRIPT_DIR}/seed.sh"
+bash "${SCRIPT_DIR}/test.sh"

--- a/scripts/analytics-local/system-test.sh
+++ b/scripts/analytics-local/system-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+wait_for_postgres source compose_source
+wait_for_postgres blue compose_blue
+
+analytics_root="${ANALYTICS_LOCAL_DATA_ROOT}/blue/analytics"
+if [[ "$ANALYTICS_LOCAL_DATA_ROOT" != /* || "$ANALYTICS_LOCAL_DATA_ROOT" == "/" ]]; then
+    echo "Refusing to use unsafe data root: ${ANALYTICS_LOCAL_DATA_ROOT}" >&2
+    exit 1
+fi
+if [[ "$analytics_root" != */blue/analytics ]]; then
+    echo "Refusing to clean unexpected analytics root: ${analytics_root}" >&2
+    exit 1
+fi
+rm -rf -- "$analytics_root"
+mkdir -p "$analytics_root"
+
+source_database_url="postgresql+psycopg2://${ANALYTICS_LOCAL_READER_USER}:${ANALYTICS_LOCAL_READER_PASSWORD}@127.0.0.1:${ANALYTICS_LOCAL_SOURCE_POSTGRES_PORT}/${ANALYTICS_LOCAL_POSTGRES_DB}"
+
+echo "Running analytics import system test"
+PYTHONPATH="${REPO_ROOT}/computor-backend/src:${REPO_ROOT}/computor-types/src${PYTHONPATH:+:${PYTHONPATH}}" \
+ANALYTICS_ROOT="$analytics_root" \
+ANALYTICS_SOURCE_DATABASE_URL="$source_database_url" \
+uv run --python 3.11 --project "${REPO_ROOT}/computor-backend" \
+    python "${SCRIPT_DIR}/system_test.py"

--- a/scripts/analytics-local/system_test.py
+++ b/scripts/analytics-local/system_test.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+
+from fastapi import BackgroundTasks
+
+from computor_backend.analytics import AnalyticsCutoffs, AnalyticsStorageConfig
+from computor_backend.analytics.config import ANALYTICS_TABLES
+from computor_backend.analytics.service import AnalyticsService
+from computor_types.analytics import AnalyticsRefreshRequest
+
+
+COURSE_ID = "20000000-0000-4000-8000-000000000001"
+BOB_MEMBER_ID = "50000000-0000-4000-8000-000000000102"
+
+SUBMISSION_CUTOFF = datetime(2026, 6, 18, 22, 1, tzinfo=timezone.utc)
+GRADING_CUTOFF = datetime(2026, 6, 19, 12, 0, tzinfo=timezone.utc)
+
+EXPECTED_ROW_COUNTS = {
+    "course": 1,
+    "course_member": 5,
+    "user": 5,
+    "student_profile": 3,
+    "course_content_kind": 2,
+    "course_content_type": 2,
+    "course_content": 3,
+    "submission_group": 6,
+    "submission_group_member": 6,
+    "submission_artifact": 8,
+    "submission_grade": 3,
+    "result": 3,
+}
+
+
+def main() -> None:
+    source_database_url = _require_env("ANALYTICS_SOURCE_DATABASE_URL")
+    analytics_root = Path(_require_env("ANALYTICS_ROOT"))
+    config = AnalyticsStorageConfig(root=analytics_root, source_name="green")
+    service = AnalyticsService(
+        config,
+        source_database_url=source_database_url,
+        export_chunk_size=2,
+    )
+
+    request = AnalyticsRefreshRequest(
+        source_name="green",
+        run_id="system-test",
+        submission_cutoff=SUBMISSION_CUTOFF,
+        grading_cutoff=GRADING_CUTOFF,
+    )
+    queued = service.trigger_refresh(
+        COURSE_ID,
+        request,
+        requested_by_user_id="system-test",
+        background_tasks=BackgroundTasks(),
+    )
+    service.run_refresh_job(queued.job_id, request)
+
+    job = service.get_job(queued.job_id)
+    _assert_equal("job.status", job.status, "succeeded")
+    _assert_equal("job.progress.stage", job.progress.get("stage"), "complete")
+    for table, expected in EXPECTED_ROW_COUNTS.items():
+        _assert_equal(f"row_counts.{table}", job.row_counts.get(table), expected)
+
+    snapshot_root = config.raw_root / "run=system-test"
+    _assert_path(snapshot_root / "manifest.json")
+    for table in ANALYTICS_TABLES:
+        table_root = snapshot_root / f"table={table}"
+        if not list(table_root.glob("*.parquet")):
+            raise AssertionError(f"{table_root} has no parquet parts")
+    _assert_path(config.duckdb_path)
+
+    cutoffs = AnalyticsCutoffs(
+        submission=SUBMISSION_CUTOFF,
+        grading=GRADING_CUTOFF,
+    ).normalized()
+    _assert_course_summary(service, cutoffs)
+    _assert_student_list(service, cutoffs)
+    _assert_student_timeline(service, cutoffs)
+    _assert_student_report(service, cutoffs)
+
+    print("Analytics import system test passed")
+
+
+def _assert_course_summary(
+    service: AnalyticsService,
+    cutoffs: AnalyticsCutoffs,
+) -> None:
+    summary = service.course_summary(COURSE_ID, cutoffs)
+    _assert_equal("summary.total_students", summary.total_students, 3)
+    _assert_equal("summary.total_max_assignments", summary.total_max_assignments, 6)
+    _assert_equal(
+        "summary.total_submitted_assignments",
+        summary.total_submitted_assignments,
+        3,
+    )
+    _assert_equal("summary.submitted_percentage", summary.submitted_percentage, 50.0)
+    _assert_equal("summary.total_graded_assignments", summary.total_graded_assignments, 2)
+    _assert_equal("summary.graded_percentage", summary.graded_percentage, 33.33)
+    _assert_equal("summary.average_grading", summary.average_grading, 0.775)
+    _assert_equal("summary.latest_job.status", summary.latest_job.status, "succeeded")
+
+
+def _assert_student_list(
+    service: AnalyticsService,
+    cutoffs: AnalyticsCutoffs,
+) -> None:
+    student_list = service.student_list(COURSE_ID, cutoffs)
+    _assert_equal("student_list.students", len(student_list.students), 3)
+    _assert_equal("student_list.gradings", len(student_list.gradings), 3)
+
+    by_member = {student.course_member_id: student for student in student_list.students}
+    bob = by_member[BOB_MEMBER_ID]
+    _assert_equal("bob.total_submitted_assignments", bob.total_submitted_assignments, 1)
+    _assert_equal("bob.total_graded_assignments", bob.total_graded_assignments, 1)
+    _assert_equal("bob.late_submission_count", bob.late_submission_count, 1)
+
+
+def _assert_student_timeline(
+    service: AnalyticsService,
+    cutoffs: AnalyticsCutoffs,
+) -> None:
+    timeline = service.student_timeline(COURSE_ID, BOB_MEMBER_ID, cutoffs)
+    _assert_equal("timeline.events", len(timeline.events), 9)
+    event_types = {event.event_type for event in timeline.events}
+    for event_type in {
+        "official_submission",
+        "test_submission",
+        "test_result",
+        "grading",
+    }:
+        if event_type not in event_types:
+            raise AssertionError(f"timeline is missing {event_type}")
+    _assert_equal(
+        "timeline.last_relation",
+        timeline.events[-1].relation_to_submission_cutoff,
+        "after_submission_cutoff",
+    )
+
+
+def _assert_student_report(
+    service: AnalyticsService,
+    cutoffs: AnalyticsCutoffs,
+) -> None:
+    report = service.student_report(COURSE_ID, BOB_MEMBER_ID, cutoffs)
+    _assert_equal(
+        "report.checkpoint.total_submitted_assignments",
+        report.checkpoint.total_submitted_assignments,
+        1,
+    )
+    _assert_equal(
+        "report.grading.total_submitted_assignments",
+        report.grading.total_submitted_assignments,
+        1,
+    )
+    _assert_equal("report.timeline.events", len(report.timeline.events), 9)
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"{name} must be set")
+    return value
+
+
+def _assert_path(path: Path) -> None:
+    if not path.exists():
+        raise AssertionError(f"{path} does not exist")
+
+
+def _assert_equal(name: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        raise AssertionError(f"{name}: expected {expected!r}, got {actual!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analytics-local/test.sh
+++ b/scripts/analytics-local/test.sh
@@ -44,4 +44,6 @@ if psql_source_reader -c \
     exit 1
 fi
 
-echo "Analytics local harness smoke test passed"
+bash "${SCRIPT_DIR}/system-test.sh"
+
+echo "Analytics local harness system test passed"


### PR DESCRIPTION
## Summary

- adds a one-command local analytics system test that starts the two isolated stacks, seeds the source, refreshes the analytics store, validates Parquet/DuckDB output, and tears down local data
- wires analytics storage and refresh settings into the production compose overlay and environment template
- documents runtime analytics configuration and the current full-snapshot refresh behavior
- makes the DuckDB grading repository tolerate source snapshots where assignment limits exist on `submission_group` but not `course_content`

## Verification

Failed before the compatibility fix:

```bash
bash scripts/analytics-local/run-system-test.sh
# _duckdb.BinderException: Binder Error: Table "cc" does not have a column named "max_test_runs"
```

Passing after this change:

```bash
python -m py_compile computor-backend/src/computor_backend/analytics/grading_repository.py computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py scripts/analytics-local/system_test.py
# exit 0
```

```bash
bash -n scripts/analytics-local/lib.sh scripts/analytics-local/setup.sh scripts/analytics-local/seed.sh scripts/analytics-local/test.sh scripts/analytics-local/system-test.sh scripts/analytics-local/run-system-test.sh scripts/analytics-local/teardown.sh
# exit 0
```

```bash
PYTHONPATH=computor-backend/src:computor-types/src uv run --python 3.11 --with duckdb==1.5.4 --with pytest==8.3.4 --with pydantic==2.11.0 --with SQLAlchemy==1.4.54 --with sqlalchemy_utils==0.41.2 --with pandas==2.1.3 --with fastapi==0.109.0 --with email-validator==2.1.0 --with PyYAML==6.0.1 --with pydantic_yaml==1.2.1 --with text-unidecode==1.3 --with psycopg2-binary==2.9.9 --with python-gitlab==5.0.0 --with redis==5.0.1 pytest computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py -q
# 11 passed, 5 warnings in 0.96s
```

```bash
PYTHONPATH=computor-backend/src:computor-types/src uv run --python 3.11 --project computor-backend ruff check scripts/analytics-local/system_test.py computor-backend/src/computor_backend/analytics/grading_repository.py computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
# All checks passed!
```

```bash
$HOME/code/prompts/scripts/check-writing-slop.py scripts/analytics-local/README.md ops/docs/ANALYTICS.md ops/environments/.env.common.template
# PASS: no writing-slop candidates at threshold medium
```

```bash
git diff --check
# exit 0
```

```bash
bash scripts/analytics-local/run-system-test.sh
# Analytics import system test passed
# Analytics local harness system test passed
# Removed local analytics data root: /tmp/computor-analytics-local
```

```bash
test ! -e /tmp/computor-analytics-local && echo 'data root removed'
# data root removed
```

```bash
docker ps -a --filter name=computor-analytics --format '{{.Names}}'
docker network ls --filter name=computor-analytics --format '{{.Name}}'
# no output from either command
```

```bash
docker compose --env-file .env.common -f ops/docker/docker-compose.base.yaml -f ops/docker/docker-compose.prod.yaml config --quiet
# exit 0; local env emitted unrelated warnings for unset existing variables
```

Broader backend collection still fails before tests run due existing local collection gaps:

```bash
PYTHONPATH=computor-backend/src:computor-types/src uv run --python 3.11 --project computor-backend pytest computor-backend/src/computor_backend/tests -q
# collected 711 items / 6 errors
# ModuleNotFoundError: No module named 'computor_client'
# ImportError: cannot import name 'import_course_members' from 'computor_backend.business_logic.course_member_import'
# ImportError: cannot import name 'CourseExecutionBackend' from 'computor_backend.model'
```
