### PR TITLE
fix(course-git): worker Forgejo reachability + registry-aware course/family creation

### DIFF
--- a/computor-backend/src/computor_backend/api/system.py
+++ b/computor-backend/src/computor_backend/api/system.py
@@ -108,8 +108,9 @@ async def create_course_family_async(
             context={"organization_id": request.organization_id}
         )
 
-    # Check if organization has GitLab integration
-    parent_gitlab_config = organization.properties.get("gitlab", {})
+    # Check if organization has GitLab integration (legacy org-scoped model;
+    # orgs may carry no properties in the course-level model, so guard the None).
+    parent_gitlab_config = (organization.properties or {}).get("gitlab", {})
     has_gitlab = bool(parent_gitlab_config.get("group_id"))
 
     # Convert to course family config format
@@ -176,17 +177,23 @@ async def create_course_async(
             context={"course_family_id": request.course_family_id}
         )
 
-    # Check if course family has GitLab integration
-    parent_gitlab_config = course_family.properties.get("gitlab", {})
+    # Check if course family has GitLab integration (legacy org-scoped model;
+    # families carry no git config in the course-level model, so guard the None).
+    parent_gitlab_config = (course_family.properties or {}).get("gitlab", {})
     has_gitlab = bool(parent_gitlab_config.get("group_id"))
 
-    # Convert to course config format
+    # Convert to course config format. In the course-level git model the caller
+    # picks a registry git server (GET /git-servers, or registers a new one) and
+    # passes it as the typed `git` binding; the course is bound to it at creation.
+    # Optional — a course may be created unbound and configured later via its git
+    # binding. Serialized to a plain dict for the Temporal activity.
     course_config = {
         "name": request.course.get("title", ""),
         "path": request.course.get("path", ""),
         "description": request.course.get("description", ""),
         "course_family_id": request.course_family_id,
-        "has_gitlab": has_gitlab
+        "has_gitlab": has_gitlab,
+        "git": request.git.model_dump() if (request.git and request.git.git_server_id) else None,
     }
 
     # Submit task using Temporal and track for permission-aware polling

