### PR TITLE
refactor(grading): fix inverted repository → services dependency

### DIFF
--- a/computor-backend/src/computor_backend/repositories/view_base.py
+++ b/computor-backend/src/computor_backend/repositories/view_base.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def _aggregate_grading_status(statuses: List[str]) -> Optional[str]:
-    from ..services.course_member_grading_stats import aggregate_grading_status
+    from ..utils.grading_status import aggregate_grading_status
 
     return aggregate_grading_status(statuses, default=None)
 

--- a/computor-backend/src/computor_backend/services/course_member_grading_stats.py
+++ b/computor-backend/src/computor_backend/services/course_member_grading_stats.py
@@ -1,23 +1,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Iterable
+from typing import Any
 
-
-def aggregate_grading_status(
-    statuses: Iterable[str | None],
-    default: str | None = "not_reviewed",
-) -> str | None:
-    valid_statuses = [status for status in statuses if status is not None]
-    if not valid_statuses:
-        return default
-    if "correction_necessary" in valid_statuses:
-        return "correction_necessary"
-    if "improvement_possible" in valid_statuses:
-        return "improvement_possible"
-    if all(status == "corrected" for status in valid_statuses):
-        return "corrected"
-    return "not_reviewed"
+# Re-exported from the util layer so repositories can use it without an upward
+# repository -> services import (the canonical definition lives in
+# computor_backend.utils.grading_status).
+from computor_backend.utils.grading_status import aggregate_grading_status
 
 
 def process_hierarchical_stats(

--- a/computor-backend/src/computor_backend/utils/grading_status.py
+++ b/computor-backend/src/computor_backend/utils/grading_status.py
@@ -1,0 +1,26 @@
+"""Pure grading-status aggregation, with no DB/service dependencies.
+
+Lives in the util layer (below both repositories and services) so that
+``repositories`` can use it without importing *upward* from ``services`` --
+which was an inverted dependency. ``services.course_member_grading_stats``
+re-exports this for backwards compatibility.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def aggregate_grading_status(
+    statuses: Iterable[str | None],
+    default: str | None = "not_reviewed",
+) -> str | None:
+    valid_statuses = [status for status in statuses if status is not None]
+    if not valid_statuses:
+        return default
+    if "correction_necessary" in valid_statuses:
+        return "correction_necessary"
+    if "improvement_possible" in valid_statuses:
+        return "improvement_possible"
+    if all(status == "corrected" for status in valid_statuses):
+        return "corrected"
+    return "not_reviewed"


### PR DESCRIPTION
`repositories/view_base.py` imported `aggregate_grading_status` **up** from `services.course_member_grading_stats` — a bottom-layer repository depending on a service. The function is pure (no DB/service deps), so moved it down to `utils/grading_status.py` where both layers can depend on it. `services` re-exports it, so analytics / business_logic / its own internal use are unchanged.

Phase 1 of 2. **Phase 2 is `refactor/grading-read-layer`, which is stacked on this branch** (its PR targets this one).

Verification: no `repositories/` file imports the grading service anymore; re-export resolves; analytics imports; all compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)