### PR TITLE
feat(analytics): live example source from the source instance

### DIFF
--- a/computor-backend/src/computor_backend/analytics/config.py
+++ b/computor-backend/src/computor_backend/analytics/config.py
@@ -18,6 +18,9 @@ ANALYTICS_TABLES = (
     "submission_artifact",
     "submission_grade",
     "result",
+    # Small mapping tables so the source view can resolve a content to its
+    # deployed example version locally; the files are fetched live from source.
+    "course_content_deployment",
 )
 
 

--- a/computor-backend/src/computor_backend/analytics/report_repository.py
+++ b/computor-backend/src/computor_backend/analytics/report_repository.py
@@ -323,6 +323,23 @@ class AnalyticsDuckDbReportRepository(AnalyticsDuckDbGradingRepository):
             ],
         )
 
+    def get_example_deployment(self, content_id: str) -> dict[str, Any] | None:
+        """Resolve a course content to its deployed example version from the
+        snapshot. Returns None when the snapshot has no deployment mapping (an
+        older snapshot, or content with no example). Files are fetched live."""
+        if not self._has_column("course_content_deployment", "example_version_id"):
+            return None
+        rows = self._rows(
+            """
+            SELECT example_version_id, example_identifier
+            FROM course_content_deployment
+            WHERE course_content_id = ?
+            LIMIT 1
+            """,
+            [str(content_id)],
+        )
+        return rows[0] if rows else None
+
     def get_timeline_events(
         self,
         course_id: str,

--- a/computor-backend/src/computor_backend/analytics/service.py
+++ b/computor-backend/src/computor_backend/analytics/service.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 from fastapi import BackgroundTasks
 import duckdb
+import httpx
 
 from computor_backend.exceptions import (
     BadRequestException,
@@ -20,6 +21,8 @@ from computor_backend.settings import settings
 from computor_types.analytics import (
     AnalyticsCourseAccess,
     AnalyticsCourseSummary,
+    AnalyticsExampleSource,
+    AnalyticsExampleSourceFile,
     AnalyticsJobStatus,
     AnalyticsRefreshRequest,
     AnalyticsStandardExample,
@@ -362,6 +365,33 @@ class AnalyticsService:
         finally:
             connection.close()
 
+    def example_source(
+        self,
+        course_id: str,
+        content_id: str,
+    ) -> AnalyticsExampleSource | None:
+        """Source files of the example deployed to a content. The deployment
+        mapping comes from the snapshot; the files are fetched live from the
+        source instance's API, server side, so the browser never touches it."""
+        connection = self._read_connection()
+        try:
+            repo = AnalyticsDuckDbReportRepository(connection)
+            deployment = repo.get_example_deployment(content_id)
+        finally:
+            connection.close()
+        if not deployment or not deployment.get("example_version_id"):
+            return None
+
+        files = _fetch_source_files(str(deployment["example_version_id"]))
+        if files is None:
+            return None
+        title = deployment.get("example_identifier") or "Example source"
+        return AnalyticsExampleSource(
+            content_id=str(content_id),
+            title=str(title),
+            files=files,
+        )
+
     def _student_checkpoints_from_connection(
         self,
         connection: duckdb.DuckDBPyConnection,
@@ -538,6 +568,41 @@ def _tag_velocity(examples: list[AnalyticsStandardExample]) -> None:
         for ex in official[best_start : best_start + window]:
             if "velocity" not in ex.flags:
                 ex.flags.append("velocity")
+
+
+def _fetch_source_files(version_id: str) -> list[AnalyticsExampleSourceFile] | None:
+    """Download an example version's files from the source instance's API. None
+    when the source API is not configured or the request fails, which the UI
+    renders as a calm 'source not available' notice."""
+    base = settings.ANALYTICS_SOURCE_API_URL
+    token = settings.ANALYTICS_SOURCE_API_TOKEN
+    if not base or not token:
+        return None
+    url = f"{base.rstrip('/')}/examples/download/{version_id}"
+    try:
+        response = httpx.get(url, headers={"X-API-Token": token}, timeout=20.0)
+    except httpx.HTTPError:
+        return None
+    if response.status_code != 200:
+        return None
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    return _source_files_from_payload(payload)
+
+
+def _source_files_from_payload(payload: object) -> list[AnalyticsExampleSourceFile]:
+    """Map an ExampleDownloadResponse `files` map to source files, keeping only
+    text (skipping base64 data-URI binaries the code view cannot show)."""
+    files = payload.get("files") if isinstance(payload, dict) else None
+    if not isinstance(files, dict):
+        return []
+    return [
+        AnalyticsExampleSourceFile(name=str(name), content=content)
+        for name, content in sorted(files.items())
+        if isinstance(content, str) and not content.startswith("data:")
+    ]
 
 
 def _read_manifest(snapshot_path: Path) -> tuple[dict[str, int], dict[str, dict[str, str]]]:

--- a/computor-backend/src/computor_backend/api/analytics.py
+++ b/computor-backend/src/computor_backend/api/analytics.py
@@ -12,18 +12,13 @@ from computor_backend.database import get_db
 from computor_backend.exceptions import ForbiddenException, NotFoundException
 from computor_backend.model.auth import User
 from computor_backend.model.course import CourseMember
-from computor_backend.model.deployment import CourseContentDeployment
 from computor_backend.permissions.auth import get_current_principal
 from computor_backend.permissions.core import check_course_permissions
 from computor_backend.permissions.principal import Principal
-from computor_backend.redis_cache import get_cache
-from computor_backend.repositories import ExampleVersionRepository
-from computor_backend.services.storage_service import get_storage_service
 from computor_types.analytics import (
     AnalyticsCourseAccess,
     AnalyticsCourseSummary,
     AnalyticsExampleSource,
-    AnalyticsExampleSourceFile,
     AnalyticsJobStatus,
     AnalyticsRefreshRequest,
     AnalyticsStandardExample,
@@ -213,65 +208,17 @@ async def get_analytics_example_source(
     content_id: str,
     permissions: Annotated[Principal, Depends(get_current_principal)],
     db: Session = Depends(get_db),
-    storage_service=Depends(get_storage_service),
 ) -> AnalyticsExampleSource:
-    """Source files of the example deployed to a course content. Gated by the
-    analytics read role, so course staff see the source without needing the
-    global example-download permission. Reads the live deployment + storage."""
+    """Source files of the example deployed to a content. The deployment mapping
+    comes from the analytics snapshot; the files are fetched live from the source
+    instance, server side, so the browser never touches the source. Gated by the
+    analytics read role. 404 (rendered as a calm notice) when the snapshot has no
+    deployment for the content or the source API is unreachable/unconfigured."""
     _require_course_role(permissions, db, course_id, ANALYTICS_READ_ROLE)
-
-    deployment = (
-        db.query(CourseContentDeployment)
-        .filter(CourseContentDeployment.course_content_id == content_id)
-        .first()
-    )
-    if deployment is None or deployment.example_version_id is None:
-        raise NotFoundException("No example deployed for this content")
-
-    version = ExampleVersionRepository(db, get_cache()).get_with_relationships(
-        str(deployment.example_version_id)
-    )
-    if version is None:
-        raise NotFoundException("Example version not found")
-
-    repository = version.example.repository
-    if repository.source_type not in ("minio", "s3"):
-        raise NotFoundException("Source view is only available for stored examples")
-
-    bucket_name = repository.source_url.split("/")[0]
-    objects = await storage_service.list_objects(
-        bucket_name=bucket_name,
-        prefix=version.storage_path,
-    )
-    files: list[AnalyticsExampleSourceFile] = []
-    for obj in objects:
-        if obj.object_name.endswith("/"):
-            continue
-        data = await storage_service.download_file(
-            bucket_name=bucket_name,
-            object_key=obj.object_name,
-        )
-        text = _as_text(data)
-        if text is None:
-            continue  # skip binaries; the source view shows code only
-        name = obj.object_name.replace(f"{version.storage_path}/", "")
-        files.append(AnalyticsExampleSourceFile(name=name, content=text))
-
-    files.sort(key=lambda file: file.name)
-    return AnalyticsExampleSource(
-        content_id=str(content_id),
-        title=version.example.title or "Example source",
-        files=files,
-    )
-
-
-def _as_text(data: bytes) -> str | None:
-    if isinstance(data, str):
-        return data
-    try:
-        return data.decode("utf-8")
-    except (UnicodeDecodeError, AttributeError):
-        return None
+    source = AnalyticsService.from_settings().example_source(course_id, content_id)
+    if source is None:
+        raise NotFoundException("Source not available for this content")
+    return source
 
 
 def _require_course_role(

--- a/computor-backend/src/computor_backend/settings.py
+++ b/computor-backend/src/computor_backend/settings.py
@@ -55,6 +55,18 @@ class BackendSettings:
         self.ANALYTICS_EXPORT_CHUNK_SIZE = int(
             os.environ.get("ANALYTICS_EXPORT_CHUNK_SIZE", "100000")
         )
+        # Read-only access to the source instance's API, used to fetch an
+        # example's source files live when a lecturer opens it. The browser
+        # never calls the source directly; this analytics backend does, server
+        # side. Empty token leaves the source view gracefully unavailable.
+        self.ANALYTICS_SOURCE_API_URL = os.environ.get(
+            "ANALYTICS_SOURCE_API_URL",
+            None,
+        )
+        self.ANALYTICS_SOURCE_API_TOKEN = os.environ.get(
+            "ANALYTICS_SOURCE_API_TOKEN",
+            None,
+        )
 
     def __new__(cls):
         if cls._instance is None:

--- a/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
+++ b/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
@@ -255,6 +255,23 @@ def test_burst_flag_ignores_steady_work_and_marks_steep_clusters():
     assert all("velocity" in e.flags for e in crammed)
 
 
+def test_source_files_from_payload_keeps_text_and_skips_binaries():
+    from computor_backend.analytics.service import _source_files_from_payload
+
+    payload = {
+        "files": {
+            "solution.py": "print(1)\n",
+            "diagram.png": "data:image/png;base64,AAAA",
+            "README.md": "# Title\n",
+        }
+    }
+    files = _source_files_from_payload(payload)
+    # Sorted by name, base64 binary dropped.
+    assert [f.name for f in files] == ["README.md", "solution.py"]
+    assert any("print(1)" in f.content for f in files)
+    assert _source_files_from_payload({}) == []
+
+
 def test_analytics_service_reads_summary_and_timeline_from_duckdb(tmp_path):
     config = AnalyticsStorageConfig(root=tmp_path)
     config.duckdb_path.parent.mkdir(parents=True)


### PR DESCRIPTION
Live example-source view. The browser never touches the source instance: the analytics backend resolves a content's deployed example version from the snapshot (new: snapshot course_content_deployment), then fetches that one example's files live from the source instance's API server-side (ANALYTICS_SOURCE_API_URL + X-API-Token), only when a lecturer opens it. Text files only. Unconfigured/unreachable source -> 404 rendered as a calm notice. Activation: set ANALYTICS_SOURCE_API_URL + read-only ANALYTICS_SOURCE_API_TOKEN in the deploy env and run one refresh to populate the mapping table. Verification: 20 analytics backend tests pass (incl. file-mapping transform). Refs computor-org/issues#255, #256.