--- a/computor-backend/src/computor_backend/business_logic/course_git.py
+++ b/computor-backend/src/computor_backend/business_logic/course_git.py
@@ -217,7 +217,23 @@ def upsert_course_git_binding(
     """Create or replace a course's git binding (lecturer-cohort only)."""
     course = _load_course_or_404(course_id, db)
     _require_course_git_manage(permissions, course)
+    binding = _apply_course_git_binding(course, data, permissions.get_user_id(), db)
+    return _binding_to_get(binding, db)
 
+
+def _apply_course_git_binding(
+    course: Course,
+    data: CourseGitBindingUpsert,
+    user_id,
+    db: Session,
+) -> CourseGitBinding:
+    """Permission-free core of :func:`upsert_course_git_binding`.
+
+    The caller must already be authorized (the lecturer endpoint checks
+    git-manage; the course-creation flow checks course-create at the API edge).
+    Extracted so a course can be bound to a registry git server during creation,
+    not only via a later lecturer call.
+    """
     binding = (
         db.query(CourseGitBinding)
         .filter(CourseGitBinding.course_id == course.id)
@@ -291,7 +307,7 @@ def upsert_course_git_binding(
         template_url = gitlab_structure.get("template_url") or template_url
 
     if binding is None:
-        binding = CourseGitBinding(course_id=course.id, created_by=permissions.get_user_id())
+        binding = CourseGitBinding(course_id=course.id, created_by=user_id)
         db.add(binding)
 
     binding.delivery = data.delivery
@@ -302,11 +318,11 @@ def upsert_course_git_binding(
     binding.student_repo_modes = list(data.student_repo_modes or [])
     if gitlab_structure is not None:
         binding.properties = {**(binding.properties or {}), "gitlab": gitlab_structure}
-    binding.updated_by = permissions.get_user_id()
+    binding.updated_by = user_id
 
     db.commit()
     db.refresh(binding)
-    return _binding_to_get(binding, db)
+    return binding
 
 
 def get_course_git_binding(

--- a/computor-backend/src/computor_backend/git_provider/__init__.py
+++ b/computor-backend/src/computor_backend/git_provider/__init__.py
@@ -17,22 +17,58 @@ def get_provider_client(git_provider) -> GitProviderClient:
     raise ValueError(f"Unsupported git provider type: {git_provider.type!r}")
 
 
+def backend_reachable_base_url(git_server) -> str:
+    """URL a *backend* component (the worker — always in docker — or the prod API,
+    also in docker) uses to REACH this server's HTTP API and git remotes.
+
+    For the configured managed Forgejo this is the per-component address from
+    ``GIT_SERVER_URL`` (service-DNS like ``computor-forgejo:3030`` inside docker,
+    ``localhost:3030`` on the host) — the same way every other in-cluster service
+    is reached, needing no host port publishing. External servers are already
+    publicly reachable, so their ``base_url`` is used as-is.
+
+    NEVER use this for student-facing values (clone URLs shown in the UI,
+    ``template_url``, ``course_member_repository`` URLs): those must stay the
+    public ``base_url``.
+
+    Detection uses the location-independent ``managed`` + ``type`` signal rather
+    than matching ``base_url`` against ``git_server_url`` (as
+    ``_forgejo_admin_basic_auth_for`` does): in the worker the public ``base_url``
+    (``localhost``) and the internal ``git_server_url`` (``computor-forgejo``)
+    deliberately differ, so a string match would never fire there.
+    """
+    if getattr(git_server, "managed", False) and (git_server.type or "").lower() == "forgejo":
+        from computor_backend.git_server.config import get_git_server_settings
+
+        settings = get_git_server_settings()
+        if settings.is_forgejo and settings.git_server_url:
+            return settings.git_server_url.rstrip("/")
+    return (git_server.base_url or "").rstrip("/")
+
+
 def get_provider_client_for_server(git_server) -> GitProviderClient:
     """Return a provider client for a ``GitServer`` registry row (course-level model).
 
     Unlike ``get_provider_client`` (legacy organization-scoped ``GitProvider``),
     this reads the registry's reversibly-encrypted service token via the
     non-deprecated ``decrypt_secret`` (wire-compatible with the legacy tokens).
+
+    The client talks to ``backend_reachable_base_url`` (service-DNS in docker),
+    not the public ``base_url`` — so REST calls work from the worker and the prod
+    API. Repo URLs the client returns come from the server's own response
+    (``clone_url``/``html_url``, built from Forgejo's ``ROOT_URL``), so they stay
+    public regardless of how we connect.
     """
     from computor_types.encryption import decrypt_secret
 
     token = decrypt_secret(git_server.token) if git_server.token else ""
+    base_url = backend_reachable_base_url(git_server)
     if git_server.type == 'forgejo':
         from .forgejo import ForgejoProviderClient
-        return ForgejoProviderClient(git_server.base_url, token)
+        return ForgejoProviderClient(base_url, token)
     if git_server.type == 'gitlab':
         from .gitlab import GitLabProviderClient
-        return GitLabProviderClient(git_server.base_url, token, None)
+        return GitLabProviderClient(base_url, token, None)
     raise ValueError(f"Unsupported git server type: {git_server.type!r}")
 
 

--- a/computor-backend/src/computor_backend/tasks/temporal_hierarchy_management.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_hierarchy_management.py
@@ -206,6 +206,24 @@ async def create_course_activity(
                     db.add(course)
                     db.flush()
 
+                # Enroll the creator as course owner so they can manage the course
+                # immediately (assign examples, release, ...). The legacy GitLab
+                # path relied on group-membership sync; the course-level model
+                # records ownership directly. Idempotent on unique (user_id, course_id).
+                from ..model.course import CourseMember
+                if user_id and (
+                    db.query(CourseMember)
+                    .filter(CourseMember.course_id == course.id, CourseMember.user_id == user_id)
+                    .first()
+                ) is None:
+                    db.add(CourseMember(
+                        course_id=course.id,
+                        user_id=user_id,
+                        course_role_id="_owner",
+                        created_by=user_id,
+                        updated_by=user_id,
+                    ))
+
                 git_binding = None
                 git_cfg = course_config.get("git") or {}
                 if git_cfg.get("git_server_id"):

--- a/computor-backend/src/computor_backend/tasks/temporal_hierarchy_management.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_hierarchy_management.py
@@ -178,7 +178,68 @@ async def create_course_activity(
 
             provider_row = db.query(GitProvider).filter(GitProvider.organization_id == str(org.id)).first()
             if not provider_row:
-                raise ValueError(f"No git provider configured for organization {org.id}")
+                # New course-level git model: no legacy org-scoped GitProvider.
+                # Create the course row, then bind it to a registry git server if
+                # one was chosen at creation. Git is per-course now — not inherited
+                # from the org/family. Authorization happened at the API edge.
+                from ..custom_types import Ltree
+
+                course = (
+                    db.query(Course)
+                    .filter(
+                        Course.course_family_id == family.id,
+                        Course.path == Ltree(config.path),
+                    )
+                    .first()
+                )
+                if course is None:
+                    course = Course(
+                        title=config.name,
+                        description=config.description or "",
+                        path=Ltree(config.path),
+                        course_family_id=family.id,
+                        organization_id=org.id,
+                        properties={},
+                        created_by=user_id,
+                        updated_by=user_id,
+                    )
+                    db.add(course)
+                    db.flush()
+
+                git_binding = None
+                git_cfg = course_config.get("git") or {}
+                if git_cfg.get("git_server_id"):
+                    from computor_types.course_git import CourseGitBindingUpsert
+                    from ..business_logic.course_git import _apply_course_git_binding
+
+                    binding = _apply_course_git_binding(
+                        course,
+                        CourseGitBindingUpsert(
+                            delivery=git_cfg.get("delivery") or "git",
+                            git_server_id=git_cfg.get("git_server_id"),
+                            template_repo=git_cfg.get("template_repo"),
+                            template_url=git_cfg.get("template_url"),
+                            default_branch=git_cfg.get("default_branch"),
+                            student_repo_modes=git_cfg.get("student_repo_modes") or [],
+                        ),
+                        user_id,
+                        db,
+                    )  # commits the course + binding together
+                    git_binding = {
+                        "git_server_id": str(binding.git_server_id) if binding.git_server_id else None,
+                        "template_url": binding.template_url,
+                    }
+                else:
+                    db.commit()
+
+                logger.info(f"Created course (course-level git model): {config.path} (ID: {course.id})")
+                return {
+                    "course_id": str(course.id),
+                    "status": "created",
+                    "name": course_config.get("name"),
+                    "provider_entity_id": None,
+                    "git_binding": git_binding,
+                }
 
             from ..git_provider import _decrypt
             token = _decrypt(provider_row.token)

--- a/computor-backend/src/computor_backend/tasks/temporal_hierarchy_management.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_hierarchy_management.py
@@ -108,7 +108,60 @@ async def create_course_family_activity(
 
             provider_row = db.query(GitProvider).filter(GitProvider.organization_id == organization_id).first()
             if not provider_row:
-                raise ValueError(f"No git provider configured for organization {organization_id}")
+                # Course-level model: no legacy org-scoped GitProvider. Create the
+                # family row and enroll the creator as owner. Course families carry
+                # no git config in this model (git is per-course). Authorization
+                # happened at the API edge.
+                from ..custom_types import Ltree
+                from ..model.course import CourseFamilyMember
+
+                family = (
+                    db.query(CourseFamily)
+                    .filter(
+                        CourseFamily.organization_id == org.id,
+                        CourseFamily.path == Ltree(config.path),
+                    )
+                    .first()
+                )
+                if family is None:
+                    family = CourseFamily(
+                        title=config.name,
+                        description=config.description or "",
+                        path=Ltree(config.path),
+                        organization_id=org.id,
+                        properties={},
+                        created_by=user_id,
+                        updated_by=user_id,
+                    )
+                    db.add(family)
+                    db.flush()
+
+                # Enroll the creator as family owner (manage courses under it).
+                # Idempotent on unique (user_id, course_family_id).
+                if user_id and (
+                    db.query(CourseFamilyMember)
+                    .filter(
+                        CourseFamilyMember.course_family_id == family.id,
+                        CourseFamilyMember.user_id == user_id,
+                    )
+                    .first()
+                ) is None:
+                    db.add(CourseFamilyMember(
+                        course_family_id=family.id,
+                        user_id=user_id,
+                        course_family_role_id="_owner",
+                        created_by=user_id,
+                        updated_by=user_id,
+                    ))
+
+                db.commit()
+                logger.info(f"Created course family (course-level model): {config.path} (ID: {family.id})")
+                return {
+                    "course_family_id": str(family.id),
+                    "status": "created",
+                    "name": family_config.get("name"),
+                    "provider_entity_id": None,
+                }
 
             from ..git_provider import _decrypt
             token = _decrypt(provider_row.token)

--- a/computor-backend/src/computor_backend/tasks/temporal_student_template_v2.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_student_template_v2.py
@@ -292,7 +292,6 @@ async def generate_student_template_activity_v2(
     from datetime import datetime, timezone
     from sqlalchemy.orm import joinedload
     from sqlalchemy import and_
-    from ..utils.docker_utils import transform_localhost_url
     from ..database import get_db_session
     from ..model.course import Course, CourseContent
     from ..model.example import Example, ExampleVersion, ExampleRepository
@@ -380,10 +379,6 @@ async def generate_student_template_activity_v2(
             )
 
         logger.info(f"Updated {len(deployments_to_process)} deployments to 'deploying' status")
-        
-        # Transform localhost URLs for Docker environments
-        student_template_url = transform_localhost_url(student_template_url)
-        logger.info(f"Using student template URL: {student_template_url}")
 
         # Get course details
         course = db.query(Course).filter(Course.id == course_id).first()
@@ -411,18 +406,30 @@ async def generate_student_template_activity_v2(
         if not gitlab_token:
             from computor_backend.model.git_server import CourseGitBinding
             from computor_types.encryption import decrypt_secret
+            from computor_backend.git_provider import backend_reachable_base_url
             binding = db.query(CourseGitBinding).filter(CourseGitBinding.course_id == course_id).first()
-            if binding is not None and binding.git_server is not None and binding.git_server.token:
-                gitlab_token = decrypt_secret(binding.git_server.token)
-                server_type = (binding.git_server.type or "gitlab").lower()
-                if gitlab_token:
-                    logger.info(
-                        f"Using service token from git server {binding.git_server.base_url} ({server_type})"
-                    )
+            if binding is not None and binding.git_server is not None:
+                if binding.git_server.token:
+                    gitlab_token = decrypt_secret(binding.git_server.token)
+                    server_type = (binding.git_server.type or "gitlab").lower()
+                    if gitlab_token:
+                        logger.info(
+                            f"Using service token from git server {binding.git_server.base_url} ({server_type})"
+                        )
+                # The stored template_url uses the public base_url (student-facing).
+                # A backend component must clone/push via the address it can reach
+                # (service-DNS in docker, localhost on host) — swap only the origin,
+                # keeping the repo path. No-op when they're the same (host API / prod).
+                public_base = (binding.git_server.base_url or "").rstrip("/")
+                reachable_base = backend_reachable_base_url(binding.git_server)
+                if public_base and reachable_base != public_base and student_template_url.startswith(public_base):
+                    student_template_url = reachable_base + student_template_url[len(public_base):]
 
         if not gitlab_token:
             logger.warning(f"No git push token found for course {course_id} (org properties or git server)")
-        
+
+        logger.info(f"Using student template URL: {student_template_url}")
+
         # Use temp directory for repository work
         with tempfile.TemporaryDirectory() as temp_dir:
             template_repo_path = os.path.join(temp_dir, "student-template")

--- a/computor-types/src/computor_types/system.py
+++ b/computor-types/src/computor_types/system.py
@@ -8,6 +8,8 @@ Temporal workflow task requests/responses and template generation.
 from typing import List, Optional, Dict
 from pydantic import BaseModel, Field
 
+from computor_types.course_git import CourseGitBindingUpsert
+
 
 class GitLabCredentials(BaseModel):
     """GitLab connection credentials (kept for backwards compatibility)."""
@@ -38,6 +40,16 @@ class CourseTaskRequest(BaseModel):
     """Request to create a course via Temporal workflow."""
     course: Dict
     course_family_id: str
+    git: Optional[CourseGitBindingUpsert] = Field(
+        None,
+        description=(
+            "Course-level git binding applied at creation: the registry git server "
+            "(git_server_id) hosting the student-template, delivery mode, and allowed "
+            "student-repo modes. Omit to create the course unbound and configure git "
+            "later via the course's git binding. Git is per-course — not inherited "
+            "from the organization or course family."
+        ),
+    )
 
 
 class TaskResponse(BaseModel):

--- a/computor-web/src/generated/types/courses.ts
+++ b/computor-web/src/generated/types/courses.ts
@@ -1247,6 +1247,8 @@ export interface CourseFamilyTaskRequest {
 export interface CourseTaskRequest {
   course: Record<string, any>;
   course_family_id: string;
+  /** Course-level git binding applied at creation: the registry git server (git_server_id) hosting the student-template, delivery mode, and allowed student-repo modes. Omit to create the course unbound and configure git later via the course's git binding. Git is per-course — not inherited from the organization or course family. */
+  git?: CourseGitBindingUpsert | null;
 }
 
 export interface GradedByCourseMember {


### PR DESCRIPTION
## Summary

Makes course **and** course-family creation + deployment work on the course-level git model (registry `GitServer` + per-course `CourseGitBinding`), instead of silently depending on the legacy org-scoped `GitProvider` (the empty `git_provider` table). Three related fixes:

### 1. Worker can't reach the managed Forgejo → "Git push failed"
The deploy activity built the student-template URL from the registry's **public** `base_url` (`localhost:3030`) and ran it through `transform_localhost_url → 172.17.0.1`, which the temporal worker can't reach (Forgejo is published on host loopback only). Now the managed Forgejo is resolved via its **per-component** `GIT_SERVER_URL` (service-DNS in docker, localhost on host) — the same way MinIO/Postgres are reached. New `backend_reachable_base_url()` also fixes the provider REST client, which used `base_url` directly (latent break for the prod API). Public `base_url`/`template_url` stay student-facing.

### 2. Registry-aware course creation (no legacy `GitProvider`)
`POST /system/deploy/courses` called `.get(...)` on a `None` `properties` (500), and `create_course_activity` always required a per-org `GitProvider` row. Now: guard the `None`, and add a course-level path that creates the course and — when a registry `git_server_id` is supplied — binds it at creation (via a permission-free core extracted from `upsert_course_git_binding`). "Inherit git config from course family" was the legacy GitLab-group model; **git is per-course now**.

### 3. Creators enrolled as `_owner` + same for course family
Course/family creation created the row but never enrolled the creator, so every lecturer endpoint (`assign-example`, …) 403'd. Both paths now enroll the creator as `_owner` (`CourseMember` / `CourseFamilyMember`). `create_course_family_activity` got the same course-level treatment (it had the identical `GitProvider` requirement).

Also: `CourseTaskRequest` gains a typed `git: Optional[CourseGitBindingUpsert]` (regenerated `courses.ts`).

## Pairs with
`computor-vsc-extension` branch `fix/course-git-deploy-and-registry-create` — the lecturer "create course" UI now picks a registry git server (or skips) instead of the legacy "inherit from family" prompt; "create course family" drops its vestigial git prompt.

## Deploy / migration notes
- **Rebuild the temporal worker** — it bakes its source; the deploy + create activities run there.
- **Existing data backfill** (applied in dev; run in other envs): enroll each course's `created_by` as `_owner`:
  ```sql
  INSERT INTO course_member (user_id, course_id, course_role_id, created_by, updated_by)
  SELECT c.created_by, c.id, '_owner', c.created_by, c.created_by FROM course c
  WHERE c.created_by IS NOT NULL AND NOT EXISTS (
    SELECT 1 FROM course_member cm WHERE cm.course_id = c.id AND cm.user_id = c.created_by);
  -- analogous INSERT for course_family / course_family_member
  ```
- **Auth cache**: the principal is cached ~15 min (`AUTH_CACHE_TTL`), so a session must re-login (or wait out the TTL) to pick up a newly-granted role.

## Testing
- `py_compile` on all touched modules; helper round-trip + validation verified.
- Worker→Forgejo reachability confirmed live (`computor-forgejo:3030` reachable, `172.17.0.1:3030` refused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
