### PR TITLE
fix(testing): resolve testing service by example slug, not just the FK

### DIFF
--- a/computor-backend/src/computor_backend/api/tests.py
+++ b/computor-backend/src/computor_backend/api/tests.py
@@ -25,8 +25,6 @@ from computor_types.results import ResultCreate, ResultList
 from computor_types.repositories import Repository
 from computor_types.tasks import TaskStatus, map_task_status_to_int
 from computor_types.tests import TestCreate, TestJob
-from computor_types.courses import CourseProperties
-from computor_types.organizations import OrganizationProperties
 from computor_backend.model.artifact import SubmissionArtifact
 from computor_backend.model.result import Result
 from computor_backend.model.course import (
@@ -277,14 +275,6 @@ async def create_test_run(
             error_code="SUBMIT_005",
             detail="Service type not found for service"
         )
-
-    # Get course and organization for GitLab configuration
-    course = db.query(Course).filter(Course.id == submission_group.course_id).first()
-    course_family = db.query(CourseFamily).filter(CourseFamily.id == course.course_family_id).first()
-    organization = db.query(Organization).filter(Organization.id == course_family.organization_id).first()
-
-    organization_properties = OrganizationProperties(**organization.properties)
-    course_properties = CourseProperties(**course.properties)
 
     # Get deployment info for reference example using repository
     deployment_repo = CourseContentDeploymentRepository(db, repo_cache)

--- a/computor-backend/src/computor_backend/api/tests.py
+++ b/computor-backend/src/computor_backend/api/tests.py
@@ -18,7 +18,6 @@ from computor_backend.database import get_db
 from computor_backend.redis_cache import get_redis_client, get_cache
 from computor_backend.cache import Cache
 from computor_backend.repositories import (
-    ServiceRepository,
     ServiceTypeRepository,
     CourseContentDeploymentRepository,
 )
@@ -250,20 +249,23 @@ async def create_test_run(
         CourseContent.id == submission_group.course_content_id
     ).first()
 
-    if not course_content or not course_content.testing_service_id:
+    if not course_content:
         raise BadRequestException(
             error_code="SUBMIT_005",
-            detail="Assignment or testing service not configured"
+            detail="Assignment not configured"
         )
 
-    # Get testing service using repository (e.g., itp-worker-python)
-    service_repo = ServiceRepository(db, repo_cache)
-    service = service_repo.get_by_id_optional(str(course_content.testing_service_id))
+    # Resolve the testing service: cached FK, else by the example's executionBackend
+    # slug (self-healing). Lets a content/example exist before the service is
+    # registered — testing works the moment the matching service appears.
+    from computor_backend.business_logic.testing_service import resolve_testing_service
+
+    service = resolve_testing_service(course_content, db)
 
     if not service:
         raise BadRequestException(
             error_code="SUBMIT_005",
-            detail="Testing service not found"
+            detail="Assignment has no testing service: no enabled service matches the example's executionBackend slug"
         )
 
     # Get the service type using repository

--- a/computor-backend/src/computor_backend/business_logic/submissions.py
+++ b/computor-backend/src/computor_backend/business_logic/submissions.py
@@ -241,8 +241,19 @@ async def upload_submission_artifact(
     if not course_content.is_submittable:
         raise BadRequestException(detail="This course content does not accept submissions")
 
-    if not course_content.testing_service_id:
-        raise BadRequestException(detail="Course content is missing a testing service to link submissions")
+    # Resolve the testing service by the example's executionBackend slug (the FK is
+    # only a cache and is often NULL when the service was registered after the
+    # example was assigned). Self-heals the FK when it resolves.
+    from computor_backend.business_logic.testing_service import resolve_testing_service
+
+    if resolve_testing_service(course_content, db) is None:
+        raise BadRequestException(
+            detail=(
+                "Course content has no testing service: its example's executionBackend "
+                "matches no registered, enabled service yet. Register that service "
+                "(matching the example's executionBackend slug) and try again."
+            )
+        )
 
     # Determine submitting course member
     submitting_member: Optional[CourseMember] = None

--- a/computor-backend/src/computor_backend/business_logic/testing_service.py
+++ b/computor-backend/src/computor_backend/business_logic/testing_service.py
@@ -1,0 +1,103 @@
+"""Resolve the testing :class:`Service` for a course content.
+
+``CourseContent.testing_service_id`` is a *cache*, not the source of truth — the
+source of truth is the deployed example's ``executionBackend.slug``. The FK is
+filled in eagerly (best-effort) when an example is assigned, but an example can
+be uploaded/assigned *before* its execution backend is registered, so the FK is
+frequently NULL and is never re-resolved on its own. Reading it directly (as the
+upload + test-run paths used to) means a perfectly valid content can't be tested
+just because the service was registered after the assignment.
+
+This resolver fixes that: prefer the cached FK, otherwise resolve by the
+example's slug, and backfill the FK so the next call is O(1). It returns None
+only when the content genuinely has no example/slug or no matching enabled
+service exists yet — so "create the content / upload the example before the
+service" keeps working, and it "just works" the moment the service appears.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from computor_backend.model.course import CourseContent
+from computor_backend.model.deployment import CourseContentDeployment
+from computor_backend.model.example import ExampleVersion
+from computor_backend.model.service import Service
+
+logger = logging.getLogger(__name__)
+
+
+def _usable(service: Optional[Service]) -> bool:
+    return bool(service and service.enabled and service.archived_at is None)
+
+
+def resolve_testing_service(course_content: CourseContent, db: Session) -> Optional[Service]:
+    """Resolve the testing service for a content (lazy + self-healing).
+
+    Order:
+      1. the cached ``testing_service_id`` FK, when it still points at a usable
+         (enabled, non-archived) service;
+      2. otherwise the service whose ``slug`` equals the deployed example
+         version's ``executionBackend.slug``;
+      3. on a fresh resolution, backfill the FK (on the content, and on the
+         example version) so later calls take the fast path and the column
+         reflects reality.
+
+    Returns None when the content has no example deployment / executionBackend
+    slug, or no enabled service matches that slug yet.
+    """
+    # 1. Cached FK fast-path.
+    if course_content.testing_service_id:
+        cached = (
+            db.query(Service)
+            .filter(Service.id == course_content.testing_service_id)
+            .first()
+        )
+        if _usable(cached):
+            return cached
+        # Stale FK (service disabled/removed) → fall through and re-resolve.
+
+    # 2. Resolve by the deployed example version's executionBackend slug.
+    deployment = (
+        db.query(CourseContentDeployment)
+        .filter(CourseContentDeployment.course_content_id == course_content.id)
+        .first()
+    )
+    if deployment is None or deployment.example_version_id is None:
+        return None
+
+    example_version = (
+        db.query(ExampleVersion)
+        .filter(ExampleVersion.id == deployment.example_version_id)
+        .first()
+    )
+    slug = example_version.get_execution_backend_slug() if example_version else None
+    if not slug:
+        return None
+
+    service = (
+        db.query(Service)
+        .filter(
+            Service.slug == slug,
+            Service.enabled.is_(True),
+            Service.archived_at.is_(None),
+        )
+        .first()
+    )
+    if service is None:
+        return None
+
+    # 3. Self-heal: cache the resolution. The caller's transaction persists it;
+    #    if the caller doesn't commit, correctness still holds (re-resolved next
+    #    time), we just don't get the O(1) fast path.
+    course_content.testing_service_id = service.id
+    if example_version is not None and example_version.testing_service_id != service.id:
+        example_version.testing_service_id = service.id
+    logger.info(
+        "Resolved testing service '%s' for course content %s by executionBackend slug "
+        "(backfilled testing_service_id)",
+        slug, course_content.id,
+    )
+    return service


### PR DESCRIPTION
## Problem
`course_content.testing_service_id` is a **cache**; the source of truth is the example's `executionBackend.slug`. The FK is set eagerly (best-effort) when an example is assigned — but an example can be uploaded/assigned **before** its execution backend is registered, so the FK is left NULL and is **never re-resolved**. Both the upload check (`submissions.py`) and the test run (`tests.py`) read the FK directly, so a content whose service was registered *after* assignment can never be tested/submitted ("Course content is missing a testing service" → VAL_001) even though a matching enabled service now exists.

Concretely (live DB): content `characters_and_strings` has example `itpcp.pgph.py.basis_char` (executionBackend slug `itpcp.exec.py`) deployed; service `itpcp.exec.py` exists and is enabled — but the content's `testing_service_id` is NULL → submit/test fail.

## Fix
`resolve_testing_service(content, db)`:
1. cached FK fast-path (when it still points at an enabled, non-archived service);
2. else resolve by the deployed example version's `executionBackend.slug` → `Service`;
3. **backfill** the FK (self-heal) so the next call is O(1) and the column reflects reality.

Wired into the upload path and the test-run path in place of the bare FK reads. The eager link stays as a cache; this just adds the always-on lazy fallback — so you can create contents / upload examples **before** the service exists, and it "just works" the moment the matching service is registered (no re-assign, no re-deploy).

## Notes
- Returns None (clear error) only when the content has no example/slug or no enabled service matches the slug yet.
- Verified: imports + compile clean; dropped the now-dead `ServiceRepository` import in `tests.py`. Not yet run end-to-end.
- Independent of the bootstrap-services PR (#184). The separate `task_queue` mismatch you already fixed in the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)