### PR TITLE
refactor(cache): drop phantom aiocache dep, stabilize repository cache keys

### DIFF
--- a/computor-backend/pyproject.toml
+++ b/computor-backend/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "click==8.1.7",
     "alive-progress==3.2.0",
     "gitpython==3.1.43",
-    "aiocache[redis]==0.12.3",
+    "redis==6.4.0",
     "SQLAlchemy==1.4.54",
     "minio==7.2.5",
     "alembic==1.15.1",

--- a/computor-backend/src/computor_backend/api/course_contents.py
+++ b/computor-backend/src/computor_backend/api/course_contents.py
@@ -45,7 +45,7 @@ from computor_backend.repositories import (
     CourseContentRepository,
     CourseContentDeploymentRepository,
 )
-from aiocache import BaseCache
+import redis.asyncio as aioredis
 
 # Create the router
 course_content_router = CrudRouter(CourseContentInterface)
@@ -165,7 +165,7 @@ async def unassign_example_from_content(
     content_id: str,
     permissions: Annotated[Principal, Depends(get_current_principal)],
     db: Session = Depends(get_db),
-    cache: Annotated[BaseCache, Depends(get_redis_client)] = None
+    cache: Annotated[aioredis.Redis, Depends(get_redis_client)] = None
 ):
     """
     Remove example assignment from course content.
@@ -416,7 +416,7 @@ async def get_course_deployment_summary(
     course_id: str,
     permissions: Annotated[Principal, Depends(get_current_principal)],
     db: Session = Depends(get_db),
-    cache: Annotated[BaseCache, Depends(get_redis_client)] = None
+    cache: Annotated[aioredis.Redis, Depends(get_redis_client)] = None
 ):
     """
     Get deployment summary for a course.
@@ -557,7 +557,7 @@ async def move_course_content(
     move_request: CourseContentMoveRequest,
     permissions: Annotated[Principal, Depends(get_current_principal)],
     db: Session = Depends(get_db),
-    cache: Annotated[BaseCache, Depends(get_redis_client)] = None
+    cache: Annotated[aioredis.Redis, Depends(get_redis_client)] = None
 ):
     """
     Move a course content to a new path and/or position.

--- a/computor-backend/src/computor_backend/repositories/base.py
+++ b/computor-backend/src/computor_backend/repositories/base.py
@@ -5,6 +5,8 @@ This module provides abstract base classes for the repository pattern,
 enabling direct database access with transparent write-through caching.
 """
 
+import hashlib
+import json
 from abc import ABC, abstractmethod
 from typing import TypeVar, Generic, List, Optional, Dict, Any, Type, Set
 from sqlalchemy.orm import Session
@@ -13,6 +15,19 @@ from sqlalchemy import inspect
 
 # Type variable for generic entity type
 T = TypeVar('T')
+
+
+def stable_params_hash(params: Dict[str, Any]) -> str:
+    """Deterministic hash of query params/criteria for cache keys.
+
+    The builtin ``hash()`` is salted per process (PYTHONHASHSEED), so
+    ``hash(frozenset(params.items()))`` yields different cache keys across
+    workers and restarts -- causing avoidable misses and confusing entries.
+    Serialize canonically (sorted keys, ``str`` fallback for UUID/enum/datetime
+    values) and digest with SHA-256 so the key is identical everywhere.
+    """
+    serialized = json.dumps(params, sort_keys=True, default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()[:16]
 
 
 class RepositoryError(Exception):
@@ -269,7 +284,7 @@ class BaseRepository(ABC, Generic[T]):
         # Try cache if enabled
         if self._use_cache():
             query_params = {"limit": limit, "offset": offset, **filters}
-            key = self.cache.key(self.entity_type, f"list:{hash(frozenset(query_params.items()))}")
+            key = self.cache.key(self.entity_type, f"list:{stable_params_hash(query_params)}")
             cached = self.cache.get_by_key(key)
             if cached is not None:
                 return [self._deserialize_entity(item) for item in cached]
@@ -293,7 +308,7 @@ class BaseRepository(ABC, Generic[T]):
         # Cache if enabled
         if self._use_cache():
             query_params = {"limit": limit, "offset": offset, **filters}
-            key = self.cache.key(self.entity_type, f"list:{hash(frozenset(query_params.items()))}")
+            key = self.cache.key(self.entity_type, f"list:{stable_params_hash(query_params)}")
             tags = self.get_list_tags(**filters)
             serialized = [self._serialize_entity(e) for e in entities]
             self.cache.set_with_tags(key=key, payload=serialized, tags=tags, ttl=self.get_ttl())
@@ -477,7 +492,7 @@ class BaseRepository(ABC, Generic[T]):
         """
         # Try cache if enabled
         if self._use_cache():
-            key = self.cache.key(self.entity_type, f"find_by:{hash(frozenset(criteria.items()))}")
+            key = self.cache.key(self.entity_type, f"find_by:{stable_params_hash(criteria)}")
             cached = self.cache.get_by_key(key)
             if cached is not None:
                 return [self._deserialize_entity(item) for item in cached]
@@ -493,7 +508,7 @@ class BaseRepository(ABC, Generic[T]):
 
         # Cache if enabled
         if self._use_cache():
-            key = self.cache.key(self.entity_type, f"find_by:{hash(frozenset(criteria.items()))}")
+            key = self.cache.key(self.entity_type, f"find_by:{stable_params_hash(criteria)}")
             tags = self.get_list_tags(**criteria)
             serialized = [self._serialize_entity(e) for e in entities]
             self.cache.set_with_tags(key=key, payload=serialized, tags=tags, ttl=self.get_ttl())
@@ -512,7 +527,7 @@ class BaseRepository(ABC, Generic[T]):
         """
         # Try cache if enabled
         if self._use_cache():
-            key = self.cache.key(self.entity_type, f"find_one_by:{hash(frozenset(criteria.items()))}")
+            key = self.cache.key(self.entity_type, f"find_one_by:{stable_params_hash(criteria)}")
             cached = self.cache.get_by_key(key)
             if cached is not None:
                 return self._deserialize_entity(cached)
@@ -528,7 +543,7 @@ class BaseRepository(ABC, Generic[T]):
 
         # Cache if enabled and entity found
         if entity and self._use_cache():
-            key = self.cache.key(self.entity_type, f"find_one_by:{hash(frozenset(criteria.items()))}")
+            key = self.cache.key(self.entity_type, f"find_one_by:{stable_params_hash(criteria)}")
             tags = self.get_entity_tags(entity)
             self.cache.set_with_tags(
                 key=key,


### PR DESCRIPTION
Two self-contained cache cleanups.

1. **Drop phantom `aiocache`** — declared but only ever used as a *wrong* type hint (`BaseCache` on something that's actually `redis.asyncio.Redis`). Fixed the 3 annotations in `course_contents.py` and removed the dep. **Caught a latent packaging bug:** `redis` was only transitively present via `aiocache[redis]` — now declared explicitly (`redis==6.4.0`) so `redis_cache.py` keeps importing on a clean install.
2. **Stable cache keys** — replaced all 6 `hash(frozenset(...))` sites in `BaseRepository` with a `stable_params_hash()` (SHA-256 over canonically-serialized params). Builtin `hash()` is per-process salted, so keys diverged across workers/restarts. Read/write paths build the key identically, so lookups still hit.

Verification: no aiocache refs remain, byte-compile, the `aioredis.Redis` annotation resolves, the new hash is order-independent + deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)