### PR TITLE
fix(cli): remove broken credentials auth, keep API-token auth

### DIFF
--- a/computor-cli/src/computor_cli/auth.py
+++ b/computor-cli/src/computor_cli/auth.py
@@ -1,7 +1,7 @@
 import os
 import click
 from functools import wraps
-from computor_cli.config import CLIAuthConfig, CredentialsAuth
+from computor_cli.config import CLIAuthConfig
 
 HOME_DIR = os.path.expanduser("~") or os.environ.get("HOME") or os.environ.get("USERPROFILE")
 COMPUTOR_DIR = os.path.join(HOME_DIR, ".computor")
@@ -29,19 +29,6 @@ def read_active_profile() -> CLIAuthConfig | None:
         return None
 
 
-def _verify_credentials(base_url: str, username: str, password: str) -> bool:
-    """Test credentials via POST /auth/login."""
-    from httpx import Client
-
-    try:
-        with Client(base_url=base_url) as client:
-            response = client.post("/auth/login", json={"username": username, "password": password})
-            return response.status_code == 200
-    except Exception as e:
-        click.echo(e)
-        return False
-
-
 def _verify_token(base_url: str, token: str) -> bool:
     """Verify an API token via GET /user with X-API-Token header."""
     from httpx import Client
@@ -53,35 +40,6 @@ def _verify_token(base_url: str, token: str) -> bool:
     except Exception as e:
         click.echo(e)
         return False
-
-
-def _create_token_with_credentials(base_url: str, username: str, password: str) -> str | None:
-    """Login with credentials, create an API token, and return it."""
-    from httpx import Client
-
-    try:
-        with Client(base_url=base_url) as client:
-            login_resp = client.post("/auth/login", json={"username": username, "password": password})
-            if login_resp.status_code != 200:
-                click.echo("Login failed: invalid credentials.")
-                return None
-
-            bearer_token = login_resp.json()["access_token"]
-
-            client.headers.update({"Authorization": f"Bearer {bearer_token}"})
-            token_resp = client.post("/api-tokens", json={
-                "name": f"cli-{username}",
-                "description": "Created by computor CLI login",
-            })
-            if token_resp.status_code != 201:
-                click.echo(f"Failed to create API token: {token_resp.text}")
-                return None
-
-            return token_resp.json()["token"]
-
-    except Exception as e:
-        click.echo(e)
-        return None
 
 
 def _save_profile(config: CLIAuthConfig):
@@ -100,74 +58,30 @@ def status():
         return
 
     click.echo(f"API:  {profile.api_url}")
-    if profile.credentials is not None:
-        click.echo(f"Auth: credentials (user: {profile.credentials.username})")
-    elif profile.token is not None:
+    if profile.token is not None:
         click.echo(f"Auth: token ({profile.token[:12]}...)")
     else:
         click.echo("Auth: none")
 
 
 @click.command()
-@click.option("--auth-method", "-a", type=click.Choice(["credentials", "token"]), prompt="Auth method")
 @click.option("--base-url", "-b", prompt="API url")
-@click.option("--username", "-u")
-@click.option("--password", "-p")
-@click.option("--token", "-t", help="Existing API token (for token auth method)")
-def login(auth_method, base_url, username, password, token):
-    """Authenticate with a Computor API server.
+@click.option("--token", "-t", help="API token (created in the web UI or via 'computor token')")
+def login(base_url, token):
+    """Authenticate with a Computor API server using an API token.
 
