### PR TITLE
Fix Temporal health check address

### DIFF
--- a/ops/docker/docker-compose.base.yaml
+++ b/ops/docker/docker-compose.base.yaml
@@ -150,7 +150,7 @@ services:
     labels:
       - "traefik.enable=false"
     healthcheck:
-      test: ["CMD", "tctl", "cluster", "health"]
+      test: ["CMD", "tctl", "--address", "temporal:7233", "cluster", "health"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- Point the Temporal container health check at the Docker service address.

## Verification
- Failing before: `docker exec temporal tctl cluster health` returned `connect: connection refused` and exit code 1.
- Passing after: `docker exec temporal tctl --address temporal:7233 cluster health` returned `temporal.api.workflowservice.v1.WorkflowService: SERVING` and exit code 0.
- `git diff --check` passed.