### PR TITLE
feat(courses): upload course_deployment.yaml on create + fix example upload ordering

### DIFF
--- a/computor-backend/src/computor_backend/api/course_deployment.py
+++ b/computor-backend/src/computor_backend/api/course_deployment.py
@@ -1,0 +1,67 @@
+"""Endpoint for deploying a single course from an uploaded course_deployment.yaml.
+
+Backs the optional "upload a course file" path on the web create-course page:
+``POST /course-families/{course_family_id}/deploy-course`` with the raw YAML and
+a ``validate_only`` flag. The YAML is a top-level ``HierarchicalCourseConfig``
+(no organizations/git/users). See ``business_logic/course_deployment.py``.
+"""
+from typing import Annotated
+from uuid import UUID
+
+import yaml
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
+
+from computor_backend.database import get_db
+from computor_backend.exceptions import BadRequestException
+from computor_backend.permissions.auth import get_current_principal
+from computor_backend.permissions.principal import Principal
+from computor_backend.business_logic.course_deployment import deploy_course_from_config
+
+from computor_types.course_deployment import CourseDeployRequest, CourseDeployResult
+from computor_types.deployments_refactored import HierarchicalCourseConfig
+
+course_deployment_router = APIRouter()
+
+
+@course_deployment_router.post(
+    "/course-families/{course_family_id}/deploy-course",
+    response_model=CourseDeployResult,
+)
+async def deploy_course(
+    course_family_id: UUID | str,
+    request: CourseDeployRequest,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+):
+    """Validate (and optionally apply) a single-course deployment under a family.
+
+    Raises:
+        400: invalid YAML / config, or (on apply) blocking validation errors
+        403: caller may not create courses in this family
+        404: course family not found
+    """
+    try:
+        data = yaml.safe_load(request.yaml)
+    except yaml.YAMLError as e:
+        raise BadRequestException(detail=f"Invalid YAML: {e}") from e
+
+    if not isinstance(data, dict):
+        raise BadRequestException(
+            detail="The file must describe a single course (a mapping at the top level)"
+        )
+
+    try:
+        config = HierarchicalCourseConfig(**data)
+    except Exception as e:  # pydantic ValidationError -> 400
+        raise BadRequestException(detail=f"Invalid course configuration: {e}") from e
+
+    return await run_in_threadpool(
+        deploy_course_from_config,
+        db,
+        permissions,
+        course_family_id,
+        config,
+        request.validate_only,
+    )

