### PR TITLE
refactor(views): generalize student/tutor view repository methods

### DIFF
--- a/computor-backend/src/computor_backend/repositories/lecturer_view.py
+++ b/computor-backend/src/computor_backend/repositories/lecturer_view.py
@@ -101,6 +101,10 @@ class LecturerViewRepository(ViewRepository):
         Returns:
             List of courses
         """
+        # NOTE: unlike the student/tutor views, this does NOT use
+        # ViewRepository._list_cached_course_dtos -- CourseInterface.search
+        # returns a raw ORM query and we serialize Course objects via __dict__
+        # (the model_dump-or-__dict__ fallback below), a different data flow.
         user_id = permissions.get_user_id_or_throw()
 
         # Try cache with query-aware key

--- a/computor-backend/src/computor_backend/repositories/student_view.py
+++ b/computor-backend/src/computor_backend/repositories/student_view.py
@@ -219,38 +219,14 @@ class StudentViewRepository(ViewRepository):
         query = user_course_content_list_query(user_id, self.db)
         course_contents_results = CourseContentStudentInterface.search(self.db, query, params).all()
 
-        response_list: List[CourseContentStudentList] = []
-        for course_contents_result in course_contents_results:
-            # Convert tuple to typed model before mapping
-            typed_result = CourseMemberCourseContentQueryResult.from_tuple(course_contents_result)
-            response_list.append(await course_member_course_content_result_mapper(typed_result, self.db))
-
-        # Aggregate status for unit-like course contents (non-submittable)
-        # Units aggregate status from their descendant submittable contents
-        response_list = self._aggregate_unit_statuses(response_list, user_id)
-
-        # Cache result with query-aware key
-        # CRITICAL: Tag with course_id AND individual course_content IDs for proper invalidation
-        related_ids = {}
-        if params.course_id:
-            # Single course filter - tag with that course_id
-            related_ids['student_view'] = str(params.course_id)
-
-        # CRITICAL: Tag each course_content for deployment-related invalidation
-        for result in response_list:
-            if hasattr(result, 'id') and result.id:
-                related_ids[f'course_content:{result.id}'] = None
-
-        self._set_cached_query_view(
-            user_id=str(user_id),
+        return await self._finalize_course_contents_view(
+            course_contents_results,
+            reader_user_id=user_id,
             view_type="course_contents",
             params=params,
-            data=self._serialize_dto_list(response_list),
-            ttl=self.get_default_ttl(),
-            related_ids=related_ids if related_ids else None
+            aggregate_user_id=user_id,
+            base_related_ids={'student_view': str(params.course_id)} if params.course_id else None,
         )
-
-        return response_list
 
     def list_courses(
         self,

--- a/computor-backend/src/computor_backend/repositories/student_view.py
+++ b/computor-backend/src/computor_backend/repositories/student_view.py
@@ -267,44 +267,20 @@ class StudentViewRepository(ViewRepository):
         Returns:
             List of courses with GitLab repository info
         """
