### PR TITLE
fix(course-deploy): surface deploy warnings (e.g. missing testing service)

### DIFF
--- a/computor-backend/src/computor_backend/business_logic/course_deployment.py
+++ b/computor-backend/src/computor_backend/business_logic/course_deployment.py
@@ -175,7 +175,8 @@ def deploy_course_from_config(
         else:
             warnings.append(
                 CourseDeployWarning(
-                    reason=f"Service '{svc.slug}' not found; assignments won't be linked to it"
+                    reason=f"Testing service '{svc.slug}' is not registered; assignments will have "
+                    f"no testing service, so students can't run tests or submit until one is linked"
                 )
             )
     default_service_id: Optional[str] = next(iter(service_ids.values()), None)

--- a/computor-web/app/courses/create/page.tsx
+++ b/computor-web/app/courses/create/page.tsx
@@ -56,6 +56,7 @@ function CreateInner() {
   const [fileText, setFileText] = useState('');
   const [validating, setValidating] = useState(false);
   const [check, setCheck] = useState<DeployResult | null>(null);
+  const [createdCourseId, setCreatedCourseId] = useState<string | null>(null);
   const hasFile = !!fileText;
 
   useEffect(() => {
@@ -80,6 +81,7 @@ function CreateInner() {
 
   async function onPickFile(file: File | undefined) {
     setCheck(null);
+    setCreatedCourseId(null);
     setError(null);
     if (!file) {
       setFileName('');
@@ -99,6 +101,7 @@ function CreateInner() {
     if (!familyId || !fileText) return;
     setValidating(true);
     setError(null);
+    setCreatedCourseId(null);
     try {
       const res = await api.post<DeployResult>(`/course-families/${familyId}/deploy-course`, {
         yaml: fileText,
@@ -133,6 +136,15 @@ function CreateInner() {
         });
         if (!res.course_id) throw new Error(res.errors?.join('; ') || 'Deploy failed');
         await configureGit(res.course_id);
+        if (res.warnings?.length) {
+          // The course was created, but something is off (e.g. a service slug
+          // didn't resolve, so assignments have no testing service). Surface the
+          // warnings instead of silently navigating away; the user can proceed.
+          setCheck(res);
+          setCreatedCourseId(res.course_id);
+          setSaving(false);
+          return;
+        }
         router.push(`/courses/${res.course_id}`);
         return;
       }
@@ -232,8 +244,20 @@ function CreateInner() {
                       ))}
                     </ul>
                   )}
-                  {check.errors.length === 0 && (
+                  {check.errors.length === 0 && !createdCourseId && (
                     <div className="text-green-600">Looks good — ready to create.</div>
+                  )}
+                  {createdCourseId && (
+                    <div className="flex items-center gap-2 pt-1 text-green-700">
+                      <span>Course created{check.warnings.length > 0 ? ' with warnings (above)' : ''}.</span>
+                      <button
+                        type="button"
+                        onClick={() => router.push(`/courses/${createdCourseId}`)}
+                        className="text-blue-600 underline"
+                      >
+                        Open course
+                      </button>
+                    </div>
                   )}
                 </div>
               )}


### PR DESCRIPTION
## Summary
Deploying a course from `course_deployment.yaml` whose `services[].slug` doesn't resolve to a registered service is intentionally a **warning, not a failure**. But on a direct **apply** the create page silently redirected to the new course, so the warning was only ever shown if you clicked **Validate** first — and you'd then discover the course is un-submittable only at test/submit time (the assignments have no `testing_service_id`).

## Changes
- **Web** (`courses/create`): on apply, if the result carries warnings, render them and offer an **"Open course"** button instead of navigating away. Clean deploys (no warnings) still redirect as before.
- **Backend** (`deploy_course_from_config`): the unresolved-service warning now spells out the consequence — *"Testing service '…' is not registered; assignments will have no testing service, so students can't run tests or submit until one is linked."*

No behavior change to validation/deployment itself — still a warning, never a hard fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)