### PR TITLE
fix(analytics): show notebooks in example source view

### DIFF
--- a/computor-backend/src/computor_backend/analytics/service.py
+++ b/computor-backend/src/computor_backend/analytics/service.py
@@ -599,16 +599,61 @@ def _source_get_json(base: str, token: str, path: str) -> object | None:
 
 
 def _source_files_from_payload(payload: object) -> list[AnalyticsExampleSourceFile]:
-    """Map an ExampleDownloadResponse `files` map to source files, keeping only
-    text (skipping base64 data-URI binaries the code view cannot show)."""
+    """Map an ExampleDownloadResponse `files` map to readable source. Plain text
+    passes through; data-URI files are decoded and kept when they are UTF-8 text
+    (e.g. notebooks, which the download wraps as base64 octet-stream); genuine
+    binaries (images) are skipped. Notebooks render as their cell sources."""
     files = payload.get("files") if isinstance(payload, dict) else None
     if not isinstance(files, dict):
         return []
-    return [
-        AnalyticsExampleSourceFile(name=str(name), content=content)
-        for name, content in sorted(files.items())
-        if isinstance(content, str) and not content.startswith("data:")
-    ]
+    result: list[AnalyticsExampleSourceFile] = []
+    for name, content in sorted(files.items()):
+        if not isinstance(content, str):
+            continue
+        text = _decode_source_text(content) if content.startswith("data:") else content
+        if text is None:
+            continue
+        if str(name).endswith(".ipynb"):
+            text = _notebook_to_source(text)
+        result.append(AnalyticsExampleSourceFile(name=str(name), content=text))
+    return result
+
+
+def _decode_source_text(data_uri: str) -> str | None:
+    """Decode a data: URI to UTF-8 text, or None when it is binary."""
+    import base64
+    from urllib.parse import unquote_to_bytes
+
+    try:
+        header, _, data = data_uri.partition(",")
+        raw = base64.b64decode(data) if ";base64" in header else unquote_to_bytes(data)
+        return raw.decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+def _notebook_to_source(text: str) -> str:
+    """Flatten a Jupyter notebook to its code and markdown cells, so the source
+    view shows the actual code rather than raw notebook JSON."""
+    try:
+        notebook = json.loads(text)
+    except ValueError:
+        return text
+    cells = notebook.get("cells") if isinstance(notebook, dict) else None
+    if not isinstance(cells, list):
+        return text
+    blocks: list[str] = []
+    for cell in cells:
+        if not isinstance(cell, dict):
+            continue
+        source = cell.get("source", "")
+        body = "".join(source) if isinstance(source, list) else str(source)
+        if not body.strip():
+            continue
+        if cell.get("cell_type") == "markdown":
+            body = "\n".join(f"# {line}" for line in body.splitlines())
+        blocks.append(body)
+    return "\n\n".join(blocks) if blocks else text
 
 
 def _read_manifest(snapshot_path: Path) -> tuple[dict[str, int], dict[str, dict[str, str]]]:

--- a/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
+++ b/computor-backend/src/computor_backend/tests/test_analytics_grading_backend.py
@@ -255,20 +255,27 @@ def test_burst_flag_ignores_steady_work_and_marks_steep_clusters():
     assert all("velocity" in e.flags for e in crammed)
 
 
-def test_source_files_from_payload_keeps_text_and_skips_binaries():
+def test_source_files_decode_text_datauris_and_skip_binaries():
+    import base64
+
     from computor_backend.analytics.service import _source_files_from_payload
 
+    png = base64.b64encode(b"\x89PNG\x00\x01\x02").decode()
+    notebook = base64.b64encode(
+        b'{"cells":[{"cell_type":"code","source":["x = 1\\n"]}]}'
+    ).decode()
     payload = {
         "files": {
             "solution.py": "print(1)\n",
-            "diagram.png": "data:image/png;base64,AAAA",
+            "diagram.png": "data:image/png;base64," + png,
+            "review.ipynb": "data:application/octet-stream;base64," + notebook,
             "README.md": "# Title\n",
         }
     }
-    files = _source_files_from_payload(payload)
-    # Sorted by name, base64 binary dropped.
-    assert [f.name for f in files] == ["README.md", "solution.py"]
-    assert any("print(1)" in f.content for f in files)
+    files = {f.name: f.content for f in _source_files_from_payload(payload)}
+    assert "diagram.png" not in files  # genuine binary skipped
+    assert "print(1)" in files["solution.py"]  # plain text passes through
+    assert "x = 1" in files["review.ipynb"]  # notebook decoded + flattened to code
     assert _source_files_from_payload({}) == []
 
 


### PR DESCRIPTION
Decode UTF-8 data-URI files (notebooks arrive as base64 octet-stream) and flatten .ipynb to its cell sources; skip genuine binaries. 20 backend tests pass.