### PR TITLE
docs: fix dev-workflow startup flow and CLI command lists

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -148,17 +148,18 @@ Command-line interface for administrative and development tasks.
 - Code generation (TypeScript, OpenAPI)
 - Admin tasks
 
-### Working Commands (9)
+### Working Commands (10)
 ```bash
-computor login              # Authenticate with API
-computor profiles           # Manage auth profiles
-computor rest               # CRUD operations
-computor admin              # Administrative commands
-computor worker             # Temporal worker management
-computor generate-types     # TypeScript interface generation
-computor generate-clients   # TypeScript client generation
-computor generate-schema    # OpenAPI schema generation
-computor generate-validators # Validator generation
+computor login              # Authenticate
+computor logout             # Clear stored credentials
+computor status             # Show current auth profile
+computor rest               # CRUD operations on entities
+computor deployment         # Apply/manage deployments
+computor token              # Manage API tokens
+computor documents          # Course document sync
+computor service            # Service accounts & service types
+computor delete             # Cascade-delete org/family/course/examples
+computor grading            # Grading queries
 ```
 
 ### Configuration
@@ -188,7 +189,7 @@ FastAPI server providing REST API and business logic.
 
 ### Entry Points
 - **`server.py`**: FastAPI app initialization and startup logic
-- **Shell Scripts**: `api.sh`, `startup.sh`, `migrations.sh`
+- **Shell Scripts**: `startup.sh` (dev/prod services), `api.sh` (dev backend), `web.sh` (dev frontend), `stop.sh`
 
 ### Architecture Layers
 

--- a/docs/developer-guide/01-getting-started.md
+++ b/docs/developer-guide/01-getting-started.md
@@ -282,7 +282,7 @@ kill -9 <PID>
 bash stop.sh
 sudo rm -rf "${SYSTEM_DEPLOYMENT_PATH}/postgres"
 bash startup.sh dev -d
-bash migrations.sh
+bash api.sh   # re-applies migrations automatically on start
 ```
 
 ### Issue: Import Errors

--- a/docs/developer-guide/02-code-organization.md
+++ b/docs/developer-guide/02-code-organization.md
@@ -201,15 +201,16 @@ computor-cli/
 ### Key Commands
 
 ```bash
-computor login                  # Authenticate with API
-computor profiles               # Manage auth profiles
+computor login                  # Authenticate
+computor logout                 # Clear stored credentials
+computor status                 # Show current auth profile
 computor rest {entity} {action} # CRUD operations
-computor admin                  # Administrative commands
-computor worker start           # Start Temporal worker
-computor generate-types         # Generate TypeScript types
-computor generate-clients       # Generate TypeScript client
-computor generate-schema        # Generate OpenAPI schema
-computor generate-validators    # Generate validators
+computor deployment apply       # Apply a deployment config
+computor token                  # Manage API tokens
+computor documents              # Course document sync
+computor service                # Service accounts & service types
+computor delete                 # Cascade-delete entities
+computor grading                # Grading queries
 ```
 
 ### Configuration
@@ -468,10 +469,11 @@ class StorageService:
 ## Shell Scripts (Root Directory)
 
 ```bash
-api.sh                      # Start FastAPI backend
-startup.sh                  # Start Docker services
+startup.sh                  # Start Docker services (dev|prod, --build to rebuild)
 stop.sh                     # Stop Docker services
-migrations.sh               # Run Alembic migrations
+api.sh                      # Start FastAPI backend (dev; runs migrations on start)
+web.sh                      # Start Next.js dev server (dev only)
+migrations.sh               # Run Alembic migrations standalone (rarely needed)
 test.sh                     # Run tests
 generate.sh                 # Unified code generation (types, schemas, clients)
 generate.sh types           # Generate TypeScript interfaces

--- a/docs/developer-guide/03-development-workflow.md
+++ b/docs/developer-guide/03-development-workflow.md
@@ -14,17 +14,14 @@ source .venv/bin/activate
 git checkout main
 git pull origin main
 
-# 3. Start Docker services (if not running)
-bash startup.sh
+# 3. Start Docker services (add --build to force a rebuild)
+bash startup.sh dev -d
 
-# 4. Run any new migrations
-bash migrations.sh
-
-# 5. Start backend API
+# 4. Start backend API (runs migrations automatically)
 bash api.sh
 
-# 6. (Optional) Start frontend in another terminal
-bash frontend.sh
+# 5. (Optional) Start frontend in another terminal (dev only)
+bash web.sh
 ```
 
 ### Making Changes


### PR DESCRIPTION
The developer-guide startup instructions were inaccurate; corrected to match `README.md` and the actual scripts.

- **03-development-workflow.md** — `bash startup.sh` → `bash startup.sh dev -d` (noted `--build`), dropped the separate `bash migrations.sh` step (`api.sh` runs migrations automatically), `bash frontend.sh` → `bash web.sh`.
- **01-getting-started.md** — fresh-DB recipe: `bash migrations.sh` → `bash api.sh`.
- **02-code-organization.md** + **architecture-overview.md** — the shell-script and CLI command listings referenced removed/nonexistent commands (`profiles`, `admin`, `worker`, `generate-*`, `frontend.sh`, migrations-as-a-step). Replaced with the real scripts (`startup`/`api`/`web`/`stop`) and the 10 live CLI commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)