-    \b
-    Auth methods:
-      credentials  - Store username/password, authenticate via bearer token per request
-      token        - Store an API token, either by pasting one (--token) or by
-                     logging in with credentials (--username) to create one
+    Create a token in the web UI (or with 'computor token') and paste it here.
     """
+    if token is None:
+        token = click.prompt("API token", hide_input=True)
 
-    if auth_method == "credentials":
-        username = username if username is not None else click.prompt("Username")
-        password = password if password is not None else click.prompt("Password", hide_input=True)
+    if not _verify_token(base_url, token):
+        click.echo("Authentication failed: invalid token.")
+        return False
 
-        if not _verify_credentials(base_url, username, password):
-            click.echo("Authentication failed.")
-            return False
-
-        _save_profile(CLIAuthConfig(
-            api_url=base_url,
-            credentials=CredentialsAuth(username=username, password=password),
-        ))
-        click.echo("Authentication successful!")
-        return True
-
-    elif auth_method == "token":
-        if token is None and username is None:
-            method = click.prompt(
-                "Provide a token or create one with credentials?",
-                type=click.Choice(["paste", "create"]),
-            )
-            if method == "paste":
-                token = click.prompt("API token", hide_input=True)
-            else:
-                username = click.prompt("Username")
-
-        if token is not None:
-            if not _verify_token(base_url, token):
-                click.echo("Authentication failed: invalid token.")
-                return False
-
-            _save_profile(CLIAuthConfig(api_url=base_url, token=token))
-            click.echo("Authentication successful!")
-            return True
-        else:
-            password = password if password is not None else click.prompt("Password", hide_input=True)
-
-            token = _create_token_with_credentials(base_url, username, password)
-            if token is None:
-                return False
-
-            _save_profile(CLIAuthConfig(api_url=base_url, token=token))
-            click.echo("Authentication successful! API token created and saved.")
-            return True
+    _save_profile(CLIAuthConfig(api_url=base_url, token=token))
+    click.echo("Authentication successful!")
+    return True
 
 
 @click.command()
@@ -221,30 +135,17 @@ async def get_computor_client(auth: CLIAuthConfig, force_new: bool = False):
     """Create and return an authenticated ComputorClient."""
     from computor_client import ComputorClient
 
-    if auth.token is not None:
-        cache_key = f"{auth.api_url}:token:{auth.token[:8]}"
-    elif auth.credentials is not None:
-        cache_key = f"{auth.api_url}:credentials:{auth.credentials.username}"
-    else:
-        cache_key = auth.api_url
+    if auth.token is None:
+        raise NotImplementedError("No API token configured; run 'computor login'")
 
+    cache_key = f"{auth.api_url}:token:{auth.token[:8]}"
     if not force_new and cache_key in _client_cache:
         return _client_cache[cache_key]
 
-    if auth.token is not None:
-        client = ComputorClient(
-            base_url=auth.api_url,
-            headers={"X-API-Token": auth.token},
-        )
-    elif auth.credentials is not None:
-        client = ComputorClient(base_url=auth.api_url)
-        await client.login(
-            username=auth.credentials.username,
-            password=auth.credentials.password,
-        )
-    else:
-        raise NotImplementedError("No authentication method configured")
-
+    client = ComputorClient(
+        base_url=auth.api_url,
+        headers={"X-API-Token": auth.token},
+    )
     _client_cache[cache_key] = client
     return client
 

--- a/computor-cli/src/computor_cli/config.py
+++ b/computor-cli/src/computor_cli/config.py
@@ -1,14 +1,7 @@
 from typing import Optional
-from pydantic import BaseModel
 from computor_types.deployments_refactored import BaseDeployment
-
-
-class CredentialsAuth(BaseModel):
-    username: str
-    password: str
 
 
 class CLIAuthConfig(BaseDeployment):
     api_url: str
-    credentials: Optional[CredentialsAuth] = None
     token: Optional[str] = None

--- a/computor-cli/src/computor_cli/deployment.py
+++ b/computor-cli/src/computor_cli/deployment.py
@@ -1513,14 +1513,6 @@ def _ensure_example_repository(repo_name: str, auth: CLIAuthConfig):
             # Authenticate
             if auth.token:
                 http_client.headers.update({"X-API-Token": auth.token})
-            elif auth.credentials:
-                auth_response = await http_client.post(
-                    "/auth/login",
-                    json={"username": auth.credentials.username, "password": auth.credentials.password}
-                )
-                auth_response.raise_for_status()
-                bearer = auth_response.json()["access_token"]
-                http_client.headers.update({"Authorization": f"Bearer {bearer}"})
 
             # Search for existing repository
             click.echo(f"    🔍 Searching for repository: {repo_name}")


### PR DESCRIPTION
The CLI's `credentials` auth method was **broken**: it `POST /auth/login`, which the backend deleted in the SSO migration, so `computor login -a credentials` (and minting a token from credentials) returned 404. API-token auth (`X-API-Token`) still works.

Removed the dead credentials path:
- **`config.py`** — dropped `CredentialsAuth` + the `CLIAuthConfig.credentials` field.
- **`auth.py`** — dropped `_verify_credentials` / `_create_token_with_credentials`; simplified `login` to **token-only** (`--base-url`/`--token`, paste or prompt; verified via `GET /user`); removed the credentials branches in `status` and `get_computor_client`.
- **`deployment.py`** — dropped the `auth.credentials → /auth/login` fallback in the example-repo helper (keeps the `X-API-Token` path).

`computor login` now takes/verifies an **API token** (create one in the web UI or via `computor token`).

**Behaviour change** (hence its own branch, not bundled with the #174 removals): `computor login` no longer has `-a/--auth-method`, `-u/--username`, `-p/--password`. Verified: package compiles, `cli` imports, `login` params are `base_url`/`token` only, `CLIAuthConfig.token` retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)