### PR TITLE
fix(testing-worker): handle API auth failure cleanly (no retry storm / traceback)

### DIFF
--- a/docker/temporal-worker-testing/testing-worker.py
+++ b/docker/temporal-worker-testing/testing-worker.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 
 from computor_types.services import ServiceGet
 from computor_client.http import AsyncHTTPClient
+from computor_client.exceptions import AuthenticationError, AuthorizationError
 
 
 # =============================================================================
@@ -64,7 +65,15 @@ async def fetch_service_config(
                 data = response.json()
                 print(f"  Response data keys: {list(data.keys()) if isinstance(data, dict) else type(data)}")
                 return ServiceGet.model_validate(data)
+        except (AuthenticationError, AuthorizationError) as e:
+            # An auth failure (missing/placeholder/invalid API_TOKEN) will never
+            # succeed by retrying, and the worker runs fine on environment config.
+            # Warn once and continue — no 60x retry loop, no scary traceback.
+            print(f"  ⚠ API token not accepted ({e}); continuing with environment config")
+            return None
         except Exception as e:
+            # Connection/timeout (NetworkError) etc. — the backend may still be
+            # starting, so retry.
             if attempt < max_retries:
                 print(f"  ⚠ Attempt {attempt}/{max_retries} failed: {e}")
                 print(f"  Retrying in {retry_interval} seconds...")


### PR DESCRIPTION
## Problem
`docker/temporal-worker-testing/testing-worker.py` fetches `/service-accounts/me` at startup. Its retry loop caught **any** exception, retried **60× over 5 minutes**, and then `traceback.print_exc()`. So a testing worker with a missing/placeholder `API_TOKEN` (e.g. `CHANGE_ME_…`) gets a **401**, which:
- spams 60 pointless retries (a 401 never fixes itself by retrying), and
- dumps a scary `AuthenticationError` stacktrace,

even though the worker falls back to environment config and runs fine. The traceback also appears "out of order" in logs because it's on stderr (unbuffered) while progress prints are on block-buffered stdout.

## Fix
Split the handler:
- **`AuthenticationError` / `AuthorizationError` (401/403)** → warn once and return `None` (continue on env config). No retry, no traceback.
- **Everything else (`NetworkError` connection/timeout, …)** → keep the retry loop; the backend may still be starting.

9-line change, logic only — pairs with the just-merged docker build unification (#179), which is why the rebuilt testing worker surfaced this.

## Testing
`py_compile` clean; `AuthenticationError`/`AuthorizationError` import from `computor_client.exceptions` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)