-        user_id = permissions.get_user_id_or_throw()
-
-        # Try cache with query-aware key
-        cached = self._get_cached_query_view(
-            user_id=str(user_id),
+        return self._list_cached_course_dtos(
+            permissions,
+            params,
+            role="_student",
             view_type="courses",
-            params=params
-        )
-        if cached is not None:
-            return [CourseStudentList.model_validate(item, from_attributes=True) for item in cached]
-
-        # Query from DB with permission filtering
-        courses = CourseStudentInterface.search(
-            self.db,
-            check_course_permissions(permissions, Course, "_student", self.db),
-            params
-        ).all()
-
-        response_list: List[CourseStudentList] = []
-        for course in courses:
-            response_list.append(CourseStudentList(
+            dto_cls=CourseStudentList,
+            row_builder=lambda course: CourseStudentList(
                 id=course.id,
                 title=course.title,
                 course_family_id=course.course_family_id,
                 organization_id=course.organization_id,
                 path=course.path,
-            ))
-
-        # Cache result with query-aware key
-        self._set_cached_query_view(
-            user_id=str(user_id),
-            view_type="courses",
-            params=params,
-            data=self._serialize_dto_list(response_list),
-            ttl=self.get_default_ttl()
+            ),
         )
-
-        return response_list
 
     def get_course(
         self,

--- a/computor-backend/src/computor_backend/repositories/student_view.py
+++ b/computor-backend/src/computor_backend/repositories/student_view.py
@@ -297,44 +297,27 @@ class StudentViewRepository(ViewRepository):
         Returns:
             Detailed course information
         """
-        user_id = permissions.get_user_id_or_throw()
+        def _build(course):
+            result = CourseStudentGet(
+                id=course.id,
+                title=course.title,
+                course_family_id=course.course_family_id,
+                organization_id=course.organization_id,
+                course_content_types=course.course_content_types,
+                path=course.path,
+            )
+            related_ids = {
+                'course_id': str(course_id),
+                'course_family_id': str(course.course_family_id),
+                'organization_id': str(course.organization_id),
+            }
+            return result, related_ids
 
-        # Try cache
-        cached = self._get_cached_view(
-            user_id=str(user_id),
+        return self._get_cached_course_dto(
+            course_id,
+            permissions,
+            role="_student",
             view_type="course",
-            view_id=str(course_id)
+            dto_cls=CourseStudentGet,
+            builder=_build,
         )
-        if cached is not None:
-            return CourseStudentGet.model_validate(cached, from_attributes=True)
-
-        # Query from DB with permission filtering
-        course = check_course_permissions(permissions, Course, "_student", self.db).filter(
-            Course.id == course_id
-        ).first()
-
-        result = CourseStudentGet(
-            id=course.id,
-            title=course.title,
-            course_family_id=course.course_family_id,
-            organization_id=course.organization_id,
-            course_content_types=course.course_content_types,
-            path=course.path,
-        )
-
-        # Cache result
-        related_ids = {
-            'course_id': str(course_id),
-            'course_family_id': str(course.course_family_id),
-            'organization_id': str(course.organization_id)
-        }
-        self._set_cached_view(
-            user_id=str(user_id),
-            view_type="course",
-            view_id=str(course_id),
-            data=self._serialize_dto(result),
-            ttl=self.get_default_ttl(),
-            related_ids=related_ids
-        )
-
-        return result

--- a/computor-backend/src/computor_backend/repositories/tutor_view.py
+++ b/computor-backend/src/computor_backend/repositories/tutor_view.py
@@ -199,53 +199,32 @@ class TutorViewRepository(ViewRepository):
         Returns:
             Course with tutor-specific info
         """
-        user_id = permissions.get_user_id_or_throw()
+        def _build(course):
+            gitlab_props = course.properties.get("gitlab", {}) if course.properties else {}
+            gitlab_projects = gitlab_props.get("projects", {})
+            result = CourseTutorGet(
+                id=str(course.id),
+                title=course.title,
+                course_family_id=str(course.course_family_id) if course.course_family_id else None,
+                organization_id=str(course.organization_id) if course.organization_id else None,
+                path=course.path,
+                repository=CourseTutorRepository(
+                    provider_url=gitlab_props.get("url"),
+                    full_path_assignments=gitlab_projects.get("assignments", {}).get("full_path"),
+                    full_path_student_template=gitlab_projects.get("student_template", {}).get("full_path"),
+                ) if gitlab_props else None,
+            )
+            return result, {'course_id': str(course_id)}
 
-        # Try cache
-        cached = self._get_cached_view(
-            user_id=str(user_id),
+        return self._get_cached_course_dto(
+            course_id,
+            permissions,
+            role="_tutor",
             view_type="tutor:course",
-            view_id=str(course_id)
+            dto_cls=CourseTutorGet,
+            builder=_build,
+            raise_if_missing=True,
         )
-        if cached is not None:
-            return CourseTutorGet.model_validate(cached, from_attributes=True)
-
-        # Query from DB
-        course = check_course_permissions(permissions, Course, "_tutor", self.db).filter(
-            Course.id == course_id
-        ).first()
-
-        if course is None:
-            from ..exceptions import NotFoundException
-            raise NotFoundException()
-
-        gitlab_props = course.properties.get("gitlab", {}) if course.properties else {}
-        gitlab_projects = gitlab_props.get("projects", {})
-
-        result = CourseTutorGet(
-            id=str(course.id),
-            title=course.title,
-            course_family_id=str(course.course_family_id) if course.course_family_id else None,
-            organization_id=str(course.organization_id) if course.organization_id else None,
-            path=course.path,
-            repository=CourseTutorRepository(
-                provider_url=gitlab_props.get("url"),
-                full_path_assignments=gitlab_projects.get("assignments", {}).get("full_path"),
-                full_path_student_template=gitlab_projects.get("student_template", {}).get("full_path"),
-            ) if gitlab_props else None
-        )
-
-        # Cache result
-        self._set_cached_view(
-            user_id=str(user_id),
-            view_type="tutor:course",
-            view_id=str(course_id),
-            data=self._serialize_dto(result),
-            ttl=self.get_default_ttl(),
-            related_ids={'course_id': str(course_id)}
-        )
-
-        return result
 
     def list_courses(
         self,

--- a/computor-backend/src/computor_backend/repositories/tutor_view.py
+++ b/computor-backend/src/computor_backend/repositories/tutor_view.py
@@ -150,39 +150,17 @@ class TutorViewRepository(ViewRepository):
         query = course_member_course_content_list_query(course_member_id, self.db, reader_user_id=reader_user_id)
         course_contents_results = CourseContentStudentInterface.search(self.db, query, params).all()
 
-        response_list = []
-        for course_contents_result in course_contents_results:
-            # Convert tuple to typed model before mapping
-            typed_result = CourseMemberCourseContentQueryResult.from_tuple(course_contents_result)
-            response_list.append(await course_member_course_content_result_mapper(typed_result, self.db))
-
-        # Aggregate status for unit-like course contents (non-submittable)
-        # Units aggregate status from their descendant submittable contents
-        response_list = self._aggregate_unit_statuses(response_list, str(course_member.user_id))
-
-        # Cache result with query-aware key
-        # CRITICAL: Include course_id for proper invalidation when submissions/results change
-        # CRITICAL: Tag each course_content for deployment-related invalidation
-        related_ids = {
-            'course_member_id': str(course_member_id),
-            'tutor_view': str(course_member.course_id)  # ← CRITICAL: Tag with course_id for invalidation
-        }
-
-        # Tag each course_content for deployment-related invalidation
-        for result in response_list:
-            if hasattr(result, 'id') and result.id:
-                related_ids[f'course_content:{result.id}'] = None
-
-        self._set_cached_query_view(
-            user_id=str(reader_user_id),
+        return await self._finalize_course_contents_view(
+            course_contents_results,
+            reader_user_id=reader_user_id,
             view_type=f"tutor:course_contents:member:{course_member_id}",
             params=params,
-            data=self._serialize_dto_list(response_list),
-            ttl=self.get_default_ttl(),
-            related_ids=related_ids
+            aggregate_user_id=str(course_member.user_id),
+            base_related_ids={
+                'course_member_id': str(course_member_id),
+                'tutor_view': str(course_member.course_id),
+            },
         )
-
-        return response_list
 
     def get_course(
         self,

--- a/computor-backend/src/computor_backend/repositories/tutor_view.py
+++ b/computor-backend/src/computor_backend/repositories/tutor_view.py
@@ -262,27 +262,10 @@ class TutorViewRepository(ViewRepository):
         Returns:
             List of courses accessible to tutor
         """
-        user_id = permissions.get_user_id_or_throw()
-
-        # Try cache with query-aware key
-        cached = self._get_cached_query_view(
-            user_id=str(user_id),
-            view_type="tutor:courses",
-            params=params
-        )
-        if cached is not None:
-            return [CourseTutorList.model_validate(item, from_attributes=True) for item in cached]
-
-        # Query from DB
-        query = check_course_permissions(permissions, Course, "_tutor", self.db)
-        courses = CourseStudentInterface.search(self.db, query, params).all()
-
-        response_list = []
-        for course in courses:
+        def _build_row(course) -> CourseTutorList:
             gitlab_props = course.properties.get("gitlab", {}) if course.properties else {}
             gitlab_projects = gitlab_props.get("projects", {})
-
-            response_list.append(CourseTutorList(
+            return CourseTutorList(
                 id=str(course.id),
                 title=course.title,
                 course_family_id=str(course.course_family_id) if course.course_family_id else None,
@@ -292,16 +275,14 @@ class TutorViewRepository(ViewRepository):
                     provider_url=gitlab_props.get("url"),
                     full_path_assignments=gitlab_projects.get("assignments", {}).get("full_path"),
                     full_path_student_template=gitlab_projects.get("student_template", {}).get("full_path"),
-                ) if gitlab_props else None
-            ))
+                ) if gitlab_props else None,
+            )
 
-        # Cache result with query-aware key
-        self._set_cached_query_view(
-            user_id=str(user_id),
+        return self._list_cached_course_dtos(
+            permissions,
+            params,
+            role="_tutor",
             view_type="tutor:courses",
-            params=params,
-            data=self._serialize_dto_list(response_list),
-            ttl=self.get_default_ttl()
+            dto_cls=CourseTutorList,
+            row_builder=_build_row,
         )
-
-        return response_list

--- a/computor-backend/src/computor_backend/repositories/view_base.py
+++ b/computor-backend/src/computor_backend/repositories/view_base.py
@@ -435,6 +435,54 @@ class ViewRepository(ABC):
         )
         return result
 
+    async def _finalize_course_contents_view(
+        self,
+        raw_results: Any,
+        *,
+        reader_user_id: Any,
+        view_type: str,
+        params: Any,
+        aggregate_user_id: str,
+        base_related_ids: Optional[Dict[str, Any]] = None,
+    ) -> List[Any]:
+        """Shared tail for the student/tutor ``list_course_contents`` views.
+
+        The two methods differ in their *heads* (signature, submission-group
+        provisioning, permission model, query function, cache ``view_type``), but
+        share this tail: map each raw query row via
+        ``course_member_course_content_result_mapper``, aggregate unit statuses,
+        tag each course_content for deployment-related cache invalidation, cache
+        the serialized DTOs, and return the list.
+        """
+        from .view_mappers import course_member_course_content_result_mapper
+        from .course_content import CourseMemberCourseContentQueryResult
+
+        response_list: List[Any] = []
+        for raw in raw_results:
+            typed = CourseMemberCourseContentQueryResult.from_tuple(raw)
+            response_list.append(await course_member_course_content_result_mapper(typed, self.db))
+
+        # Units aggregate status from their descendant submittable contents.
+        response_list = self._aggregate_unit_statuses(response_list, aggregate_user_id)
+
+        # Tag with the view's base ids plus each course_content (deployment
+        # invalidation). ``or None`` preserves the prior behaviour of passing an
+        # empty tag set as None.
+        related_ids = dict(base_related_ids or {})
+        for result in response_list:
+            if hasattr(result, 'id') and result.id:
+                related_ids[f'course_content:{result.id}'] = None
+
+        self._set_cached_query_view(
+            user_id=str(reader_user_id),
+            view_type=view_type,
+            params=params,
+            data=self._serialize_dto_list(response_list),
+            ttl=self.get_default_ttl(),
+            related_ids=related_ids or None,
+        )
+        return response_list
+
     def _serialize_query_params(self, params: Any, use_hash: bool = True) -> str:
         """
         Serialize query parameters into a stable, deterministic cache key component.

--- a/computor-backend/src/computor_backend/repositories/view_base.py
+++ b/computor-backend/src/computor_backend/repositories/view_base.py
@@ -383,6 +383,58 @@ class ViewRepository(ABC):
         )
         return response_list
 
+    def _get_cached_course_dto(
+        self,
+        course_id: Any,
+        permissions: Any,
+        *,
+        role: str,
+        view_type: str,
+        dto_cls: type,
+        builder: Callable[[Any], "tuple[Any, dict]"],
+        raise_if_missing: bool = False,
+    ) -> Any:
+        """Shared ``get_course`` skeleton for the DTO-building course views.
+
+        Used by ``StudentViewRepository`` and ``TutorViewRepository``. Cache-first
+        read (deserialize via ``dto_cls``); on miss, permission-filter the
+        ``Course`` query by ``course_id``, then call ``builder(course)`` which
+        returns ``(dto, related_ids)``; cache the serialized dto and return it.
+
+        ``raise_if_missing`` controls the not-found behaviour: the tutor view
+        raises ``NotFoundException`` when the course is absent/forbidden, whereas
+        the student view historically does not (preserved as the default).
+        """
+        from ..permissions.core import check_course_permissions
+        from ..model.course import Course
+
+        user_id = permissions.get_user_id_or_throw()
+
+        cached = self._get_cached_view(
+            user_id=str(user_id), view_type=view_type, view_id=str(course_id)
+        )
+        if cached is not None:
+            return dto_cls.model_validate(cached, from_attributes=True)
+
+        course = check_course_permissions(permissions, Course, role, self.db).filter(
+            Course.id == course_id
+        ).first()
+        if course is None and raise_if_missing:
+            from ..exceptions import NotFoundException
+            raise NotFoundException()
+
+        result, related_ids = builder(course)
+
+        self._set_cached_view(
+            user_id=str(user_id),
+            view_type=view_type,
+            view_id=str(course_id),
+            data=self._serialize_dto(result),
+            ttl=self.get_default_ttl(),
+            related_ids=related_ids,
+        )
+        return result
+
     def _serialize_query_params(self, params: Any, use_hash: bool = True) -> str:
         """
         Serialize query parameters into a stable, deterministic cache key component.

--- a/computor-backend/src/computor_backend/repositories/view_base.py
+++ b/computor-backend/src/computor_backend/repositories/view_base.py
@@ -7,7 +7,7 @@ work with query results, DTOs, and complex data structures.
 """
 
 from abc import ABC
-from typing import Any, Optional, Dict, List
+from typing import Any, Callable, Optional, Dict, List
 from sqlalchemy.orm import Session
 import logging
 import json
@@ -332,6 +332,56 @@ class ViewRepository(ABC):
             List of serialized data
         """
         return [self._serialize_dto(dto) for dto in dtos]
+
+    def _list_cached_course_dtos(
+        self,
+        permissions: Any,
+        params: Any,
+        *,
+        role: str,
+        view_type: str,
+        dto_cls: type,
+        row_builder: Callable[[Any], Any],
+    ) -> List[Any]:
+        """Shared ``list_courses`` skeleton for the DTO-building course views.
+
+        Used by ``StudentViewRepository`` and ``TutorViewRepository``, whose
+        ``list_courses`` differ only in role, cache ``view_type``, DTO class and
+        per-row mapping. Both permission-filter the same ``Course`` query, search
+        via ``CourseStudentInterface`` and build pydantic DTOs.
+
+        Flow: cache-first read (deserialize via ``dto_cls``); on miss,
+        permission-filter the query, run the search, map each ORM row through
+        ``row_builder``, cache the serialized DTOs, and return them.
+
+        NOTE: ``LecturerViewRepository.list_courses`` intentionally does NOT use
+        this -- it returns a raw ORM query (``CourseInterface.search``) and
+        serializes ``Course`` objects via ``__dict__``, a different data flow.
+        """
+        from ..permissions.core import check_course_permissions
+        from ..model.course import Course
+        from ..interfaces.student_courses import CourseStudentInterface
+
+        user_id = permissions.get_user_id_or_throw()
+
+        cached = self._get_cached_query_view(
+            user_id=str(user_id), view_type=view_type, params=params
+        )
+        if cached is not None:
+            return [dto_cls.model_validate(item, from_attributes=True) for item in cached]
+
+        query = check_course_permissions(permissions, Course, role, self.db)
+        courses = CourseStudentInterface.search(self.db, query, params).all()
+        response_list = [row_builder(course) for course in courses]
+
+        self._set_cached_query_view(
+            user_id=str(user_id),
+            view_type=view_type,
+            params=params,
+            data=self._serialize_dto_list(response_list),
+            ttl=self.get_default_ttl(),
+        )
+        return response_list
 
     def _serialize_query_params(self, params: Any, use_hash: bool = True) -> str:
         """


### PR DESCRIPTION
The student and tutor view repositories had copy-pasted cache skeletons. Extracted the shared logic into three `ViewRepository` helpers, each call now passing only what differs (role / view_type / dto_cls / builder):
- `list_courses` → `_list_cached_course_dtos`
- `get_course` → `_get_cached_course_dto` (preserves tutor's 404 vs student's no-check)
- `list_course_contents` → `_finalize_course_contents_view` (shared **tail** only — the heads genuinely differ: student provisions submission groups & takes `user_id`; tutor checks `_tutor` & takes `course_member_id`)

`LecturerViewRepository` is deliberately left separate — `CourseInterface.search` returns a raw ORM query (not `.all()`'d DTOs) and it serializes via `__dict__`, a different data flow.

⚠️ **Highest-risk branch of the set**: user-facing read paths with no fast test coverage. Verified by equivalence analysis + compile + import only — **please manual-smoke-test before merge**. Surfaced (untouched) latent issues: student `get_course` has no not-found check; tutor `list_course_contents` returns raw cache on hit but DTOs on miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)