### PR TITLE
fix(analytics): gradient-based burst flag, graceful missing source, deploy chmod

### DIFF
--- a/computor-backend/src/computor_backend/analytics/report_repository.py
+++ b/computor-backend/src/computor_backend/analytics/report_repository.py
@@ -217,6 +217,112 @@ class AnalyticsDuckDbReportRepository(AnalyticsDuckDbGradingRepository):
             ],
         )
 
+    def get_student_examples(
+        self,
+        course_id: str,
+        course_member_id: str,
+    ) -> list[dict[str, Any]]:
+        """Per standard example for one student: latest grade/score, official
+        submission time, test-run count, lateness, and the latest tutor comment.
+        Flags are derived in the service from these raw signals."""
+        submittable_filter, submittable_params = self._submittable_filter(course_id)
+        time_column = self._submission_time_column()
+        comment_inner = (
+            "sgd.comment" if self._has_column("submission_grade", "comment") else "NULL"
+        )
+
+        # The evidence view shows the actual latest official submission and marks
+        # it late, rather than hiding submissions made after the cutoff.
+        late_params: list[Any] = []
+        late_filter = self._after_cutoff_filter(
+            f"sa.{time_column}", self.cutoffs.submission, late_params
+        )
+        grade_params: list[Any] = []
+        grading_cutoff = self._cutoff_filter("sgd.graded_at", self.cutoffs.grading, grade_params)
+
+        return self._rows(
+            f"""
+            WITH submittable AS (
+                SELECT cc.id AS content_id, CAST(cc.path AS VARCHAR) AS path,
+                       cc.title, cct.slug AS category
+                FROM course_content cc
+                JOIN course_content_type cct ON cct.id = cc.course_content_type_id
+                JOIN course_content_kind cck ON cck.id = cct.course_content_kind_id
+                WHERE {submittable_filter}
+            ),
+            official AS (
+                SELECT sg.course_content_id, MAX(sa.{time_column}) AS submitted_at
+                FROM submission_group sg
+                JOIN submission_group_member sgm ON sgm.submission_group_id = sg.id
+                JOIN submission_artifact sa ON sa.submission_group_id = sg.id
+                WHERE sgm.course_member_id = ?
+                  AND sa.submit = true
+                GROUP BY sg.course_content_id
+            ),
+            late_official AS (
+                SELECT DISTINCT sg.course_content_id
+                FROM submission_group sg
+                JOIN submission_group_member sgm ON sgm.submission_group_id = sg.id
+                JOIN submission_artifact sa ON sa.submission_group_id = sg.id
+                WHERE sgm.course_member_id = ?
+                  AND sa.submit = true
+                  {late_filter}
+            ),
+            tests AS (
+                SELECT sg.course_content_id, COUNT(DISTINCT sa.id) AS test_rounds
+                FROM submission_group sg
+                JOIN submission_group_member sgm ON sgm.submission_group_id = sg.id
+                JOIN submission_artifact sa ON sa.submission_group_id = sg.id
+                WHERE sgm.course_member_id = ?
+                  AND sa.submit = false
+                GROUP BY sg.course_content_id
+            ),
+            latest_grade AS (
+                SELECT course_content_id, grade, status, comment, graded_at
+                FROM (
+                    SELECT sg.course_content_id, sgd.grade, sgd.status,
+                           {comment_inner} AS comment, sgd.graded_at,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY sg.course_content_id
+                               ORDER BY sgd.graded_at DESC
+                           ) AS rn
+                    FROM submission_group sg
+                    JOIN submission_group_member sgm ON sgm.submission_group_id = sg.id
+                    JOIN submission_artifact sa ON sa.submission_group_id = sg.id
+                    JOIN submission_grade sgd ON sgd.artifact_id = sa.id
+                    WHERE sgm.course_member_id = ?
+                      AND sa.submit = true
+                      {grading_cutoff}
+                ) ranked
+                WHERE ranked.rn = 1
+            )
+            SELECT
+                s.content_id, s.path, s.title, s.category,
+                o.submitted_at,
+                COALESCE(t.test_rounds, 0) AS test_rounds,
+                g.grade,
+                g.status AS grade_status,
+                g.comment AS comment,
+                g.graded_at,
+                (lo.course_content_id IS NOT NULL) AS late
+            FROM submittable s
+            LEFT JOIN official o ON o.course_content_id = s.content_id
+            LEFT JOIN late_official lo ON lo.course_content_id = s.content_id
+            LEFT JOIN tests t ON t.course_content_id = s.content_id
+            LEFT JOIN latest_grade g ON g.course_content_id = s.content_id
+            ORDER BY s.path
+            """,
+            [
+                *submittable_params,
+                str(course_member_id),
+                str(course_member_id),
+                *late_params,
+                str(course_member_id),
+                str(course_member_id),
+                *grade_params,
+            ],
+        )
+
     def get_timeline_events(
         self,
         course_id: str,

--- a/computor-backend/src/computor_backend/analytics/report_repository.py
+++ b/computor-backend/src/computor_backend/analytics/report_repository.py
@@ -183,6 +183,8 @@ class AnalyticsDuckDbReportRepository(AnalyticsDuckDbGradingRepository):
                 COUNT(sc.content_id) AS total_max_assignments,
                 COUNT(sub.course_content_id) AS total_submitted_assignments,
                 COUNT(grd.course_content_id) AS total_graded_assignments,
+                COUNT(CASE WHEN grd.grade >= 0.6 THEN grd.course_content_id END)
+                    AS standard_passed,
                 AVG(grd.grade) AS average_grading,
                 MAX(sub.latest_submission_at) AS latest_submission_at,
                 COALESCE(MAX(late.late_submission_count), 0) AS late_submission_count

--- a/computor-backend/src/computor_backend/analytics/service.py
+++ b/computor-backend/src/computor_backend/analytics/service.py
@@ -406,7 +406,9 @@ def _checkpoint_from_row(
     total_max = int(row["total_max_assignments"] or 0)
     submitted = int(row["total_submitted_assignments"] or 0)
     graded = int(row["total_graded_assignments"] or 0)
+    passed = int(row.get("standard_passed") or 0)
     average = row.get("average_grading")
+    average_value = round(float(average), 4) if average is not None else None
     return AnalyticsStudentCheckpoint(
         course_member_id=str(row["course_member_id"]),
         course_id=str(course_id),
@@ -420,9 +422,13 @@ def _checkpoint_from_row(
         submitted_percentage=_percentage(submitted, total_max),
         total_graded_assignments=graded,
         graded_percentage=_percentage(graded, total_max),
-        average_grading=round(float(average), 4) if average is not None else None,
+        average_grading=average_value,
         latest_submission_at=row.get("latest_submission_at"),
         late_submission_count=int(row.get("late_submission_count") or 0),
+        standard_total=total_max,
+        standard_passed=passed,
+        pass_rate=_percentage(passed, total_max),
+        average_score=average_value,
     )
 
 

--- a/computor-backend/src/computor_backend/analytics/service.py
+++ b/computor-backend/src/computor_backend/analytics/service.py
@@ -453,8 +453,13 @@ def _checkpoint_from_row(
 # already-ingested snapshot with no extra requests or statistics.
 _PASS_THRESHOLD = 0.6
 _LOW_ITERATION_MAX_ROUNDS = 1
-_VELOCITY_WINDOW_SECONDS = 24 * 3600
-_VELOCITY_MIN_IN_WINDOW = 5
+# Burst = a steep stretch of the submission curve: this many consecutive
+# official submissions (capped at how many the student has) completed within the
+# span below. Measuring the gradient over many examples avoids flagging steady
+# one-per-week work.
+_BURST_WINDOW_EXAMPLES = 15
+_BURST_MIN_WINDOW = 3
+_BURST_MAX_SPAN_SECONDS = 7 * 24 * 3600
 _GRADING_STATUS_CORRECTION_NECESSARY = 2
 
 
@@ -507,18 +512,32 @@ def _examples_from_rows(rows: list[dict[str, Any]]) -> list[AnalyticsStandardExa
 
 
 def _tag_velocity(examples: list[AnalyticsStandardExample]) -> None:
-    """Flag a submission burst: an official example whose submission time sits in
-    a 24h window holding at least _VELOCITY_MIN_IN_WINDOW official submissions."""
-    official = [ex for ex in examples if ex.official and ex.submitted_at is not None]
-    for ex in official:
-        in_window = sum(
-            1
-            for other in official
-            if abs((other.submitted_at - ex.submitted_at).total_seconds())
-            <= _VELOCITY_WINDOW_SECONDS
-        )
-        if in_window >= _VELOCITY_MIN_IN_WINDOW and "velocity" not in ex.flags:
-            ex.flags.append("velocity")
+    """Flag a submission burst by the steepness of the submission curve, not by a
+    count of threshold crossings. Take a window of consecutive official
+    submissions (a gradient over many examples) and flag the single steepest one
+    when those examples were completed within a short span. Steady weekly work
+    spreads the window over weeks and never triggers; one busy late week does."""
+    official = sorted(
+        (ex for ex in examples if ex.official and ex.submitted_at is not None),
+        key=lambda ex: ex.submitted_at,
+    )
+    n = len(official)
+    window = min(_BURST_WINDOW_EXAMPLES, n)
+    if window < _BURST_MIN_WINDOW:
+        return
+    best_span: float | None = None
+    best_start = 0
+    for start in range(0, n - window + 1):
+        span = (
+            official[start + window - 1].submitted_at - official[start].submitted_at
+        ).total_seconds()
+        if best_span is None or span < best_span:
+            best_span = span
+            best_start = start
+    if best_span is not None and best_span <= _BURST_MAX_SPAN_SECONDS:
+        for ex in official[best_start : best_start + window]:
+            if "velocity" not in ex.flags:
+                ex.flags.append("velocity")
 
 
 def _read_manifest(snapshot_path: Path) -> tuple[dict[str, int], dict[str, dict[str, str]]]:

--- a/computor-backend/src/computor_backend/analytics/service.py
+++ b/computor-backend/src/computor_backend/analytics/service.py
@@ -22,11 +22,13 @@ from computor_types.analytics import (
     AnalyticsCourseSummary,
     AnalyticsJobStatus,
     AnalyticsRefreshRequest,
+    AnalyticsStandardExample,
     AnalyticsStudentCheckpoint,
     AnalyticsStudentList,
     AnalyticsStudentReport,
     AnalyticsStudentTimeline,
     AnalyticsTimelineEvent,
+    AnalyticsTutorComment,
 )
 
 from .config import ANALYTICS_TABLES, AnalyticsCutoffs, AnalyticsStorageConfig
@@ -345,6 +347,21 @@ class AnalyticsService:
         finally:
             connection.close()
 
+    def student_examples(
+        self,
+        course_id: str,
+        course_member_id: str,
+        cutoffs: AnalyticsCutoffs,
+    ) -> list[AnalyticsStandardExample]:
+        connection = self._read_connection()
+        try:
+            repo = AnalyticsDuckDbReportRepository(connection, cutoffs)
+            return _examples_from_rows(
+                repo.get_student_examples(course_id, course_member_id)
+            )
+        finally:
+            connection.close()
+
     def _student_checkpoints_from_connection(
         self,
         connection: duckdb.DuckDBPyConnection,
@@ -430,6 +447,78 @@ def _checkpoint_from_row(
         pass_rate=_percentage(passed, total_max),
         average_score=average_value,
     )
+
+
+# Score-pass and integrity heuristics. Deliberately simple: derivable from the
+# already-ingested snapshot with no extra requests or statistics.
+_PASS_THRESHOLD = 0.6
+_LOW_ITERATION_MAX_ROUNDS = 1
+_VELOCITY_WINDOW_SECONDS = 24 * 3600
+_VELOCITY_MIN_IN_WINDOW = 5
+_GRADING_STATUS_CORRECTION_NECESSARY = 2
+
+
+def _examples_from_rows(rows: list[dict[str, Any]]) -> list[AnalyticsStandardExample]:
+    examples: list[AnalyticsStandardExample] = []
+    for row in rows:
+        grade = row.get("grade")
+        score = float(grade) if grade is not None else None
+        passed = score is not None and score >= _PASS_THRESHOLD
+        submitted_at = row.get("submitted_at")
+        official = submitted_at is not None
+        test_rounds = int(row.get("test_rounds") or 0)
+        status = int(row.get("grade_status") or 0)
+        comment_text = row.get("comment")
+
+        comments: list[AnalyticsTutorComment] = []
+        if comment_text:
+            comments.append(
+                AnalyticsTutorComment(
+                    author_role="tutor",
+                    text=str(comment_text),
+                    created_at=row.get("graded_at"),
+                )
+            )
+
+        flags: list[str] = []
+        if passed and test_rounds <= _LOW_ITERATION_MAX_ROUNDS:
+            flags.append("low_iteration")
+        if comment_text and status == _GRADING_STATUS_CORRECTION_NECESSARY:
+            flags.append("tutor_concern")
+
+        examples.append(
+            AnalyticsStandardExample(
+                content_id=str(row["content_id"]),
+                path=str(row["path"]),
+                title=row.get("title") or str(row["path"]),
+                category=row.get("category"),
+                score=score,
+                passed=passed,
+                test_rounds=test_rounds,
+                submitted_at=submitted_at,
+                official=official,
+                late=bool(row.get("late")),
+                flags=flags,
+                comments=comments,
+            )
+        )
+    _tag_velocity(examples)
+    return examples
+
+
+def _tag_velocity(examples: list[AnalyticsStandardExample]) -> None:
+    """Flag a submission burst: an official example whose submission time sits in
+    a 24h window holding at least _VELOCITY_MIN_IN_WINDOW official submissions."""
+    official = [ex for ex in examples if ex.official and ex.submitted_at is not None]
+    for ex in official:
+        in_window = sum(
+            1
+            for other in official
+            if abs((other.submitted_at - ex.submitted_at).total_seconds())
+            <= _VELOCITY_WINDOW_SECONDS
+        )
+        if in_window >= _VELOCITY_MIN_IN_WINDOW and "velocity" not in ex.flags:
+            ex.flags.append("velocity")
 
 
 def _read_manifest(snapshot_path: Path) -> tuple[dict[str, int], dict[str, dict[str, str]]]:

--- a/computor-backend/src/computor_backend/api/analytics.py
+++ b/computor-backend/src/computor_backend/api/analytics.py
@@ -12,14 +12,21 @@ from computor_backend.database import get_db
 from computor_backend.exceptions import ForbiddenException, NotFoundException
 from computor_backend.model.auth import User
 from computor_backend.model.course import CourseMember
+from computor_backend.model.deployment import CourseContentDeployment
 from computor_backend.permissions.auth import get_current_principal
 from computor_backend.permissions.core import check_course_permissions
 from computor_backend.permissions.principal import Principal
+from computor_backend.redis_cache import get_cache
+from computor_backend.repositories import ExampleVersionRepository
+from computor_backend.services.storage_service import get_storage_service
 from computor_types.analytics import (
     AnalyticsCourseAccess,
     AnalyticsCourseSummary,
+    AnalyticsExampleSource,
+    AnalyticsExampleSourceFile,
     AnalyticsJobStatus,
     AnalyticsRefreshRequest,
+    AnalyticsStandardExample,
     AnalyticsStudentList,
     AnalyticsStudentReport,
     AnalyticsStudentTimeline,
@@ -175,6 +182,96 @@ async def get_course_analytics_student_timeline(
         course_member_id,
         _cutoffs(submission_cutoff, grading_cutoff),
     )
+
+
+@analytics_router.get(
+    "/courses/{course_id}/students/{course_member_id}/examples",
+    response_model=list[AnalyticsStandardExample],
+)
+async def list_course_analytics_student_examples(
+    course_id: str,
+    course_member_id: str,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+    submission_cutoff: datetime | None = None,
+    grading_cutoff: datetime | None = None,
+) -> list[AnalyticsStandardExample]:
+    _require_course_role(permissions, db, course_id, ANALYTICS_READ_ROLE)
+    return AnalyticsService.from_settings().student_examples(
+        course_id,
+        course_member_id,
+        _cutoffs(submission_cutoff, grading_cutoff),
+    )
+
+
+@analytics_router.get(
+    "/courses/{course_id}/examples/{content_id}/source",
+    response_model=AnalyticsExampleSource,
+)
+async def get_analytics_example_source(
+    course_id: str,
+    content_id: str,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+    storage_service=Depends(get_storage_service),
+) -> AnalyticsExampleSource:
+    """Source files of the example deployed to a course content. Gated by the
+    analytics read role, so course staff see the source without needing the
+    global example-download permission. Reads the live deployment + storage."""
+    _require_course_role(permissions, db, course_id, ANALYTICS_READ_ROLE)
+
+    deployment = (
+        db.query(CourseContentDeployment)
+        .filter(CourseContentDeployment.course_content_id == content_id)
+        .first()
+    )
+    if deployment is None or deployment.example_version_id is None:
+        raise NotFoundException("No example deployed for this content")
+
+    version = ExampleVersionRepository(db, get_cache()).get_with_relationships(
+        str(deployment.example_version_id)
+    )
+    if version is None:
+        raise NotFoundException("Example version not found")
+
+    repository = version.example.repository
+    if repository.source_type not in ("minio", "s3"):
+        raise NotFoundException("Source view is only available for stored examples")
+
+    bucket_name = repository.source_url.split("/")[0]
+    objects = await storage_service.list_objects(
+        bucket_name=bucket_name,
+        prefix=version.storage_path,
+    )
+    files: list[AnalyticsExampleSourceFile] = []
+    for obj in objects:
+        if obj.object_name.endswith("/"):
+            continue
+        data = await storage_service.download_file(
+            bucket_name=bucket_name,
+            object_key=obj.object_name,
+        )
+        text = _as_text(data)
+        if text is None:
+            continue  # skip binaries; the source view shows code only
+        name = obj.object_name.replace(f"{version.storage_path}/", "")
+        files.append(AnalyticsExampleSourceFile(name=name, content=text))
+
+    files.sort(key=lambda file: file.name)
+    return AnalyticsExampleSource(
+        content_id=str(content_id),
+        title=version.example.title or "Example source",
+        files=files,
+    )
+
+
+def _as_text(data: bytes) -> str | None:
+    if isinstance(data, str):
+        return data
+    try:
+        return data.decode("utf-8")
+    except (UnicodeDecodeError, AttributeError):
+        return None
 
 
 def _require_course_role(

--- a/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
+++ b/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
@@ -160,6 +160,32 @@ def test_report_repository_tracks_actual_grading_checkpoint_counts():
     assert bob["average_grading"] == 0.70
 
 
+def test_report_repository_counts_score_pass_at_threshold():
+    # A pass over a standard example means the latest grade reached 60%, not
+    # merely that the student submitted or was graded. Add a graded-but-failing
+    # second assignment for Bob so passed (1) differs from graded (2).
+    conn = duckdb.connect(":memory:")
+    _create_schema(conn)
+    _insert_fixture(conn)
+    conn.execute(
+        "INSERT INTO submission_grade VALUES "
+        "('80000000-0000-4000-8000-000000000199', "
+        "'70000000-0000-4000-8000-000000000122', "
+        "'50000000-0000-4000-8000-000000000002', "
+        "'2026-06-25 08:00:00+00', 0.30, 2)"
+    )
+    repo = AnalyticsDuckDbReportRepository(conn, cutoffs=AnalyticsCutoffs(None, None))
+    by_member = {row["course_member_id"]: row for row in repo.get_student_checkpoint_rows(COURSE_ID)}
+
+    alice = by_member[ALICE_MEMBER_ID]
+    assert alice["total_graded_assignments"] == 2
+    assert alice["standard_passed"] == 2  # 0.85 and 0.90 both clear 60%
+
+    bob = by_member[BOB_MEMBER_ID]
+    assert bob["total_graded_assignments"] == 2
+    assert bob["standard_passed"] == 1  # 0.70 passes, 0.30 does not
+
+
 def test_analytics_service_reads_summary_and_timeline_from_duckdb(tmp_path):
     config = AnalyticsStorageConfig(root=tmp_path)
     config.duckdb_path.parent.mkdir(parents=True)

--- a/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
+++ b/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
@@ -223,6 +223,38 @@ def test_analytics_service_student_examples_derives_flags(tmp_path):
     assert b2.late is True
 
 
+def test_burst_flag_ignores_steady_work_and_marks_steep_clusters():
+    from datetime import timedelta
+
+    from computor_backend.analytics.service import _tag_velocity
+    from computor_types.analytics import AnalyticsStandardExample
+
+    base = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+    def make(i, when):
+        return AnalyticsStandardExample(
+            content_id=f"c{i}",
+            path=f"week_{i}.ex",
+            title=f"Example {i}",
+            score=0.8,
+            passed=True,
+            test_rounds=3,
+            submitted_at=when,
+            official=True,
+            late=False,
+        )
+
+    # One submission per week is the vertical ladder, not a burst.
+    steady = [make(i, base + timedelta(weeks=i)) for i in range(6)]
+    _tag_velocity(steady)
+    assert all("velocity" not in e.flags for e in steady)
+
+    # Six examples inside a day and a half is a genuine burst.
+    crammed = [make(i, base + timedelta(hours=6 * i)) for i in range(6)]
+    _tag_velocity(crammed)
+    assert all("velocity" in e.flags for e in crammed)
+
+
 def test_analytics_service_reads_summary_and_timeline_from_duckdb(tmp_path):
     config = AnalyticsStorageConfig(root=tmp_path)
     config.duckdb_path.parent.mkdir(parents=True)

--- a/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
+++ b/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
@@ -186,6 +186,43 @@ def test_report_repository_counts_score_pass_at_threshold():
     assert bob["standard_passed"] == 1  # 0.70 passes, 0.30 does not
 
 
+def test_report_repository_lists_student_examples_with_rounds_and_lateness():
+    repo = _report_repo_with_fixture(
+        submission_cutoff=datetime(2026, 6, 18, 22, 1, tzinfo=timezone.utc),
+        grading_cutoff=None,
+    )
+    by_path = {
+        row["path"]: row for row in repo.get_student_examples(COURSE_ID, BOB_MEMBER_ID)
+    }
+    # Bob's assignment 2: late official submission preceded by three test runs.
+    a2 = by_path["week1.assignment2"]
+    assert a2["test_rounds"] == 3
+    assert a2["submitted_at"] is not None
+    assert bool(a2["late"]) is True
+
+
+def test_analytics_service_student_examples_derives_flags(tmp_path):
+    service = _service_with_fixture(tmp_path)
+    cutoffs = AnalyticsCutoffs(
+        submission=datetime(2026, 6, 18, 22, 1, tzinfo=timezone.utc),
+        grading=None,
+    )
+
+    alice = {ex.path: ex for ex in service.student_examples(COURSE_ID, ALICE_MEMBER_ID, cutoffs)}
+    a1 = alice["week1.assignment1"]
+    # Passed with no test runs -> low-iteration flag.
+    assert a1.passed is True
+    assert a1.test_rounds == 0
+    assert "low_iteration" in a1.flags
+
+    bob = {ex.path: ex for ex in service.student_examples(COURSE_ID, BOB_MEMBER_ID, cutoffs)}
+    b2 = bob["week1.assignment2"]
+    # Three test rounds before submitting -> not a low-iteration pass.
+    assert b2.test_rounds == 3
+    assert "low_iteration" not in b2.flags
+    assert b2.late is True
+
+
 def test_analytics_service_reads_summary_and_timeline_from_duckdb(tmp_path):
     config = AnalyticsStorageConfig(root=tmp_path)
     config.duckdb_path.parent.mkdir(parents=True)

--- a/computor-types/src/computor_types/analytics.py
+++ b/computor-types/src/computor_types/analytics.py
@@ -96,6 +96,49 @@ class AnalyticsStudentCheckpoint(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class AnalyticsTutorComment(BaseModel):
+    author_role: str
+    text: str
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsStandardExample(BaseModel):
+    content_id: str
+    path: str
+    title: str
+    category: str | None = None
+    unit: str | None = None
+    score: float | None = None
+    passed: bool = False
+    test_rounds: int = 0
+    submitted_at: datetime | None = None
+    official: bool = False
+    late: bool = False
+    flags: list[str] = Field(default_factory=list)
+    comments: list[AnalyticsTutorComment] = Field(default_factory=list)
+    href: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsExampleSourceFile(BaseModel):
+    name: str
+    content: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsExampleSource(BaseModel):
+    content_id: str
+    title: str
+    files: list[AnalyticsExampleSourceFile] = Field(default_factory=list)
+    href: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class AnalyticsTimelineEvent(BaseModel):
     occurred_at: datetime
     event_type: str

--- a/computor-types/src/computor_types/analytics.py
+++ b/computor-types/src/computor_types/analytics.py
@@ -86,6 +86,12 @@ class AnalyticsStudentCheckpoint(BaseModel):
     average_grading: float | None = None
     latest_submission_at: datetime | None = None
     late_submission_count: int = 0
+    # Score-pass over standard (submittable) examples: a pass means the latest
+    # grade reached the pass threshold, not merely that the student submitted.
+    standard_total: int = 0
+    standard_passed: int = 0
+    pass_rate: float = 0.0
+    average_score: float | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/computor-web/app/courses/[id]/lecturer/analytics/examples/[contentId]/page.tsx
+++ b/computor-web/app/courses/[id]/lecturer/analytics/examples/[contentId]/page.tsx
@@ -35,7 +35,6 @@ export default function ExampleSourcePage() {
         const s = await getExampleSource(courseId, contentId);
         if (cancelled) return;
         setSource(s);
-        if (!s) setError('No source available for this example.');
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load source.');
       } finally {
@@ -62,6 +61,13 @@ export default function ExampleSourcePage() {
 
         {loading && <p className="text-sm text-gray-500">Loading source…</p>}
         {error && <p className="text-sm text-red-600">{error}</p>}
+
+        {!loading && !error && (!source || source.files.length === 0) && (
+          <p className="rounded-lg border border-dashed border-gray-200 p-6 text-sm text-gray-500">
+            The example source isn’t available in this analytics snapshot. It is served
+            from the deployed example repository, which this snapshot doesn’t include yet.
+          </p>
+        )}
 
         {source && source.files.length > 0 && (
           <div className="rounded-lg border border-gray-200 bg-white">

--- a/startup.sh
+++ b/startup.sh
@@ -291,9 +291,10 @@ if [ "${KEYCLOAK_ENABLED}" = "true" ]; then
     fi
 fi
 
-# Make postgres init script executable
+# Make postgres init script executable. Tolerate a deploy user who is not the
+# file owner (the file ships executable from git, so this is only a touch-up).
 if [ -f "docker/postgres-init/01-create-multiple-databases.sh" ]; then
-    chmod +x docker/postgres-init/01-create-multiple-databases.sh
+    chmod +x docker/postgres-init/01-create-multiple-databases.sh 2>/dev/null || true
 fi
 
 # Start services


### PR DESCRIPTION
Lecturer feedback fixes. Burst flag now measures submission-curve steepness (steepest window of <=15 consecutive official submissions, flagged only when done within a week) instead of a volatile 24h count. Example source page shows a calm notice when the deployed example repo is not in the snapshot, instead of a red error. startup.sh tolerates a non-owner deploy user for the postgres-init chmod. Verification: 19 analytics backend tests pass (incl. new burst test); tsc + lint clean. Refs computor-org/issues#255, #256.