### PR TITLE
fix(analytics): gradient-based burst flag, graceful missing source, deploy chmod

### DIFF
--- a/computor-backend/src/computor_backend/analytics/service.py
+++ b/computor-backend/src/computor_backend/analytics/service.py
@@ -453,8 +453,13 @@ def _checkpoint_from_row(
 # already-ingested snapshot with no extra requests or statistics.
 _PASS_THRESHOLD = 0.6
 _LOW_ITERATION_MAX_ROUNDS = 1
-_VELOCITY_WINDOW_SECONDS = 24 * 3600
-_VELOCITY_MIN_IN_WINDOW = 5
+# Burst = a steep stretch of the submission curve: this many consecutive
+# official submissions (capped at how many the student has) completed within the
+# span below. Measuring the gradient over many examples avoids flagging steady
+# one-per-week work.
+_BURST_WINDOW_EXAMPLES = 15
+_BURST_MIN_WINDOW = 3
+_BURST_MAX_SPAN_SECONDS = 7 * 24 * 3600
 _GRADING_STATUS_CORRECTION_NECESSARY = 2
 
 
@@ -507,18 +512,32 @@ def _examples_from_rows(rows: list[dict[str, Any]]) -> list[AnalyticsStandardExa
 
 
 def _tag_velocity(examples: list[AnalyticsStandardExample]) -> None:
-    """Flag a submission burst: an official example whose submission time sits in
-    a 24h window holding at least _VELOCITY_MIN_IN_WINDOW official submissions."""
-    official = [ex for ex in examples if ex.official and ex.submitted_at is not None]
-    for ex in official:
-        in_window = sum(
-            1
-            for other in official
-            if abs((other.submitted_at - ex.submitted_at).total_seconds())
-            <= _VELOCITY_WINDOW_SECONDS
-        )
-        if in_window >= _VELOCITY_MIN_IN_WINDOW and "velocity" not in ex.flags:
-            ex.flags.append("velocity")
+    """Flag a submission burst by the steepness of the submission curve, not by a
+    count of threshold crossings. Take a window of consecutive official
+    submissions (a gradient over many examples) and flag the single steepest one
+    when those examples were completed within a short span. Steady weekly work
+    spreads the window over weeks and never triggers; one busy late week does."""
+    official = sorted(
+        (ex for ex in examples if ex.official and ex.submitted_at is not None),
+        key=lambda ex: ex.submitted_at,
+    )
+    n = len(official)
+    window = min(_BURST_WINDOW_EXAMPLES, n)
+    if window < _BURST_MIN_WINDOW:
+        return
+    best_span: float | None = None
+    best_start = 0
+    for start in range(0, n - window + 1):
+        span = (
+            official[start + window - 1].submitted_at - official[start].submitted_at
+        ).total_seconds()
+        if best_span is None or span < best_span:
+            best_span = span
+            best_start = start
+    if best_span is not None and best_span <= _BURST_MAX_SPAN_SECONDS:
+        for ex in official[best_start : best_start + window]:
+            if "velocity" not in ex.flags:
+                ex.flags.append("velocity")
 
 
 def _read_manifest(snapshot_path: Path) -> tuple[dict[str, int], dict[str, dict[str, str]]]:

--- a/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
+++ b/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
@@ -223,6 +223,38 @@ def test_analytics_service_student_examples_derives_flags(tmp_path):
     assert b2.late is True
 
 
+def test_burst_flag_ignores_steady_work_and_marks_steep_clusters():
+    from datetime import timedelta
+
+    from computor_backend.analytics.service import _tag_velocity
+    from computor_types.analytics import AnalyticsStandardExample
+
+    base = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+    def make(i, when):
+        return AnalyticsStandardExample(
+            content_id=f"c{i}",
+            path=f"week_{i}.ex",
+            title=f"Example {i}",
+            score=0.8,
+            passed=True,
+            test_rounds=3,
+            submitted_at=when,
+            official=True,
+            late=False,
+        )
+
+    # One submission per week is the vertical ladder, not a burst.
+    steady = [make(i, base + timedelta(weeks=i)) for i in range(6)]
+    _tag_velocity(steady)
+    assert all("velocity" not in e.flags for e in steady)
+
+    # Six examples inside a day and a half is a genuine burst.
+    crammed = [make(i, base + timedelta(hours=6 * i)) for i in range(6)]
+    _tag_velocity(crammed)
+    assert all("velocity" in e.flags for e in crammed)
+
+
 def test_analytics_service_reads_summary_and_timeline_from_duckdb(tmp_path):
     config = AnalyticsStorageConfig(root=tmp_path)
     config.duckdb_path.parent.mkdir(parents=True)

--- a/computor-web/app/courses/[id]/lecturer/analytics/examples/[contentId]/page.tsx
+++ b/computor-web/app/courses/[id]/lecturer/analytics/examples/[contentId]/page.tsx
@@ -35,7 +35,6 @@ export default function ExampleSourcePage() {
         const s = await getExampleSource(courseId, contentId);
         if (cancelled) return;
         setSource(s);
-        if (!s) setError('No source available for this example.');
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load source.');
       } finally {
@@ -62,6 +61,13 @@ export default function ExampleSourcePage() {
 
         {loading && <p className="text-sm text-gray-500">Loading source…</p>}
         {error && <p className="text-sm text-red-600">{error}</p>}
+
+        {!loading && !error && (!source || source.files.length === 0) && (
+          <p className="rounded-lg border border-dashed border-gray-200 p-6 text-sm text-gray-500">
+            The example source isn’t available in this analytics snapshot. It is served
+            from the deployed example repository, which this snapshot doesn’t include yet.
+          </p>
+        )}
 
         {source && source.files.length > 0 && (
           <div className="rounded-lg border border-gray-200 bg-white">

--- a/startup.sh
+++ b/startup.sh
@@ -291,9 +291,10 @@ if [ "${KEYCLOAK_ENABLED}" = "true" ]; then
     fi
 fi
 
-# Make postgres init script executable
+# Make postgres init script executable. Tolerate a deploy user who is not the
+# file owner (the file ships executable from git, so this is only a touch-up).
 if [ -f "docker/postgres-init/01-create-multiple-databases.sh" ]; then
-    chmod +x docker/postgres-init/01-create-multiple-databases.sh
+    chmod +x docker/postgres-init/01-create-multiple-databases.sh 2>/dev/null || true
 fi
 
 # Start services


### PR DESCRIPTION
Lecturer feedback fixes. Burst flag now measures submission-curve steepness (steepest window of <=15 consecutive official submissions, flagged only when completed within a week) instead of a volatile 24h/>=5 count, so steady weekly work no longer registers and one busy late week does. Example source page shows a calm notice when the deployed example repository is not in the snapshot, instead of a red error. startup.sh tolerates a non-owner deploy user for the postgres-init chmod. Verification: 19 analytics backend tests pass (incl. new burst test); tsc + lint clean. Refs computor-org/issues#255, #256.