--- a/computor-backend/src/computor_backend/business_logic/course_deployment.py
+++ b/computor-backend/src/computor_backend/business_logic/course_deployment.py
@@ -112,21 +112,47 @@ def deploy_course_from_config(
     errors: List[str] = []
     warnings: List[CourseDeployWarning] = []
 
-    # --- content types: validate kinds + build slug -> config / submittable maps
+    # --- content types: validate kinds. The unique key is (slug, kind), NOT slug
+    # alone: the same slug may be defined twice with different kinds (e.g. a
+    # 'training' unit and a 'training' assignment). A content node's reference is
+    # disambiguated by tree structure — a node with children resolves to a
+    # non-submittable (unit) type, a leaf to a submittable (assignment) type.
     kinds: Dict[str, CourseContentKind] = {k.id: k for k in db.query(CourseContentKind).all()}
-    ct_by_slug: Dict[str, object] = {}
-    submittable_by_slug: Dict[str, bool] = {}
-    for ct in (config.content_types or []):
-        if ct.slug in ct_by_slug:
-            errors.append(f"Duplicate content type slug '{ct.slug}'")
-            continue
+    ct_configs = list(config.content_types or [])
+    cts_by_slug: Dict[str, list] = {}
+    seen_slug_kind: set = set()
+    for ct in ct_configs:
         if ct.kind not in kinds:
             errors.append(
                 f"Content type '{ct.slug}' has unknown kind '{ct.kind}' "
                 f"(expected one of: {', '.join(sorted(kinds)) or 'none'})"
             )
-        ct_by_slug[ct.slug] = ct
-        submittable_by_slug[ct.slug] = bool(kinds.get(ct.kind) and kinds[ct.kind].submittable)
+        key = (ct.slug, ct.kind)
+        if key in seen_slug_kind:
+            errors.append(f"Duplicate content type '{ct.slug}' (kind '{ct.kind}')")
+            continue
+        seen_slug_kind.add(key)
+        cts_by_slug.setdefault(ct.slug, []).append(ct)
+
+    def _is_submittable(ct) -> bool:
+        return bool(kinds.get(ct.kind) and kinds[ct.kind].submittable)
+
+    def _resolve_ct(slug: str, has_children: bool):
+        """Pick the content-type config for a reference, disambiguating a shared
+        slug by structure. Returns (config | None, mismatch_warning | None)."""
+        candidates = cts_by_slug.get(slug)
+        if not candidates:
+            return None, None
+        if len(candidates) == 1:
+            ct = candidates[0]
+            if has_children and _is_submittable(ct):
+                return ct, "is an assignment (submittable) but has nested contents"
+            return ct, None
+        want_submittable = not has_children
+        for ct in candidates:
+            if _is_submittable(ct) == want_submittable:
+                return ct, None
+        return candidates[0], None
 
     # --- course path must be free within the family
     if not config.path:
@@ -155,7 +181,7 @@ def deploy_course_from_config(
     default_service_id: Optional[str] = next(iter(service_ids.values()), None)
 
     version_repo = ExampleVersionRepository(db, get_cache())
-    summary = CourseDeploySummary(content_types=len(ct_by_slug))
+    summary = CourseDeploySummary(content_types=len(seen_slug_kind))
 
     def _resolve_version_tag(example: Example, requested: Optional[str]) -> Optional[str]:
         """Resolve the concrete semantic version tag to assign (None if none available)."""
@@ -165,7 +191,7 @@ def deploy_course_from_config(
         latest = version_repo.find_latest_version(str(example.id))
         return latest.version_tag if latest else None
 
-    def _walk(items, parent_path: Optional[str], ct_rows: Optional[Dict[str, CourseContentType]], counter: List[float], seen: Optional[set]):
+    def _walk(items, parent_path: Optional[str], ct_rows: Optional[Dict[tuple, CourseContentType]], counter: List[float], seen: Optional[set]):
         """Validate (ct_rows is None) or apply (ct_rows given) the content tree."""
         apply = ct_rows is not None
         for c in items:
@@ -182,10 +208,16 @@ def deploy_course_from_config(
                     errors.append(f"Duplicate content path '{full}'")
                 seen.add(full)
 
-            known_type = c.content_type in ct_by_slug
-            if not known_type:
+            ct_cfg, ct_warn = _resolve_ct(c.content_type, bool(c.contents))
+            if ct_cfg is None:
                 errors.append(f"Content '{full}' references undefined content_type '{c.content_type}'")
-            submittable = submittable_by_slug.get(c.content_type, False)
+                _walk(c.contents or [], full, ct_rows, counter, seen)
+                continue
+            if ct_warn:
+                warnings.append(
+                    CourseDeployWarning(path=full, reason=f"Content type '{c.content_type}' {ct_warn}")
+                )
+            submittable = _is_submittable(ct_cfg)
 
             if submittable:
                 summary.assignments += 1
@@ -230,8 +262,8 @@ def deploy_course_from_config(
                     elif not apply:
                         summary.examples_assigned += 1
 
-            if apply and known_type:
-                ct_row = ct_rows[c.content_type]
+            if apply:
+                ct_row = ct_rows[(ct_cfg.slug, ct_cfg.kind)]
                 position = c.position if c.position is not None else counter[0]
                 counter[0] += 1.0
                 content = CourseContent(
@@ -323,10 +355,13 @@ def deploy_course_from_config(
         )
     )
 
-    ct_rows: Dict[str, CourseContentType] = {}
-    for slug, ct in ct_by_slug.items():
+    ct_rows: Dict[tuple, CourseContentType] = {}
+    for ct in ct_configs:
+        key = (ct.slug, ct.kind)
+        if key in ct_rows:
+            continue
         row = CourseContentType(
-            slug=slug,
+            slug=ct.slug,
             title=ct.title,
             description=ct.description,
             color=ct.color or "green",
@@ -337,7 +372,7 @@ def deploy_course_from_config(
             updated_by=permissions.user_id,
         )
         db.add(row)
-        ct_rows[slug] = row
+        ct_rows[key] = row
     db.flush()
     # Commit the course + owner membership + content types before assigning
     # examples (assign_example_to_content authorizes against the live membership).

--- a/computor-backend/src/computor_backend/business_logic/course_deployment.py
+++ b/computor-backend/src/computor_backend/business_logic/course_deployment.py
@@ -1,0 +1,355 @@
+"""Deploy a single course (identity + content tree) from a course-level config.
+
+This is the server-side counterpart to the CLI's ``_deploy_course_contents``
+orchestration (``computor-cli``), but scoped to ONE course under an existing
+course family and driven by the web "create course" upload. It takes a
+:class:`HierarchicalCourseConfig` (parsed from ``course_deployment.yaml``) and:
+
+  1. authorizes course creation in the family (same gate as ``POST /courses``);
+  2. validates the config (content-type kinds, content-type references, paths,
+     and that every ``example_identifier`` resolves in the example library);
+  3. on apply: creates the course, enrolls the caller as ``_owner`` (so the
+     example-assignment ``_lecturer`` gate passes), creates the content types,
+     then walks the ``contents`` tree creating ``CourseContent`` rows and
+     assigning examples via the existing :func:`assign_example_to_content`.
+
+Validation problems are split into *errors* (block an apply) and *warnings*
+(e.g. an unresolved example — the content is still created, just without one).
+
+NOTE: this is intentionally synchronous. ``assign_example_to_content`` commits
+per assignment, so a failure midway can leave a partially-populated course
+(recoverable); the course + owner + content types are committed up front.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Dict, List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from computor_types.deployments_refactored import HierarchicalCourseConfig
+from computor_types.course_deployment import (
+    CourseDeployResult,
+    CourseDeploySummary,
+    CourseDeployWarning,
+)
+from computor_types.validation import normalize_version
+
+from computor_backend.custom_types.ltree import Ltree
+from computor_backend.database import set_db_user
+from computor_backend.exceptions import (
+    BadRequestException,
+    ForbiddenException,
+    NotFoundException,
+)
+from computor_backend.model.course import (
+    Course,
+    CourseContent,
+    CourseContentKind,
+    CourseContentType,
+    CourseFamily,
+    CourseMember,
+)
+from computor_backend.model.example import Example
+from computor_backend.model.organization import Organization
+from computor_backend.model.service import Service
+from computor_backend.permissions.handlers import permission_registry
+from computor_backend.permissions.principal import Principal
+from computor_backend.redis_cache import get_cache
+from computor_backend.repositories.example_version_repo import ExampleVersionRepository
+from computor_backend.business_logic.lecturer_deployment import assign_example_to_content
+
+logger = logging.getLogger(__name__)
+
+# Course-content path segments are validated by a DB CHECK constraint:
+# ``^[a-z0-9_]+(\.[a-z0-9_]+)*$``. Each segment provided in the YAML must match
+# the per-segment part of that pattern.
+_SEGMENT_RE = re.compile(r"^[a-z0-9_]+$")
+
+
+def _humanize(segment: str) -> str:
+    try:
+        words = [w.capitalize() for w in segment.replace("_", " ").replace("-", " ").split() if w]
+        return " ".join(words) or segment
+    except Exception:
+        return segment
+
+
+def _authorize_create(permissions: Principal, family: CourseFamily, db: Session) -> None:
+    """Mirror the create-authorization that ``create_db`` applies for courses."""
+    if permissions.is_admin:
+        return
+    handler = permission_registry.get_handler(Course)
+    context = {
+        "course_family_id": str(family.id),
+        "organization_id": str(family.organization_id),
+    }
+    if handler is None or not handler.can_perform_action(
+        permissions, "create", resource_id=None, context=context
+    ):
+        raise ForbiddenException(
+            detail="You don't have permission to create courses in this course family"
+        )
+
+
+def deploy_course_from_config(
+    db: Session,
+    permissions: Principal,
+    course_family_id: str | UUID,
+    config: HierarchicalCourseConfig,
+    validate_only: bool = False,
+) -> CourseDeployResult:
+    """Validate and (optionally) apply a single-course deployment config."""
+
+    family = db.query(CourseFamily).filter(CourseFamily.id == course_family_id).first()
+    if not family:
+        raise NotFoundException(detail="Course family not found")
+
+    _authorize_create(permissions, family, db)
+
+    errors: List[str] = []
+    warnings: List[CourseDeployWarning] = []
+
+    # --- content types: validate kinds + build slug -> config / submittable maps
+    kinds: Dict[str, CourseContentKind] = {k.id: k for k in db.query(CourseContentKind).all()}
+    ct_by_slug: Dict[str, object] = {}
+    submittable_by_slug: Dict[str, bool] = {}
+    for ct in (config.content_types or []):
+        if ct.slug in ct_by_slug:
+            errors.append(f"Duplicate content type slug '{ct.slug}'")
+            continue
+        if ct.kind not in kinds:
+            errors.append(
+                f"Content type '{ct.slug}' has unknown kind '{ct.kind}' "
+                f"(expected one of: {', '.join(sorted(kinds)) or 'none'})"
+            )
+        ct_by_slug[ct.slug] = ct
+        submittable_by_slug[ct.slug] = bool(kinds.get(ct.kind) and kinds[ct.kind].submittable)
+
+    # --- course path must be free within the family
+    if not config.path:
+        errors.append("The config is missing a course 'path'")
+    else:
+        existing = (
+            db.query(Course)
+            .filter(Course.course_family_id == family.id, Course.path == Ltree(config.path))
+            .first()
+        )
+        if existing:
+            errors.append(f"A course with path '{config.path}' already exists in this family")
+
+    # --- resolve service slugs (for testing_service_id on assignments)
+    service_ids: Dict[str, str] = {}
+    for svc in (config.services or []):
+        row = db.query(Service).filter(Service.slug == svc.slug).first()
+        if row:
+            service_ids[svc.slug] = str(row.id)
+        else:
+            warnings.append(
+                CourseDeployWarning(
+                    reason=f"Service '{svc.slug}' not found; assignments won't be linked to it"
+                )
+            )
+    default_service_id: Optional[str] = next(iter(service_ids.values()), None)
+
+    version_repo = ExampleVersionRepository(db, get_cache())
+    summary = CourseDeploySummary(content_types=len(ct_by_slug))
+
+    def _resolve_version_tag(example: Example, requested: Optional[str]) -> Optional[str]:
+        """Resolve the concrete semantic version tag to assign (None if none available)."""
+        if requested and requested.lower() != "latest":
+            normalized = normalize_version(requested)
+            return normalized if version_repo.find_by_version_tag(example.id, normalized) else None
+        latest = version_repo.find_latest_version(str(example.id))
+        return latest.version_tag if latest else None
+
+    def _walk(items, parent_path: Optional[str], ct_rows: Optional[Dict[str, CourseContentType]], counter: List[float], seen: Optional[set]):
+        """Validate (ct_rows is None) or apply (ct_rows given) the content tree."""
+        apply = ct_rows is not None
+        for c in items:
+            if not c.path:
+                errors.append(f"A content under '{parent_path or '<root>'}' is missing a 'path'")
+                continue
+            if not _SEGMENT_RE.match(c.path):
+                errors.append(
+                    f"Invalid path segment '{c.path}' — use lowercase letters, digits and underscores only"
+                )
+            full = f"{parent_path}.{c.path}" if parent_path else c.path
+            if seen is not None:
+                if full in seen:
+                    errors.append(f"Duplicate content path '{full}'")
+                seen.add(full)
+
+            known_type = c.content_type in ct_by_slug
+            if not known_type:
+                errors.append(f"Content '{full}' references undefined content_type '{c.content_type}'")
+            submittable = submittable_by_slug.get(c.content_type, False)
+
+            if submittable:
+                summary.assignments += 1
+            else:
+                summary.units += 1
+                if c.example_identifier:
+                    warnings.append(
+                        CourseDeployWarning(
+                            path=full,
+                            example_identifier=c.example_identifier,
+                            reason="example_identifier on non-submittable content is ignored",
+                        )
+                    )
+
+            # Resolve the example (validate it exists + has a version) up front.
+            example: Optional[Example] = None
+            version_tag: Optional[str] = None
+            if submittable and c.example_identifier:
+                example = (
+                    db.query(Example)
+                    .filter(Example.identifier == Ltree(c.example_identifier))
+                    .first()
+                )
+                if not example:
+                    warnings.append(
+                        CourseDeployWarning(
+                            path=full,
+                            example_identifier=c.example_identifier,
+                            reason="Example not found in the library; content created without an example",
+                        )
+                    )
+                else:
+                    version_tag = _resolve_version_tag(example, c.example_version_tag)
+                    if not version_tag:
+                        warnings.append(
+                            CourseDeployWarning(
+                                path=full,
+                                example_identifier=c.example_identifier,
+                                reason=f"No matching version ('{c.example_version_tag or 'latest'}') for example",
+                            )
+                        )
+                    elif not apply:
+                        summary.examples_assigned += 1
+
+            if apply and known_type:
+                ct_row = ct_rows[c.content_type]
+                position = c.position if c.position is not None else counter[0]
+                counter[0] += 1.0
+                content = CourseContent(
+                    title=c.title or _humanize(c.path),
+                    description=c.description,
+                    path=Ltree(full),
+                    course_id=ct_row.course_id,
+                    course_content_type_id=ct_row.id,
+                    position=position,
+                    max_group_size=c.max_group_size or 1,
+                    max_test_runs=c.max_test_runs,
+                    max_submissions=c.max_submissions,
+                    testing_service_id=default_service_id if submittable else None,
+                    properties=dict(c.properties) if c.properties else None,
+                    created_by=permissions.user_id,
+                    updated_by=permissions.user_id,
+                )
+                db.add(content)
+                # Flush so the before_insert listener populates course_content_kind_id /
+                # is_submittable and we get the content id for example assignment.
+                db.flush()
+
+                if submittable and example and version_tag:
+                    try:
+                        assign_example_to_content(
+                            course_content_id=content.id,
+                            example_identifier=c.example_identifier,
+                            version_tag=version_tag,
+                            permissions=permissions,
+                            db=db,
+                        )  # commits
+                        summary.examples_assigned += 1
+                    except Exception as e:  # noqa: BLE001 - surface as a warning, keep going
+                        logger.warning("assign-example failed for %s: %s", full, e)
+                        warnings.append(
+                            CourseDeployWarning(
+                                path=full,
+                                example_identifier=c.example_identifier,
+                                reason=f"Failed to assign example: {e}",
+                            )
+                        )
+
+            _walk(c.contents or [], full, ct_rows, counter, seen)
+
+    # Validation pass (no writes).
+    _walk(config.contents or [], None, None, [1.0], set())
+
+    result = CourseDeployResult(
+        validated=True,
+        applied=False,
+        course_id=None,
+        course_path=config.path or "",
+        course_title=config.name,
+        summary=summary,
+        warnings=warnings,
+        errors=errors,
+    )
+
+    if validate_only:
+        return result
+    if errors:
+        raise BadRequestException(detail="Cannot apply: " + "; ".join(errors))
+
+    # ----- APPLY -----
+    set_db_user(db, permissions.user_id)
+
+    course = Course(
+        title=config.name,
+        description=config.description or "",
+        path=Ltree(config.path),
+        course_family_id=family.id,
+        organization_id=family.organization_id,
+        properties={},
+        created_by=permissions.user_id,
+        updated_by=permissions.user_id,
+    )
+    db.add(course)
+    db.flush()
+
+    # Enroll the caller as owner so they can manage the course immediately and so
+    # the (live, DB-backed) _lecturer gate in assign_example_to_content passes.
+    db.add(
+        CourseMember(
+            course_id=course.id,
+            user_id=permissions.user_id,
+            course_role_id="_owner",
+            created_by=permissions.user_id,
+            updated_by=permissions.user_id,
+        )
+    )
+
+    ct_rows: Dict[str, CourseContentType] = {}
+    for slug, ct in ct_by_slug.items():
+        row = CourseContentType(
+            slug=slug,
+            title=ct.title,
+            description=ct.description,
+            color=ct.color or "green",
+            properties=dict(ct.properties) if ct.properties else {},
+            course_id=course.id,
+            course_content_kind_id=ct.kind,
+            created_by=permissions.user_id,
+            updated_by=permissions.user_id,
+        )
+        db.add(row)
+        ct_rows[slug] = row
+    db.flush()
+    # Commit the course + owner membership + content types before assigning
+    # examples (assign_example_to_content authorizes against the live membership).
+    db.commit()
+
+    # Reset per-apply counters (the validation pass populated them already).
+    summary.assignments = 0
+    summary.units = 0
+    summary.examples_assigned = 0
+    _walk(config.contents or [], None, ct_rows, [1.0], None)
+    db.commit()
+
+    result.applied = True
+    result.course_id = str(course.id)
+    return result

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -72,6 +72,7 @@ from computor_backend.api.services import services_router
 from computor_backend.api.api_tokens import api_tokens_router
 from computor_backend.api.git_servers import git_servers_router
 from computor_backend.api.course_git import course_git_router
+from computor_backend.api.course_deployment import course_deployment_router
 from computor_backend.api.course_member_import import course_member_import_router
 from computor_backend.api.course_member_gradings import course_member_gradings_router
 from computor_backend.api.analytics import analytics_router
@@ -497,6 +498,8 @@ app.include_router(
 # lecturer-facing per-course binding. Auth is enforced per-endpoint.
 app.include_router(git_servers_router, tags=["git-servers"])
 app.include_router(course_git_router, tags=["course-git"])
+# Single-course deploy from an uploaded course_deployment.yaml (web create page).
+app.include_router(course_deployment_router, tags=["course-deployment"])
 
 # app.include_router(
 #     info_router,

--- a/computor-types/src/computor_types/course_deployment.py
+++ b/computor-types/src/computor_types/course_deployment.py
@@ -1,0 +1,66 @@
+"""DTOs for deploying a single course from an uploaded ``course_deployment.yaml``.
+
+The web "create course" page can optionally upload a course-level deployment
+file — a top-level :class:`~computor_types.deployments_refactored.HierarchicalCourseConfig`
+(``name``, ``path``, ``services``, ``content_types`` and a nested ``contents``
+tree), with no organization/git/users keys. The file is first *validated*
+(``validate_only=True``) and then *applied* under an existing course family.
+
+These are plain request/response models (not registered CRUD entities).
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CourseDeployRequest(BaseModel):
+    """Upload payload for the course-deployment endpoint.
+
+    The raw YAML text is sent as-is and parsed server-side into a
+    ``HierarchicalCourseConfig`` — the client never needs to model the schema.
+    """
+
+    yaml: str = Field(..., description="Raw contents of the course_deployment.yaml file")
+    validate_only: bool = Field(
+        False,
+        description="When true, parse and check the config (examples resolve, content types exist, "
+        "path free) without creating anything.",
+    )
+
+
+class CourseDeployWarning(BaseModel):
+    """A non-fatal issue found while validating/applying the config.
+
+    Warnings never block a deploy; the affected content is still created (just
+    without an example, typically)."""
+
+    path: Optional[str] = Field(None, description="Dotted course-content path the warning relates to")
+    example_identifier: Optional[str] = Field(None, description="Example identifier the warning relates to")
+    reason: str = Field(..., description="Human-readable explanation")
+
+
+class CourseDeploySummary(BaseModel):
+    """Counts of what was (or would be) created."""
+
+    content_types: int = Field(0, description="Number of content types")
+    units: int = Field(0, description="Number of non-submittable contents (units)")
+    assignments: int = Field(0, description="Number of submittable contents (assignments)")
+    examples_assigned: int = Field(0, description="Number of examples assigned to assignments")
+
+
+class CourseDeployResult(BaseModel):
+    """Outcome of a validate or apply run."""
+
+    validated: bool = Field(..., description="Whether the config parsed and the checks ran")
+    applied: bool = Field(..., description="Whether the course was actually created")
+    course_id: Optional[str] = Field(None, description="ID of the created course (apply only)")
+    course_path: str = Field(..., description="Course path/slug from the file")
+    course_title: Optional[str] = Field(None, description="Course title/name from the file")
+    summary: CourseDeploySummary = Field(default_factory=CourseDeploySummary)
+    warnings: List[CourseDeployWarning] = Field(default_factory=list)
+    errors: List[str] = Field(
+        default_factory=list,
+        description="Fatal problems that block an apply (e.g. unknown content type, path taken)",
+    )

--- a/computor-web/app/courses/create/page.tsx
+++ b/computor-web/app/courses/create/page.tsx
@@ -19,6 +19,20 @@ const MODE_LABELS: Record<string, string> = {
   download: 'Download — no git',
 };
 
+// Response of POST /course-families/{id}/deploy-course (validate or apply).
+interface DeployWarning { path?: string | null; example_identifier?: string | null; reason: string }
+interface DeploySummary { content_types: number; units: number; assignments: number; examples_assigned: number }
+interface DeployResult {
+  validated: boolean;
+  applied: boolean;
+  course_id?: string | null;
+  course_path: string;
+  course_title?: string | null;
+  summary: DeploySummary;
+  warnings: DeployWarning[];
+  errors: string[];
+}
+
 function CreateInner() {
   const router = useRouter();
   const familyIdParam = useSearchParam('familyId');
@@ -36,6 +50,13 @@ function CreateInner() {
   const [modes, setModes] = useState<string[]>(['managed']);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Optional "upload a course_deployment.yaml" flow.
+  const [fileName, setFileName] = useState('');
+  const [fileText, setFileText] = useState('');
+  const [validating, setValidating] = useState(false);
+  const [check, setCheck] = useState<DeployResult | null>(null);
+  const hasFile = !!fileText;
 
   useEffect(() => {
     if (authLoading || !isAuthenticated) return;
@@ -57,10 +78,64 @@ function CreateInner() {
 
   const toggleMode = (m: string) => setModes((ms) => (ms.includes(m) ? ms.filter((x) => x !== m) : [...ms, m]));
 
+  async function onPickFile(file: File | undefined) {
+    setCheck(null);
+    setError(null);
+    if (!file) {
+      setFileName('');
+      setFileText('');
+      return;
+    }
+    try {
+      const text = await file.text();
+      setFileName(file.name);
+      setFileText(text);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not read the file');
+    }
+  }
+
+  async function validate() {
+    if (!familyId || !fileText) return;
+    setValidating(true);
+    setError(null);
+    try {
+      const res = await api.post<DeployResult>(`/course-families/${familyId}/deploy-course`, {
+        yaml: fileText,
+        validate_only: true,
+      });
+      setCheck(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Validation failed');
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  async function configureGit(courseId: string) {
+    if (canConfigureGit && gitEnabled && serverId) {
+      try {
+        await api.put(`/courses/${courseId}/git`, { delivery: 'git', git_server_id: serverId, student_repo_modes: modes });
+      } catch (e) {
+        throw new Error('Course created, but git setup failed: ' + (e instanceof Error ? e.message : ''));
+      }
+    }
+  }
+
   async function save() {
     setSaving(true);
     setError(null);
     try {
+      if (hasFile) {
+        const res = await api.post<DeployResult>(`/course-families/${familyId}/deploy-course`, {
+          yaml: fileText,
+          validate_only: false,
+        });
+        if (!res.course_id) throw new Error(res.errors?.join('; ') || 'Deploy failed');
+        await configureGit(res.course_id);
+        router.push(`/courses/${res.course_id}`);
+        return;
+      }
       const course = await api.post<CourseGet>('/courses', {
         path: path.trim(),
         course_family_id: familyId,
@@ -68,13 +143,7 @@ function CreateInner() {
         description: description.trim() || null,
       });
       // One step: configure git immediately so a course is never left without it.
-      if (canConfigureGit && gitEnabled && serverId) {
-        try {
-          await api.put(`/courses/${course.id}/git`, { delivery: 'git', git_server_id: serverId, student_repo_modes: modes });
-        } catch (e) {
-          throw new Error('Course created, but git setup failed: ' + (e instanceof Error ? e.message : ''));
-        }
-      }
+      await configureGit(course.id);
       router.push(`/courses/${course.id}`);
     } catch (e) {
       setSaving(false);
@@ -86,6 +155,8 @@ function CreateInner() {
     return <Forbidden message="You do not have permission to create courses." />;
   }
 
+  const blocked = hasFile && (check?.errors?.length ?? 0) > 0;
+
   return (
     <AuthenticatedLayout>
       <FormPanel
@@ -94,8 +165,8 @@ function CreateInner() {
         description="A course is one run of a lecture in a single term — students enroll here, get their repositories, and submit their work. It belongs to a course family (the lecture)."
         error={error}
         submitting={saving}
-        disabled={!path.trim() || !familyId}
-        submitLabel="Create"
+        disabled={!familyId || (hasFile ? blocked : !path.trim())}
+        submitLabel={hasFile ? 'Create from file' : 'Create'}
         onCancel={() => router.push('/courses')}
         onSubmit={save}
       >
@@ -107,15 +178,82 @@ function CreateInner() {
             ))}
           </select>
         </Field>
-        <Field label="Path (slug)" required hint="Lowercase, URL-safe identifier, unique within the course family. Hard to change later.">
-          <input value={path} onChange={(e) => setPath(e.target.value)} placeholder="algorithms-2026w" className={inputCls} />
+
+        <Field
+          label="Import from file (optional)"
+          hint="Upload a course_deployment.yaml to create the course with its content types and full content tree. Identity (path/title) comes from the file."
+        >
+          <input
+            type="file"
+            accept=".yaml,.yml,application/x-yaml,text/yaml"
+            onChange={(e) => onPickFile(e.target.files?.[0])}
+            className="block w-full text-sm text-gray-600 file:mr-3 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-blue-50 file:text-blue-700 file:text-sm file:font-medium hover:file:bg-blue-100"
+          />
+          {hasFile && (
+            <div className="mt-2 space-y-2">
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-gray-500 font-mono truncate">{fileName}</span>
+                <button
+                  type="button"
+                  onClick={validate}
+                  disabled={!familyId || validating}
+                  className="px-3 py-1 text-xs font-medium text-blue-700 bg-blue-50 rounded-lg hover:bg-blue-100 disabled:opacity-50"
+                >
+                  {validating ? 'Validating…' : 'Validate'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onPickFile(undefined)}
+                  className="px-3 py-1 text-xs text-gray-500 hover:bg-gray-100 rounded-lg"
+                >
+                  Clear
+                </button>
+              </div>
+
+              {check && (
+                <div className="text-xs space-y-1 border border-gray-200 rounded-lg p-3 bg-gray-50">
+                  <div className="text-gray-700">
+                    <span className="font-medium">{check.course_title || check.course_path}</span>{' '}
+                    <span className="font-mono text-gray-500">({check.course_path})</span>
+                  </div>
+                  <div className="text-gray-500">
+                    {check.summary.content_types} content types · {check.summary.units} units ·{' '}
+                    {check.summary.assignments} assignments · {check.summary.examples_assigned} examples
+                  </div>
+                  {check.errors.length > 0 && (
+                    <ul className="text-red-600 list-disc pl-4">
+                      {check.errors.map((e, i) => <li key={i}>{e}</li>)}
+                    </ul>
+                  )}
+                  {check.warnings.length > 0 && (
+                    <ul className="text-amber-600 list-disc pl-4">
+                      {check.warnings.map((w, i) => (
+                        <li key={i}>{w.path ? `${w.path}: ` : ''}{w.reason}</li>
+                      ))}
+                    </ul>
+                  )}
+                  {check.errors.length === 0 && (
+                    <div className="text-green-600">Looks good — ready to create.</div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </Field>
-        <Field label="Title" hint="Display name for this run, e.g. 'Algorithms — Winter 2026'.">
-          <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Algorithms — Winter 2026" className={inputCls} />
-        </Field>
-        <Field label="Description">
-          <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={2} className={inputCls} />
-        </Field>
+
+        {!hasFile && (
+          <>
+            <Field label="Path (slug)" required hint="Lowercase, URL-safe identifier, unique within the course family. Hard to change later.">
+              <input value={path} onChange={(e) => setPath(e.target.value)} placeholder="algorithms-2026w" className={inputCls} />
+            </Field>
+            <Field label="Title" hint="Display name for this run, e.g. 'Algorithms — Winter 2026'.">
+              <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Algorithms — Winter 2026" className={inputCls} />
+            </Field>
+            <Field label="Description">
+              <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={2} className={inputCls} />
+            </Field>
+          </>
+        )}
 
         {canConfigureGit && servers.length > 0 && (
           <div className="border-t border-gray-200 pt-4 space-y-3">

--- a/computor-web/package.json
+++ b/computor-web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "highlight.js": "11.11.1",
+    "js-yaml": "^4.3.0",
     "jszip": "^3.10.1",
     "next": "16.1.5",
     "react": "19.2.0",
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@playwright/test": "1.60.0",
     "@tailwindcss/postcss": "^4",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/computor-web/src/utils/exampleZip.ts
+++ b/computor-web/src/utils/exampleZip.ts
@@ -1,4 +1,5 @@
 import JSZip from 'jszip';
+import { load as parseYaml } from 'js-yaml';
 
 /**
  * Client-side discovery of one-or-many examples inside an uploaded .zip.
@@ -49,6 +50,99 @@ async function readContent(entry: JSZip.JSZipObject, relPath: string): Promise<s
   return relPath === 'meta.yaml' ? entry.async('string') : entry.async('base64');
 }
 
+/**
+ * Pull the slug and (test) dependency slugs out of an example's meta.yaml.
+ *
+ * Mirrors the CLI (`_read_meta_and_dependencies`): the slug falls back to the
+ * directory name with `-`/`_` mapped to dots; `testDependencies` may live at the
+ * root or under `properties`, and each entry is either a bare slug string or an
+ * object with a `slug` field (a missing version means "latest").
+ */
+function metaSlugAndDeps(dir: string, metaText: string | undefined): { slug: string; deps: string[] } {
+  let slug = dir.replace(/[-_]/g, '.');
+  const deps: string[] = [];
+  if (metaText) {
+    let meta: unknown;
+    try {
+      meta = parseYaml(metaText);
+    } catch {
+      meta = undefined;
+    }
+    if (meta && typeof meta === 'object') {
+      const m = meta as Record<string, any>;
+      if (typeof m.slug === 'string' && m.slug) slug = m.slug;
+      let td = m.properties && typeof m.properties === 'object' ? m.properties.testDependencies : undefined;
+      if (td == null) td = m.testDependencies;
+      if (Array.isArray(td)) {
+        for (const item of td) {
+          if (typeof item === 'string') deps.push(item);
+          else if (item && typeof item === 'object' && typeof item.slug === 'string') deps.push(item.slug);
+        }
+      }
+    }
+  }
+  return { slug, deps };
+}
+
+/**
+ * Topologically sort discovered examples so an example another depends on is
+ * uploaded first (the backend rejects an upload whose testDependencies aren't
+ * yet in the repository). Only dependencies present in this batch are
+ * considered; ties and cycles fall back to a stable alphabetical order.
+ * Mirrors the CLI's `_toposort_by_dependencies`.
+ */
+function sortByDependencies(examples: DiscoveredExample[]): DiscoveredExample[] {
+  if (examples.length < 2) return examples;
+
+  const nodes = examples.map((e) => ({ e, ...metaSlugAndDeps(e.directory, e.files['meta.yaml']) }));
+  const bySlug = new Map<string, (typeof nodes)[number]>();
+  for (const n of nodes) bySlug.set(n.slug, n); // last wins, like the CLI
+
+  const indeg = new Map<string, number>();
+  const rev = new Map<string, Set<string>>(); // dep slug -> dependent slugs
+  for (const n of nodes) {
+    rev.set(n.slug, rev.get(n.slug) ?? new Set());
+    const inBatch = n.deps.filter((d) => bySlug.has(d) && d !== n.slug);
+    indeg.set(n.slug, inBatch.length);
+    for (const d of inBatch) {
+      rev.set(d, rev.get(d) ?? new Set());
+      rev.get(d)!.add(n.slug);
+    }
+  }
+
+  const cmp = (a: string, b: string) => bySlug.get(a)!.e.directory.localeCompare(bySlug.get(b)!.e.directory);
+  const queue = [...bySlug.keys()].filter((s) => (indeg.get(s) ?? 0) === 0).sort(cmp);
+  const order: string[] = [];
+  while (queue.length) {
+    const s = queue.shift()!;
+    order.push(s);
+    for (const nx of [...(rev.get(s) ?? [])].sort(cmp)) {
+      indeg.set(nx, (indeg.get(nx) ?? 0) - 1);
+      if ((indeg.get(nx) ?? 0) === 0) {
+        queue.push(nx);
+        queue.sort(cmp);
+      }
+    }
+  }
+  // Cycle (or unreachable) fallback: append remaining slugs in stable order.
+  if (order.length < bySlug.size) {
+    order.push(...[...bySlug.keys()].filter((s) => !order.includes(s)).sort(cmp));
+  }
+
+  const seen = new Set<DiscoveredExample>();
+  const result: DiscoveredExample[] = [];
+  for (const s of order) {
+    const node = bySlug.get(s);
+    if (node && !seen.has(node.e)) {
+      result.push(node.e);
+      seen.add(node.e);
+    }
+  }
+  // Any examples whose slug collided and weren't emitted (kept stable).
+  for (const n of nodes) if (!seen.has(n.e)) result.push(n.e);
+  return result;
+}
+
 export async function discoverExamplesInZip(file: File): Promise<DiscoveredExample[]> {
   const zip = await JSZip.loadAsync(file);
   const entries = Object.values(zip.files).filter((f) => !f.dir);
@@ -95,5 +189,6 @@ export async function discoverExamplesInZip(file: File): Promise<DiscoveredExamp
   if (result.length === 0) {
     throw new Error('No meta.yaml found at the zip root or one directory deep.');
   }
-  return result.sort((a, b) => a.directory.localeCompare(b.directory));
+  // Upload dependencies before the examples that depend on them.
+  return sortByDependencies(result);
 }


### PR DESCRIPTION
## Summary
Adds an optional **single-course deployment upload** to the web create-course page, plus two fixes uncovered while testing it.

### Course deployment upload (`/courses/create`)
Upload a `course_deployment.yaml` — a top-level `HierarchicalCourseConfig` (`name`/`path`/`services`/`content_types`/nested `contents`, **no** organizations/git/users) — **validate** it, then **apply** it under the family in the URL.

- **`POST /course-families/{family_id}/deploy-course`** `{ yaml, validate_only }` → parses to `HierarchicalCourseConfig`, runs `deploy_course_from_config` (threadpool).
- `deploy_course_from_config`: authorizes creation with the **same gate as `POST /courses`**; validates content-type kinds/references, path segments + duplicates, and that every `example_identifier` resolves (with a version). On apply it creates the course, **self-enrolls the caller as `_owner`** (committed before example assignment so the live `_lecturer` gate passes for non-admins), creates content types, then walks the tree creating `CourseContent` and assigning examples via the existing `assign_example_to_content`. Errors block apply; unresolved examples are warnings.
- Web: optional file picker; when a file is chosen the manual path/title/description fields hide (identity comes from the file), a **Validate** button shows counts/warnings/errors, **Create** applies then configures git exactly as before.

### Fix: content types are unique by `(slug, kind)`, not slug
The `course_content_type` unique index is `(slug, course_id, kind)`, so the same slug can be a **unit** *and* an **assignment** (e.g. `training`, `advanced`, `exam`). Validation wrongly flagged these as duplicates. Now dedups on `(slug, kind)` and resolves a content node's `content_type` by tree structure — a node with children → the unit type, a leaf → the assignment type.

### Fix: order multi-example uploads by `testDependencies`
The web examples upload sent examples alphabetically, so an example depending on another in the same zip could upload first and get rejected. `discoverExamplesInZip` now parses each `meta.yaml` (js-yaml) for `slug` + `testDependencies` (both bare-slug strings and `{slug, version}` objects; missing version = latest) and topologically sorts so in-batch dependencies upload first — mirroring the CLI's `_toposort_by_dependencies`.

### Also
Removes three stray dev planning docs from the release branch (work preserved on their feature branches + history).

## Notes
- No DB migration (reuses existing tables). Synchronous apply.
- Referenced examples must already be in the library (warnings otherwise).
- Verified: backend modules import, web `tsc` clean, dependency-ordering + `(slug,kind)` resolution validated against the real `course_deployment.yaml` (87 contents resolve). Not yet run end-to-end against a live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)