### PR TITLE
feat: GDPR consent gate + file-based privacy notices

### DIFF
--- a/computor-backend/src/computor_backend/alembic/versions/dd2e3f4a5b6c_add_consent_tables.py
+++ b/computor-backend/src/computor_backend/alembic/versions/dd2e3f4a5b6c_add_consent_tables.py
@@ -1,16 +1,19 @@
 """Add GDPR consent tables (policy_versions, user_consents)
 
 Revision ID: dd2e3f4a5b6c
-Revises: cc1d2e3f4a5b
+Revises: c9a1b2d3e4f5
 Create Date: 2026-07-04 12:00:00.000000
 
+Re-parented onto the release/2026.10 head (c9a1b2d3e4f5) when that branch was
+merged into feat/consent-gate: the consent tables are independent of the
+intervening migrations, so they simply apply last.
 """
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 revision = 'dd2e3f4a5b6c'
-down_revision = 'cc1d2e3f4a5b'
+down_revision = 'c9a1b2d3e4f5'
 branch_labels = None
 depends_on = None
 

--- a/computor-backend/src/computor_backend/alembic/versions/dd2e3f4a5b6c_add_consent_tables.py
+++ b/computor-backend/src/computor_backend/alembic/versions/dd2e3f4a5b6c_add_consent_tables.py
@@ -1,0 +1,68 @@
+"""Add GDPR consent tables (policy_versions, user_consents)
+
+Revision ID: dd2e3f4a5b6c
+Revises: cc1d2e3f4a5b
+Create Date: 2026-07-04 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'dd2e3f4a5b6c'
+down_revision = 'cc1d2e3f4a5b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'policy_versions',
+        sa.Column('id', postgresql.UUID(), server_default=sa.text('uuid_generate_v4()'), nullable=False),
+        sa.Column('version', sa.Text(), nullable=False),
+        sa.Column('languages', postgresql.ARRAY(sa.Text()), server_default=sa.text("'{}'::text[]"), nullable=False),
+        sa.Column('effective_from', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('content_hashes', postgresql.JSONB(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('policy_versions_version_idx', 'policy_versions', ['version'], unique=True)
+    op.create_index('policy_versions_effective_from_idx', 'policy_versions', ['effective_from'])
+
+    op.create_table(
+        'user_consents',
+        sa.Column('id', postgresql.UUID(), server_default=sa.text('uuid_generate_v4()'), nullable=False),
+        sa.Column('user_id', postgresql.UUID(), nullable=False),
+        sa.Column('policy_version', sa.Text(), nullable=False),
+        sa.Column('granted_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('withdrawn_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('ip_address', postgresql.INET(), nullable=True),
+        sa.Column('user_agent', sa.Text(), nullable=True),
+        sa.Column('purposes', postgresql.JSONB(), nullable=True),
+        sa.Column('version', sa.BigInteger(), server_default=sa.text('0'), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['policy_version'], ['policy_versions.version'], ondelete='RESTRICT'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('user_consents_user_id_idx', 'user_consents', ['user_id'])
+    # Partial unique index: at most one ACTIVE consent per (user, version).
+    # Makes concurrent first-consent idempotent while allowing re-consent
+    # after withdrawal (withdrawn rows stay for the audit trail).
+    op.create_index(
+        'user_consents_active_uq',
+        'user_consents',
+        ['user_id', 'policy_version'],
+        unique=True,
+        postgresql_where=sa.text('withdrawn_at IS NULL'),
+    )
+
+
+def downgrade():
+    op.drop_index('user_consents_active_uq', table_name='user_consents')
+    op.drop_index('user_consents_user_id_idx', table_name='user_consents')
+    op.drop_table('user_consents')
+    op.drop_index('policy_versions_effective_from_idx', table_name='policy_versions')
+    op.drop_index('policy_versions_version_idx', table_name='policy_versions')
+    op.drop_table('policy_versions')

--- a/computor-backend/src/computor_backend/api/consent.py
+++ b/computor-backend/src/computor_backend/api/consent.py
@@ -1,0 +1,186 @@
+"""GDPR consent endpoints.
+
+All endpoints require authentication but are WHITELISTED in the consent-gate
+middleware (an unconsented user must be able to read the policy, check their
+status, and give/withdraw consent).
+
+The current policy version is always resolved via
+business_logic.consent.resolve_current_policy_version — the same Redis-cached
+helper the middleware uses — so the version these endpoints report and accept
+is exactly the version the gate enforces (no cache-coherence window around
+scheduled effective_from boundaries).
+
+Legal note: whether this records consent-as-legal-basis (GDPR Art. 6(1)(a)) or
+an informed acknowledgment of processing based on contract/public task depends
+on the privacy policy text itself — the mechanism is identical. Strictly
+necessary authentication cookies (Keycloak SSO) do not require opt-in and are
+presented as information only in the UI.
+"""
+
+import ipaddress
+import logging
+from typing import Annotated, List, Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.orm import Session
+
+from computor_backend.business_logic.consent import (
+    ConsentService,
+    cache_consent_status,
+    invalidate_consent_cache,
+    resolve_current_policy_version,
+)
+from computor_backend.database import get_db
+from computor_backend.exceptions import ForbiddenException
+from computor_backend.permissions.auth import get_current_principal
+from computor_backend.permissions.principal import Principal
+from computor_backend.utils.client_info import get_client_ip, get_user_agent
+from computor_types.consent import (
+    ConsentCreate,
+    ConsentStatusGet,
+    PolicyTextGet,
+    PolicyVersionCreate,
+    PolicyVersionGet,
+)
+
+logger = logging.getLogger(__name__)
+
+consent_router = APIRouter()
+
+
+@consent_router.get("/status", response_model=ConsentStatusGet)
+async def get_consent_status(
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> ConsentStatusGet:
+    """Current policy version and whether the caller has consented to it."""
+    required_version = await resolve_current_policy_version()
+    service = ConsentService(db)
+    return ConsentStatusGet(**service.get_status(principal.user_id, required_version))
+
+
+@consent_router.post("", response_model=ConsentStatusGet, status_code=201)
+async def give_consent(
+    payload: ConsentCreate,
+    request: Request,
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> ConsentStatusGet:
+    """Record the caller's consent for the current policy version.
+
+    Captures ip/user-agent as proof of consent. Idempotent (partial unique
+    index on active consents). Refreshes the middleware's Redis gate cache so
+    the user can access the API immediately without re-login.
+    """
+    required_version = await resolve_current_policy_version()
+    service = ConsentService(db)
+    consent = service.record_consent(
+        user_id=principal.user_id,
+        policy_version=payload.policy_version,
+        required_version=required_version,
+        ip_address=_valid_ip_or_none(get_client_ip(request)),
+        user_agent=get_user_agent(request),
+        purposes=payload.purposes,
+    )
+    await cache_consent_status(principal.user_id, consent.policy_version, True)
+    logger.info(f"User {principal.user_id} consented to policy version '{consent.policy_version}'")
+    return ConsentStatusGet(
+        required_version=consent.policy_version,
+        has_consented=True,
+        granted_at=consent.granted_at,
+    )
+
+
+@consent_router.post("/withdraw", response_model=ConsentStatusGet)
+async def withdraw_consent(
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> ConsentStatusGet:
+    """Withdraw consent (GDPR Art. 7(3)). The caller is gated again afterwards."""
+    required_version = await resolve_current_policy_version()
+    service = ConsentService(db)
+    withdrawn = service.withdraw_consent(principal.user_id)
+    if required_version is not None:
+        await invalidate_consent_cache(principal.user_id, required_version)
+    logger.info(f"User {principal.user_id} withdrew consent ({withdrawn} record(s))")
+    return ConsentStatusGet(
+        required_version=required_version,
+        has_consented=required_version is None,
+        granted_at=None,
+    )
+
+
+@consent_router.get("/policy", response_model=PolicyTextGet)
+async def get_policy_text(
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    lang: Optional[str] = Query(None, description="Preferred language code, e.g. 'de'"),
+    db: Session = Depends(get_db),
+) -> PolicyTextGet:
+    """Current policy version + Markdown notice text, with language fallback."""
+    required_version = await resolve_current_policy_version()
+    service = ConsentService(db)
+    return PolicyTextGet(**await service.get_policy_text(required_version, lang))
+
+
+# ---------------------------------------------------------------------------
+# Admin: publish policy versions (append-only)
+# ---------------------------------------------------------------------------
+
+@consent_router.get("/policy-versions", response_model=List[PolicyVersionGet])
+async def list_policy_versions(
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> List[PolicyVersionGet]:
+    """List all policy versions (admin)."""
+    if not principal.is_admin:
+        raise ForbiddenException("Requires _admin role")
+    service = ConsentService(db)
+    return [_policy_to_get(p) for p in service.policy_versions.list_versions()]
+
+
+@consent_router.post("/policy-versions", response_model=PolicyVersionGet, status_code=201)
+async def publish_policy_version(
+    payload: PolicyVersionCreate,
+    principal: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> PolicyVersionGet:
+    """Publish a new policy version (admin).
+
+    Uploads the Markdown texts to MinIO, inserts the append-only
+    policy_versions row, and invalidates the current-version cache. If
+    effective_from <= now, every user without consent for the new version is
+    re-gated on their next request.
+    """
+    if not principal.is_admin:
+        raise ForbiddenException("Requires _admin role")
+    service = ConsentService(db)
+    policy = await service.publish_policy_version(
+        version=payload.version,
+        texts=payload.texts,
+        effective_from=payload.effective_from,
+    )
+    return _policy_to_get(policy)
+
+
+def _policy_to_get(policy) -> PolicyVersionGet:
+    return PolicyVersionGet(
+        id=str(policy.id),
+        version=policy.version,
+        languages=list(policy.languages or []),
+        effective_from=policy.effective_from,
+        content_hashes=policy.content_hashes,
+        created_at=policy.created_at,
+    )
+
+
+def _valid_ip_or_none(value: Optional[str]) -> Optional[str]:
+    """get_client_ip returns client-controlled header text (Forwarded/XFF),
+    which need not be a valid address ('unknown', obfuscated identifiers).
+    The column is INET, so anything unparsable is stored as NULL instead of
+    failing the whole consent INSERT."""
+    if not value:
+        return None
+    try:
+        return str(ipaddress.ip_address(value.strip()))
+    except ValueError:
+        return None

--- a/computor-backend/src/computor_backend/business_logic/bootstrap.py
+++ b/computor-backend/src/computor_backend/business_logic/bootstrap.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 import yaml
@@ -221,3 +221,142 @@ def _ensure_example_repository(cfg: ExampleRepositoryConfig, system: Principal, 
             return f"created WITHOUT ensuring bucket '{bucket}' (MinIO unavailable: {exc})"
 
     return "created"
+
+
+# ---------------------------------------------------------------------------
+# Consent policy versions (data/consent/*)
+# ---------------------------------------------------------------------------
+
+def _consent_dir() -> str:
+    """Directory of privacy-notice version folders (parallel to data/deployments).
+
+    ``CONSENT_DIR`` overrides it (prod mount); otherwise resolve relative to the
+    repo root, same as ``_deployments_dir`` (the dev API runs from
+    ``computor-backend/src``, not the repo root).
+    """
+    env = os.environ.get("CONSENT_DIR")
+    if env:
+        return env
+    repo_root = Path(__file__).resolve().parents[4]
+    return str(repo_root / "data" / "consent")
+
+
+def _coerce_effective_from(value) -> "datetime | None":
+    """Normalise a policy.yaml ``effective_from`` to a datetime (or None = now).
+
+    YAML may hand us None, a bare ``date``/``datetime`` (unquoted timestamps), or
+    a string; accept all and reject anything unparseable.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day)
+    text = str(value).strip().replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"invalid effective_from '{value}' (use ISO 8601)") from exc
+
+
+def _load_policy_dir(path: Path):
+    """Read a ``data/consent/<version>/`` directory.
+
+    Returns ``(version, effective_from, texts)`` where ``texts`` maps a language
+    code to its Markdown. ``version`` defaults to the directory name; languages
+    default to every ``{lang}.md`` present (``policy.yaml`` may override both, plus
+    ``effective_from``). Mirrors the ``computor consent publish`` CLI loader.
+    """
+    meta = {}
+    meta_file = path / "policy.yaml"
+    if meta_file.exists():
+        meta = yaml.safe_load(meta_file.read_text(encoding="utf-8")) or {}
+
+    version = str(meta.get("version") or path.name)
+    effective_from = _coerce_effective_from(meta.get("effective_from"))
+
+    languages = meta.get("languages")
+    texts: dict[str, str] = {}
+    if languages:
+        for lang in languages:
+            f = path / f"{lang}.md"
+            if not f.exists():
+                raise ValueError(f"policy.yaml declares language '{lang}' but {f.name} is missing")
+            texts[lang] = f.read_text(encoding="utf-8")
+    else:
+        for f in sorted(path.glob("*.md")):
+            if f.name.lower() == "readme.md":
+                continue
+            texts[f.stem] = f.read_text(encoding="utf-8")
+
+    if not texts:
+        raise ValueError("no language Markdown files ('*.md') found")
+
+    return version, effective_from, texts
+
+
+async def ensure_bootstrap_policies() -> None:
+    """Publish privacy notices from ``data/consent/*`` idempotently at startup.
+
+    Each sub-directory is a version (``{version}/{lang}.md`` + optional
+    ``policy.yaml``). Every version not already in the DB is published (write-once,
+    so existing versions are skipped and re-runs are a no-op), which brings a fresh
+    system up with its consent notice already in force.
+
+    Gated by ``CONSENT_BOOTSTRAP_ENABLED`` (default true) — set it to false to keep
+    publishing an explicit CLI/UI action. Async because publishing uploads the
+    Markdown to MinIO; best-effort and logged, never raises into startup.
+    """
+    if os.environ.get("CONSENT_BOOTSTRAP_ENABLED", "true").lower() not in ("true", "1", "yes", "on"):
+        print("[STARTUP] Bootstrap policies: disabled (CONSENT_BOOTSTRAP_ENABLED=false)")
+        return
+
+    consent_dir = _consent_dir()
+    if not os.path.isdir(consent_dir):
+        print(f"[STARTUP] Bootstrap policies: no consent dir at {consent_dir} — skipping")
+        return
+
+    version_dirs = sorted(
+        d
+        for d in os.listdir(consent_dir)
+        if not d.startswith(".") and os.path.isdir(os.path.join(consent_dir, d))
+    )
+    if not version_dirs:
+        print(f"[STARTUP] Bootstrap policies: no version directories in {consent_dir}")
+        return
+
+    from computor_backend.business_logic.consent import ConsentService
+    from computor_backend.repositories.consent import PolicyVersionRepository
+
+    print(f"[STARTUP] Bootstrap policies: scanning {len(version_dirs)} version(s) in {consent_dir}")
+    published = 0
+    with get_db_session() as db:
+        existing = {p.version for p in PolicyVersionRepository(db).list_versions()}
+        service = ConsentService(db)
+        for name in version_dirs:
+            try:
+                version, effective_from, texts = _load_policy_dir(Path(consent_dir) / name)
+            except Exception as exc:  # noqa: BLE001 - one bad dir shouldn't block the rest
+                print(f"[STARTUP] Bootstrap policy '{name}' is invalid, skipping: {exc}")
+                continue
+
+            if version in existing:
+                print(f"[STARTUP] Bootstrap policy '{version}': already present")
+                continue
+
+            try:
+                await service.publish_policy_version(
+                    version=version, texts=texts, effective_from=effective_from
+                )
+                existing.add(version)
+                published += 1
+                print(f"[STARTUP] Bootstrap policy '{version}': published ({', '.join(texts)})")
+            except Exception as exc:  # noqa: BLE001 - best-effort per version (e.g. MinIO down)
+                print(f"[STARTUP] Bootstrap policy '{version}' failed: {exc}")
+
+    if published:
+        print(
+            f"[STARTUP] Bootstrap policies: published {published} new version(s) — "
+            f"unconsented users are now gated"
+        )

--- a/computor-backend/src/computor_backend/business_logic/consent.py
+++ b/computor-backend/src/computor_backend/business_logic/consent.py
@@ -1,0 +1,288 @@
+"""Business logic for the GDPR consent gate.
+
+Responsibilities:
+- Resolve the current policy version (DB, cached in Redis) — through ONE
+  shared helper (resolve_current_policy_version) used by both the middleware
+  and the consent endpoints, so the version the gate enforces and the version
+  the API reports/accepts can never disagree for longer than a single cache
+  read.
+- Check / record / withdraw user consent (DB, per-user gate result cached in
+  Redis).
+- Serve policy Markdown texts from MinIO (``policies/{version}/{lang}.md``,
+  write-once) with language fallback and a Redis content cache (the texts are
+  immutable per (version, lang)).
+
+Redis keys (shared with the consent middleware):
+- ``consent:current_version``            -> current version string (sentinel ``__none__`` if unconfigured)
+- ``consent:{user_id}:{policy_version}`` -> "1"/"0" gate result
+- ``consent:policytext:{version}:{lang}``-> cached Markdown content
+
+Because the per-user key includes the policy version, publishing a new version
+automatically invalidates all stale "1" entries (they are keyed by the old
+version and simply stop being read).
+"""
+
+import hashlib
+import io
+import logging
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
+
+from computor_backend.exceptions import BadRequestException, NotFoundException
+from computor_backend.model.consent import PolicyVersion, UserConsent
+from computor_backend.repositories.consent import ConsentRepository, PolicyVersionRepository
+
+logger = logging.getLogger(__name__)
+
+CURRENT_VERSION_KEY = "consent:current_version"
+CURRENT_VERSION_TTL = 300  # seconds; also invalidated explicitly on publish
+CONSENT_STATUS_TTL = 300  # seconds
+POLICY_TEXT_TTL = 3600  # seconds; content is immutable per (version, lang)
+NO_VERSION_SENTINEL = "__none__"
+
+POLICY_OBJECT_TEMPLATE = "policies/{version}/{lang}.md"
+POLICY_TEXT_CACHE_KEY = "consent:policytext:{version}:{lang}"
+FALLBACK_LANGUAGE = "en"
+
+
+def consent_cache_key(user_id: str, policy_version: str) -> str:
+    return f"consent:{user_id}:{policy_version}"
+
+
+# ---------------------------------------------------------------------------
+# Current-version resolution (Redis-cached; the single source of truth for
+# both the middleware and the endpoints)
+# ---------------------------------------------------------------------------
+
+def _load_current_version_from_db() -> Optional[str]:
+    from computor_backend.database import get_db_session
+
+    with get_db_session() as db:
+        current = PolicyVersionRepository(db).get_current()
+        return current.version if current else None
+
+
+async def resolve_current_policy_version() -> Optional[str]:
+    """The policy version currently in force, or None if none is configured.
+
+    Redis-cached (CURRENT_VERSION_TTL); on a miss, reads the DB in a
+    threadpool using its own short session and refreshes the cache.
+    """
+    cached = await get_cached_current_version()
+    if cached is not None:
+        return None if cached == NO_VERSION_SENTINEL else cached
+
+    version = await run_in_threadpool(_load_current_version_from_db)
+    await cache_current_version(version)
+    return version
+
+
+# ---------------------------------------------------------------------------
+# Redis cache helpers (async, used by endpoints and the middleware)
+# ---------------------------------------------------------------------------
+
+async def get_cached_current_version() -> Optional[str]:
+    """Cached current version. Returns None on cache miss, the sentinel string
+    NO_VERSION_SENTINEL when 'no policy configured' is cached."""
+    from computor_backend.redis_cache import get_redis_client
+    redis = await get_redis_client()
+    return await redis.get(CURRENT_VERSION_KEY)
+
+
+async def cache_current_version(version: Optional[str]) -> None:
+    from computor_backend.redis_cache import get_redis_client
+    redis = await get_redis_client()
+    await redis.set(CURRENT_VERSION_KEY, version or NO_VERSION_SENTINEL, ex=CURRENT_VERSION_TTL)
+
+
+async def invalidate_current_version_cache() -> None:
+    from computor_backend.redis_cache import get_redis_client
+    redis = await get_redis_client()
+    await redis.delete(CURRENT_VERSION_KEY)
+
+
+async def cache_consent_status(user_id: str, policy_version: str, has_consent: bool) -> None:
+    from computor_backend.redis_cache import get_redis_client
+    redis = await get_redis_client()
+    await redis.set(consent_cache_key(user_id, policy_version), "1" if has_consent else "0", ex=CONSENT_STATUS_TTL)
+
+
+async def invalidate_consent_cache(user_id: str, policy_version: str) -> None:
+    from computor_backend.redis_cache import get_redis_client
+    redis = await get_redis_client()
+    await redis.delete(consent_cache_key(user_id, policy_version))
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+class ConsentService:
+    def __init__(self, db: Session):
+        self.db = db
+        self.consents = ConsentRepository(db)
+        self.policy_versions = PolicyVersionRepository(db)
+
+    # -- gate checks -----------------------------------------------------------
+
+    def has_valid_consent(self, user_id: str, policy_version: str) -> bool:
+        """True iff the user has an active consent row for the given version."""
+        return self.consents.get_active_consent(user_id, policy_version) is not None
+
+    def get_status(self, user_id: str, required_version: Optional[str]) -> dict:
+        """Status against the version the gate enforces (pass the value from
+        resolve_current_policy_version so gate and status agree)."""
+        if required_version is None:
+            return {"required_version": None, "has_consented": True, "granted_at": None}
+        active = self.consents.get_active_consent(user_id, required_version)
+        return {
+            "required_version": required_version,
+            "has_consented": active is not None,
+            "granted_at": active.granted_at if active else None,
+        }
+
+    # -- consent lifecycle -----------------------------------------------------
+
+    def record_consent(
+        self,
+        user_id: str,
+        policy_version: str,
+        required_version: Optional[str],
+        ip_address: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        purposes: Optional[dict] = None,
+    ) -> UserConsent:
+        """Record consent for policy_version, which must equal required_version
+        (the gate-enforced version resolved by the caller)."""
+        if required_version is None:
+            raise BadRequestException("No policy version is configured; consent is not required")
+        if policy_version != required_version:
+            raise BadRequestException(f"Policy version mismatch: current version is '{required_version}'")
+        return self.consents.create_consent(
+            user_id=user_id,
+            policy_version=policy_version,
+            ip_address=ip_address,
+            user_agent=user_agent,
+            purposes=purposes,
+        )
+
+    def withdraw_consent(self, user_id: str) -> int:
+        return self.consents.withdraw(user_id)
+
+    # -- policy text (MinIO) -----------------------------------------------------
+
+    def resolve_language(self, policy: PolicyVersion, lang: Optional[str]) -> str:
+        languages = policy.languages or []
+        if lang and lang in languages:
+            return lang
+        if FALLBACK_LANGUAGE in languages:
+            return FALLBACK_LANGUAGE
+        if languages:
+            return languages[0]
+        raise NotFoundException(f"Policy version '{policy.version}' has no language variants")
+
+    async def get_policy_text(self, required_version: Optional[str], lang: Optional[str] = None) -> dict:
+        """Policy version + Markdown text, with language fallback.
+
+        The content is immutable per (version, lang), so it is cached in Redis;
+        MinIO is only hit on a cache miss.
+        """
+        if required_version is None:
+            raise NotFoundException("No policy version is configured")
+        policy = self.policy_versions.get_by_version(required_version)
+        if policy is None:
+            raise NotFoundException(f"Policy version '{required_version}' not found")
+        served_lang = self.resolve_language(policy, lang)
+
+        content = await _get_policy_text_cached(policy.version, served_lang)
+        return {
+            "version": policy.version,
+            "lang": served_lang,
+            "languages": policy.languages or [],
+            "effective_from": policy.effective_from,
+            "content": content,
+        }
+
+    # -- publishing (admin) ------------------------------------------------------
+
+    async def publish_policy_version(
+        self,
+        version: str,
+        texts: dict,
+        effective_from: Optional[datetime] = None,
+    ) -> PolicyVersion:
+        """Publish a new policy version: upload the texts to MinIO, insert the
+        append-only DB row, invalidate the current-version cache.
+
+        Write-once is enforced by the DB row (a version that exists can never
+        be published again). Orphaned objects from a previously FAILED publish
+        of the same version string may be overwritten — otherwise a failed
+        publish would burn the version name forever.
+        """
+        if self.policy_versions.get_by_version(version) is not None:
+            raise BadRequestException(f"Policy version '{version}' already exists (versions are immutable)")
+
+        from computor_backend.services.storage_service import StorageService
+        storage = StorageService()
+
+        content_hashes = {}
+        for lang, text_content in texts.items():
+            raw = text_content.encode("utf-8")
+            object_key = POLICY_OBJECT_TEMPLATE.format(version=version, lang=lang)
+            await storage.upload_file(
+                file_data=io.BytesIO(raw),
+                object_key=object_key,
+                content_type="text/markdown; charset=utf-8",
+                metadata={"policy-version": version, "lang": lang},
+            )
+            content_hashes[lang] = hashlib.sha256(raw).hexdigest()
+
+        policy = PolicyVersion(
+            version=version,
+            languages=list(texts.keys()),
+            content_hashes=content_hashes,
+            **({"effective_from": effective_from} if effective_from else {}),
+        )
+        self.db.add(policy)
+        try:
+            self.db.commit()
+        except IntegrityError:
+            # Concurrent publish of the same version string: the first commit
+            # wins. content_hashes on the winning row remain the tamper check
+            # if the loser's uploads landed last.
+            self.db.rollback()
+            raise BadRequestException(f"Policy version '{version}' already exists (versions are immutable)")
+        self.db.refresh(policy)
+
+        await invalidate_current_version_cache()
+        logger.info(f"Published policy version '{version}' (languages: {list(texts.keys())})")
+        return policy
+
+
+async def _get_policy_text_cached(version: str, lang: str) -> str:
+    from computor_backend.redis_cache import get_redis_client
+
+    cache_key = POLICY_TEXT_CACHE_KEY.format(version=version, lang=lang)
+    try:
+        redis = await get_redis_client()
+        cached = await redis.get(cache_key)
+        if cached is not None:
+            return cached
+    except Exception:
+        logger.warning("Policy text cache read failed; falling back to storage", exc_info=True)
+        redis = None
+
+    from computor_backend.services.storage_service import StorageService
+    data = await StorageService().download_file(POLICY_OBJECT_TEMPLATE.format(version=version, lang=lang))
+    content = data.decode("utf-8")
+
+    if redis is not None:
+        try:
+            await redis.set(cache_key, content, ex=POLICY_TEXT_TTL)
+        except Exception:
+            logger.warning("Policy text cache write failed", exc_info=True)
+    return content

--- a/computor-backend/src/computor_backend/middleware/__init__.py
+++ b/computor-backend/src/computor_backend/middleware/__init__.py
@@ -1,5 +1,6 @@
 """Middleware for FastAPI application."""
 from .upload_limiter import UploadSizeLimiterMiddleware
 from .maintenance import MaintenanceMiddleware
+from .consent import ConsentGateMiddleware
 
-__all__ = ["UploadSizeLimiterMiddleware", "MaintenanceMiddleware"]
+__all__ = ["UploadSizeLimiterMiddleware", "MaintenanceMiddleware", "ConsentGateMiddleware"]

--- a/computor-backend/src/computor_backend/middleware/consent.py
+++ b/computor-backend/src/computor_backend/middleware/consent.py
@@ -1,0 +1,183 @@
+"""
+GDPR consent-gate middleware.
+
+Blocks API access for AUTHENTICATED users who have not consented to the
+current privacy-policy version. Unauthenticated requests pass through — the
+per-route auth dependency handles them (no double-handling).
+
+Pure ASGI (not BaseHTTPMiddleware) to keep WebSocket upgrades working, same
+as the other middlewares in this package.
+
+REGISTRATION ORDER (server.py): authentication in this codebase is a per-route
+dependency, not middleware, so the request has no resolved Principal when any
+middleware runs. This gate therefore resolves the user itself via
+middleware/principal_lookup.py (Redis principal cache, sso_session fallback,
+api_token DB fallback). The gate must be added so it runs INSIDE CORS (so 403
+responses carry CORS headers) — see the middleware block in server.py.
+
+Gate logic per request:
+  1. Non-HTTP scope (WebSocket, lifespan) -> pass.
+  2. OPTIONS (CORS preflight) or whitelisted path -> pass.
+  3. Resolve the principal (see principal_lookup docstring for precedence and
+     sources). Unresolvable -> pass (the route's auth dependency will 401;
+     note HTTP Basic is not resolvable here and is therefore not gated).
+  4. Service principals (is_service) -> pass; automation is not a data subject
+     giving consent.
+  5. Resolve the current policy version via the same Redis-cached helper the
+     consent endpoints use (business_logic.consent.resolve_current_policy_version),
+     so gate and API always agree on the required version. No version
+     configured -> gate inactive, pass.
+  6. Check consent (Redis `consent:{user_id}:{version}`, DB fallback).
+  7. No valid consent -> 403 {"error": "consent_required", "required_version": ...}.
+
+Fail-open: on Redis/DB errors the request passes (logged). Consistent with
+MaintenanceMiddleware — an infrastructure outage must not take down the API.
+The downstream app is always invoked OUTSIDE the check's try block so
+endpoint exceptions propagate normally and are never swallowed or retried.
+"""
+
+import logging
+from typing import Optional
+
+from starlette.concurrency import run_in_threadpool
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from computor_backend.middleware.principal_lookup import resolve_principal_from_scope
+
+logger = logging.getLogger(__name__)
+
+# Paths reachable WITHOUT consent. Prefixes end with "/" so they cannot
+# accidentally cover sibling routes (e.g. "/docs" must not exempt "/documents",
+# "/ws" would exempt "/workspaces/..."; WebSockets are already skipped by
+# scope type).
+EXEMPT_PATHS_EXACT = (
+    "/",                   # HEAD / liveness probe
+    "/consent",            # POST /consent (the consent endpoints themselves)
+    "/docs",               # Swagger UI
+    "/redoc",
+    "/openapi.json",
+    "/extensions-public",
+    "/extensions-getting-started",
+)
+
+EXEMPT_PATH_PREFIXES = (
+    "/consent/",           # status / policy / withdraw / policy-versions
+    "/auth/",              # login / logout / callback / token refresh
+    "/password/",          # password reset flow
+    "/invites/",           # public invite acceptance (pre-account)
+    "/docs/",              # Swagger UI sub-paths (oauth2-redirect)
+)
+
+# GET-only exemptions: the web UI must be able to load the signed-in user's
+# identity to render the consent page itself. Exact paths, so /user-roles etc.
+# stay gated.
+EXEMPT_GET_PATHS_EXACT = (
+    "/user",
+    "/user/views",
+)
+
+
+class ConsentGateMiddleware:
+    """Pure ASGI middleware enforcing the GDPR consent gate."""
+
+    def __init__(self, app: ASGIApp, enabled: Optional[bool] = None):
+        self.app = app
+        if enabled is None:
+            from computor_backend.settings import settings
+            enabled = settings.CONSENT_GATE_ENABLED
+        self.enabled = enabled
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope["type"] != "http" or not self.enabled:
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        method = scope.get("method", "GET")
+
+        # required_version is set iff the request must be blocked. The check
+        # runs in its own try so a Redis/DB failure fails open — and the
+        # downstream app is invoked outside it, so endpoint exceptions
+        # propagate normally instead of being swallowed here.
+        required_version: Optional[str] = None
+        if method != "OPTIONS" and not self._is_exempt(path, method):
+            try:
+                required_version = await self._blocked_version(scope)
+            except Exception as e:
+                logger.warning(f"Consent gate check failed, failing open: {e}")
+
+        if required_version is not None:
+            logger.info(f"Consent gate: blocked {method} {path}")
+            response = JSONResponse(
+                status_code=403,
+                content={
+                    "error": "consent_required",
+                    "required_version": required_version,
+                },
+            )
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)
+
+    async def _blocked_version(self, scope: Scope) -> Optional[str]:
+        """The policy version the caller still has to consent to, or None to allow."""
+        principal = await resolve_principal_from_scope(scope)
+        if principal is None:
+            # Unauthenticated or unresolvable -> the route's auth dependency
+            # is responsible (401); nothing for the consent gate to do.
+            return None
+        if principal.get("is_service"):
+            return None
+
+        from computor_backend.business_logic.consent import resolve_current_policy_version
+
+        required_version = await resolve_current_policy_version()
+        if required_version is None:
+            # No policy configured -> gate inactive.
+            return None
+
+        user_id = str(principal["user_id"])
+        if await self._has_consent(user_id, required_version):
+            return None
+        return required_version
+
+    # ------------------------------------------------------------------
+    # Whitelisting
+    # ------------------------------------------------------------------
+
+    def _is_exempt(self, path: str, method: str) -> bool:
+        if path in EXEMPT_PATHS_EXACT:
+            return True
+        if method in ("GET", "HEAD") and path in EXEMPT_GET_PATHS_EXACT:
+            return True
+        return any(path.startswith(prefix) for prefix in EXEMPT_PATH_PREFIXES)
+
+    # ------------------------------------------------------------------
+    # Consent check (Redis first, DB fallback in threadpool)
+    # ------------------------------------------------------------------
+
+    async def _has_consent(self, user_id: str, required_version: str) -> bool:
+        from computor_backend.business_logic.consent import (
+            cache_consent_status,
+            consent_cache_key,
+        )
+        from computor_backend.redis_cache import get_redis_client
+
+        redis = await get_redis_client()
+        cached = await redis.get(consent_cache_key(user_id, required_version))
+        if cached is not None:
+            return cached == "1"
+
+        has_consent = await run_in_threadpool(self._db_has_consent, user_id, required_version)
+        await cache_consent_status(user_id, required_version, has_consent)
+        return has_consent
+
+    @staticmethod
+    def _db_has_consent(user_id: str, required_version: str) -> bool:
+        from computor_backend.database import get_db_session
+        from computor_backend.repositories.consent import ConsentRepository
+
+        with get_db_session() as db:
+            return ConsentRepository(db).get_active_consent(user_id, required_version) is not None

--- a/computor-backend/src/computor_backend/middleware/principal_lookup.py
+++ b/computor-backend/src/computor_backend/middleware/principal_lookup.py
@@ -1,0 +1,165 @@
+"""Best-effort principal resolution for pure-ASGI middlewares.
+
+Authentication in this codebase is a per-route dependency
+(permissions/auth.py:get_current_principal), so no middleware ever sees a
+resolved Principal. Middlewares that need the caller's identity (maintenance
+admin bypass, consent gate) resolve it here from the caches the auth system
+maintains, without running full authentication.
+
+Credential precedence mirrors permissions/auth.py:parse_authorization_header
+exactly (X-API-Token, then GLP-CREDS, then Authorization, then the
+ct_access_token cookie only when no Authorization header is present), so the
+identity a middleware acts on is the same one the route will authenticate.
+
+Resolution sources per credential type:
+- SSO tokens: principal cache; fallback to the sso_session store.
+- API tokens: principal cache; fallback to a single indexed DB lookup
+  (api_token.token_hash is a deterministic sha256).
+- GLP-CREDS: principal cache only.
+- HTTP Basic: NOT resolvable (would require password verification here);
+  callers must treat these as unresolved.
+
+Never raises: any Redis/DB failure resolves to None and is logged. Each
+caller decides what None means (maintenance: not admin; consent gate: pass
+through and let the route's auth dependency handle the request).
+"""
+
+import base64
+import hashlib
+import json
+import logging
+from typing import Optional
+
+from starlette.concurrency import run_in_threadpool
+from starlette.types import Scope
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_principal_from_scope(scope: Scope) -> Optional[dict]:
+    """Resolve the request's principal as a plain dict.
+
+    Returns at least {"user_id", "is_admin", "is_service"} on success, or
+    None when the request carries no resolvable credentials.
+    """
+    try:
+        headers = dict(scope.get("headers") or [])
+
+        api_token = _decode(headers.get(b"x-api-token"))
+        if api_token:
+            principal = await _check_principal_cache("api_token_permissions", api_token)
+            if principal is not None:
+                return principal
+            return await run_in_threadpool(_resolve_api_token_from_db, api_token)
+
+        glp_creds = _decode(headers.get(b"glp-creds"))
+        if glp_creds:
+            return await _resolve_glp_creds(glp_creds)
+
+        authorization = _decode(headers.get(b"authorization"))
+        if authorization:
+            scheme, _, param = authorization.partition(" ")
+            if scheme.lower() == "bearer" and param.strip():
+                return await _resolve_sso_token(param.strip())
+            # Basic (or unknown scheme): not resolvable without verification.
+            return None
+
+        cookie_header = _decode(headers.get(b"cookie"))
+        if cookie_header:
+            token = _extract_cookie(cookie_header, "ct_access_token")
+            if token:
+                return await _resolve_sso_token(token)
+    except Exception:
+        logger.warning("Principal resolution from scope failed", exc_info=True)
+
+    return None
+
+
+async def _resolve_sso_token(token: str) -> Optional[dict]:
+    principal = await _check_principal_cache("sso_permissions", token)
+    if principal is not None:
+        return principal
+
+    # Principal cache expired but the session may still be live in Redis.
+    from computor_backend.redis_cache import get_redis_client
+    from computor_backend.utils.token_hash import hash_token
+
+    redis = await get_redis_client()
+    session_data = await redis.get(f"sso_session:{hash_token(token)}")
+    if session_data:
+        user_id = json.loads(session_data).get("user_id")
+        if user_id:
+            # Session store carries no role info; flags default conservatively.
+            return {"user_id": str(user_id), "is_admin": False, "is_service": False}
+    return None
+
+
+async def _check_principal_cache(prefix: str, token: str) -> Optional[dict]:
+    """Same cache key format as permissions/auth.py: sha256(f"{prefix}:{token}")."""
+    from computor_backend.redis_cache import get_redis_client
+
+    cache_key = hashlib.sha256(f"{prefix}:{token}".encode()).hexdigest()
+    redis = await get_redis_client()
+    cached_data = await redis.get(cache_key)
+    if not cached_data:
+        return None
+    principal_data = json.loads(cached_data)
+    if not principal_data.get("user_id"):
+        return None
+    return principal_data
+
+
+async def _resolve_glp_creds(header_value: str) -> Optional[dict]:
+    """GLP-CREDS principal cache lookup (key: sha256(f"{url}::{token}"))."""
+    from computor_backend.redis_cache import get_redis_client
+
+    try:
+        creds = json.loads(base64.b64decode(header_value))
+        url, token = creds.get("url"), creds.get("token")
+    except Exception:
+        return None
+    if not url or not token:
+        return None
+    cache_key = hashlib.sha256(f"{url}::{token}".encode()).hexdigest()
+    redis = await get_redis_client()
+    cached_data = await redis.get(cache_key)
+    if not cached_data:
+        return None
+    principal_data = json.loads(cached_data)
+    return principal_data if principal_data.get("user_id") else None
+
+
+def _resolve_api_token_from_db(token: str) -> Optional[dict]:
+    """One indexed lookup: api_token.token_hash (deterministic sha256) -> user."""
+    from computor_backend.database import get_db_session
+    from computor_backend.model.auth import User
+    from computor_backend.model.service import ApiToken
+    from computor_backend.utils.api_token import hash_api_token, validate_token_format
+
+    if not validate_token_format(token):
+        return None
+    token_hash = hash_api_token(token)
+    with get_db_session() as db:
+        row = (
+            db.query(ApiToken.user_id, User.is_service)
+            .join(User, User.id == ApiToken.user_id)
+            .filter(ApiToken.token_hash == token_hash, ApiToken.revoked_at.is_(None))
+            .first()
+        )
+        if row is None:
+            return None
+        return {"user_id": str(row.user_id), "is_admin": False, "is_service": bool(row.is_service)}
+
+
+def _decode(value) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="ignore")
+    return value or ""
+
+
+def _extract_cookie(cookie_header: str, name: str) -> Optional[str]:
+    for part in cookie_header.split(";"):
+        part = part.strip()
+        if part.startswith(f"{name}="):
+            return part[len(name) + 1:]
+    return None

--- a/computor-backend/src/computor_backend/model/__init__.py
+++ b/computor-backend/src/computor_backend/model/__init__.py
@@ -29,6 +29,7 @@ from .artifact import SubmissionArtifact, ResultArtifact, SubmissionGrade, Submi
 from .service import Service, ServiceType, ApiToken
 from .invite import InviteLink
 from .git_server import GitServer, CourseGitBinding, CourseMemberRepository
+from .consent import PolicyVersion, UserConsent
 
 # Import all models to ensure relationships are properly set up
 from . import (
@@ -48,6 +49,7 @@ from . import (
     service,
     invite,
     git_server,
+    consent,
 )
 
 __all__ = [
@@ -120,4 +122,7 @@ __all__ = [
     'GitServer',
     'CourseGitBinding',
     'CourseMemberRepository',
+    # GDPR consent
+    'PolicyVersion',
+    'UserConsent',
 ]

--- a/computor-backend/src/computor_backend/model/consent.py
+++ b/computor-backend/src/computor_backend/model/consent.py
@@ -1,0 +1,59 @@
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Index, Text, text, func
+from sqlalchemy.dialects.postgresql import ARRAY, INET, JSONB, UUID
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class PolicyVersion(Base):
+    """A privacy-policy / data-processing-notice version.
+
+    Append-only: rows are never updated or deleted. A change to the policy
+    text = a new row. The Markdown texts themselves live in MinIO under
+    ``policies/{version}/{lang}.md`` (write-once); ``content_hashes`` stores
+    a sha256 per language for tamper-evidence.
+
+    The current version is the row with the latest ``effective_from <= now()``.
+    """
+    __tablename__ = 'policy_versions'
+
+    id = Column(UUID, primary_key=True, server_default=text("uuid_generate_v4()"))
+    version = Column(Text, nullable=False, unique=True, index=True)
+    languages = Column(ARRAY(Text), nullable=False, server_default=text("'{}'::text[]"))
+    effective_from = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    content_hashes = Column(JSONB, nullable=True)  # {lang: sha256-hex of the MinIO object}
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+
+class UserConsent(Base):
+    """Auditable record of a user's consent / acknowledgment of a policy version.
+
+    A user has valid consent for a version iff a row exists with that
+    ``policy_version`` and ``withdrawn_at IS NULL``. The partial unique index
+    makes re-consent idempotent under concurrency.
+    """
+    __tablename__ = 'user_consents'
+
+    id = Column(UUID, primary_key=True, server_default=text("uuid_generate_v4()"))
+    user_id = Column(ForeignKey('user.id', ondelete='CASCADE'), nullable=False, index=True)
+    policy_version = Column(ForeignKey('policy_versions.version', ondelete='RESTRICT'), nullable=False)
+    granted_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    withdrawn_at = Column(DateTime(timezone=True), nullable=True)
+    ip_address = Column(INET, nullable=True)  # proof of consent
+    user_agent = Column(Text, nullable=True)  # proof of consent
+    purposes = Column(JSONB, nullable=True)  # granular purposes, if any
+
+    version = Column(BigInteger, server_default=text("0"))
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        Index(
+            'user_consents_active_uq',
+            'user_id', 'policy_version',
+            unique=True,
+            postgresql_where=text('withdrawn_at IS NULL'),
+        ),
+    )
+
+    user = relationship('User', foreign_keys=[user_id])

--- a/computor-backend/src/computor_backend/repositories/consent.py
+++ b/computor-backend/src/computor_backend/repositories/consent.py
@@ -1,0 +1,99 @@
+"""Repositories for GDPR consent records and policy versions."""
+
+import logging
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from computor_backend.model.consent import PolicyVersion, UserConsent
+from computor_backend.repositories.base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class PolicyVersionRepository(BaseRepository[PolicyVersion]):
+    """Append-only repository for policy versions. No update/delete methods on purpose."""
+
+    def __init__(self, db: Session, cache=None):
+        super().__init__(db, PolicyVersion, cache)
+
+    def get_current(self) -> Optional[PolicyVersion]:
+        """The version in effect now: latest effective_from <= now()."""
+        return (
+            self.db.query(PolicyVersion)
+            .filter(PolicyVersion.effective_from <= func.now())
+            .order_by(PolicyVersion.effective_from.desc())
+            .first()
+        )
+
+    def get_by_version(self, version: str) -> Optional[PolicyVersion]:
+        return self.db.query(PolicyVersion).filter(PolicyVersion.version == version).first()
+
+    def list_versions(self) -> List[PolicyVersion]:
+        return self.db.query(PolicyVersion).order_by(PolicyVersion.effective_from.desc()).all()
+
+
+class ConsentRepository(BaseRepository[UserConsent]):
+    def __init__(self, db: Session, cache=None):
+        super().__init__(db, UserConsent, cache)
+
+    def get_active_consent(self, user_id: str, policy_version: str) -> Optional[UserConsent]:
+        """Active (non-withdrawn) consent of a user for a specific policy version."""
+        return (
+            self.db.query(UserConsent)
+            .filter(
+                UserConsent.user_id == user_id,
+                UserConsent.policy_version == policy_version,
+                UserConsent.withdrawn_at.is_(None),
+            )
+            .first()
+        )
+
+    def create_consent(
+        self,
+        user_id: str,
+        policy_version: str,
+        ip_address: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        purposes: Optional[dict] = None,
+    ) -> UserConsent:
+        """Record consent. Idempotent: a concurrent duplicate insert hits the
+        partial unique index and resolves to the already-existing active row."""
+        consent = UserConsent(
+            user_id=user_id,
+            policy_version=policy_version,
+            ip_address=ip_address,
+            user_agent=user_agent,
+            purposes=purposes,
+        )
+        self.db.add(consent)
+        try:
+            self.db.commit()
+        except IntegrityError:
+            self.db.rollback()
+            existing = self.get_active_consent(user_id, policy_version)
+            if existing is not None:
+                return existing
+            raise
+        self.db.refresh(consent)
+        return consent
+
+    def withdraw(self, user_id: str) -> int:
+        """Withdraw ALL active consents of a user (GDPR Art. 7(3)).
+
+        Returns the number of rows withdrawn. Rows are kept (withdrawn_at set)
+        for the audit trail.
+        """
+        count = (
+            self.db.query(UserConsent)
+            .filter(UserConsent.user_id == user_id, UserConsent.withdrawn_at.is_(None))
+            .update(
+                {UserConsent.withdrawn_at: datetime.now(timezone.utc)},
+                synchronize_session=False,
+            )
+        )
+        self.db.commit()
+        return count

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -250,6 +250,17 @@ async def startup_logic():
     except Exception as e:
         print(f"[STARTUP] Bootstrap services seeding failed (non-fatal): {e}")
 
+    # Publish privacy notices from data/consent/* idempotently (write-once), so a
+    # fresh system comes up with its consent notice already in force. Awaited
+    # directly (not off-thread): publishing uploads Markdown to MinIO via async
+    # storage. Best-effort; never blocks startup. Disable with
+    # CONSENT_BOOTSTRAP_ENABLED=false to keep publishing an explicit CLI/UI action.
+    from computor_backend.business_logic.bootstrap import ensure_bootstrap_policies
+    try:
+        await ensure_bootstrap_policies()
+    except Exception as e:
+        print(f"[STARTUP] Bootstrap policies seeding failed (non-fatal): {e}")
+
     # If Coder is enabled, wait for it and ensure admin user exists
     if os.environ.get("CODER_ENABLED", "false").lower() in ("true", "1"):
         from computor_backend.coder.client import CoderClient

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -79,6 +79,7 @@ from computor_backend.api.course_member_gradings import course_member_gradings_r
 from computor_backend.api.workspace_roles import workspace_roles_router
 from computor_backend.api.maintenance import maintenance_router
 from computor_backend.api.invites import invites_router
+from computor_backend.api.consent import consent_router
 from computor_backend.api.accounts import accounts_router
 from computor_backend.api.documents import documents_router
 from computor_backend.exceptions import register_exception_handlers
@@ -336,11 +337,17 @@ origins = [
 ]
 
 # Middleware order (last added = outermost = runs first):
-# 1. CORS (outermost) - ensures CORS headers on all responses including 503
+# 1. CORS (outermost) - ensures CORS headers on all responses including 503/403
 # 2. Maintenance - blocks non-GET for non-admins during maintenance
-# 3. Upload size limiter (innermost) - enforces body size limits
-from computor_backend.middleware import UploadSizeLimiterMiddleware, MaintenanceMiddleware
+# 3. Consent gate - 403 consent_required for authenticated users without
+#    current GDPR consent. Auth in this app is a per-route dependency, so the
+#    gate resolves the user itself from the Redis principal/session caches
+#    (see middleware/consent.py); it must only run inside CORS so blocked
+#    responses carry CORS headers.
+# 4. Upload size limiter (innermost) - enforces body size limits
+from computor_backend.middleware import UploadSizeLimiterMiddleware, MaintenanceMiddleware, ConsentGateMiddleware
 app.add_middleware(UploadSizeLimiterMiddleware)
+app.add_middleware(ConsentGateMiddleware)
 app.add_middleware(MaintenanceMiddleware)
 
 app.add_middleware(
@@ -549,6 +556,14 @@ app.include_router(
 app.include_router(
     invites_router,
     tags=["invites", "user-management"]
+)
+
+# GDPR consent gate endpoints. Whitelisted in ConsentGateMiddleware — they must
+# be reachable by authenticated-but-unconsented users.
+app.include_router(
+    consent_router,
+    prefix="/consent",
+    tags=["consent", "gdpr"]
 )
 
 app.include_router(

--- a/computor-backend/src/computor_backend/settings.py
+++ b/computor-backend/src/computor_backend/settings.py
@@ -28,6 +28,11 @@ class BackendSettings:
         self.API_ADMIN_EMAIL = os.environ.get("API_ADMIN_EMAIL", None)
         self.API_ADMIN_PASSWORD = os.environ.get("API_ADMIN_PASSWORD", None)
 
+        # GDPR consent gate (middleware/consent.py). The gate is additionally
+        # inactive while no policy_versions row is effective, so this flag is
+        # an operational escape hatch, not the primary rollout switch.
+        self.CONSENT_GATE_ENABLED = os.environ.get("CONSENT_GATE_ENABLED", "true").lower() in ["true", "1", "yes", "on"]
+
         # Extension public download URL
         self.EXTENSION_PUBLIC_DOWNLOAD_URL = os.environ.get("EXTENSION_PUBLIC_DOWNLOAD_URL", None)
 

--- a/computor-backend/src/computor_backend/tests/test_consent.py
+++ b/computor-backend/src/computor_backend/tests/test_consent.py
@@ -1,0 +1,383 @@
+"""Tests for the GDPR consent gate.
+
+Covers: middleware gating (whitelisted vs. not, consented vs. not),
+identity resolution (bearer / cookie / sso_session fallback / API-token /
+service principals, credential precedence), policy-version bump re-gating,
+withdrawal, Redis cache invalidation, whitelist boundary collisions
+(/docs vs /documents, /ws vs /workspaces), downstream exception passthrough,
+language fallback, and service-level version checks.
+
+The DB fallbacks are patched (the sqlite test_db fixture cannot create the
+postgres-typed tables); Redis is replaced by an in-memory fake.
+"""
+
+import asyncio
+import hashlib
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from computor_backend.business_logic import consent as consent_logic
+from computor_backend.business_logic.consent import ConsentService
+from computor_backend.exceptions import BadRequestException, NotFoundException
+from computor_backend.middleware import principal_lookup
+from computor_backend.middleware.consent import ConsentGateMiddleware
+from computor_backend.utils.token_hash import hash_token
+
+CURRENT = "2026-07-01"
+NEXT = "2026-08-01"
+TOKEN = "test-access-token"
+API_TOKEN = "ctp_" + "a" * 32
+USER = "11111111-1111-1111-1111-111111111111"
+OTHER_USER = "22222222-2222-2222-2222-222222222222"
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+
+    async def delete(self, *keys):
+        for key in keys:
+            self.store.pop(key, None)
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    redis = FakeRedis()
+
+    async def _get_redis_client():
+        return redis
+
+    monkeypatch.setattr("computor_backend.redis_cache.get_redis_client", _get_redis_client)
+    return redis
+
+
+@pytest.fixture
+def gate_state(monkeypatch):
+    """Controls what the DB fallbacks see."""
+    state = {"version": CURRENT, "consents": set(), "api_tokens": {}}  # consents: {(user_id, version)}
+    monkeypatch.setattr(
+        consent_logic, "_load_current_version_from_db",
+        lambda: state["version"],
+    )
+    monkeypatch.setattr(
+        ConsentGateMiddleware, "_db_has_consent",
+        staticmethod(lambda user_id, version: (user_id, version) in state["consents"]),
+    )
+    monkeypatch.setattr(
+        principal_lookup, "_resolve_api_token_from_db",
+        lambda token: state["api_tokens"].get(token),
+    )
+    return state
+
+
+@pytest.fixture
+def app(fake_redis, gate_state):
+    app = FastAPI()
+    app.add_middleware(ConsentGateMiddleware, enabled=True)
+    app.state.protected_calls = 0
+
+    @app.get("/protected")
+    def protected():
+        app.state.protected_calls += 1
+        return {"ok": True}
+
+    @app.get("/boom")
+    def boom():
+        app.state.protected_calls += 1
+        raise ValueError("endpoint blew up")
+
+    @app.post("/user-roles")
+    def user_roles():
+        return {"ok": True}
+
+    @app.get("/documents/some-doc")
+    def documents():
+        return {"gated": True}
+
+    @app.get("/workspaces/roles")
+    def workspace_roles():
+        return {"gated": True}
+
+    @app.get("/consent/status")
+    def consent_status():
+        return {"whitelisted": True}
+
+    @app.get("/auth/providers")
+    def auth_providers():
+        return {"whitelisted": True}
+
+    @app.get("/user")
+    def user_me():
+        return {"whitelisted": True}
+
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def seed_principal(redis, token, user_id, is_service=False, prefix="sso_permissions"):
+    key = hashlib.sha256(f"{prefix}:{token}".encode()).hexdigest()
+    redis.store[key] = json.dumps({"user_id": user_id, "is_service": is_service})
+
+
+def bearer(token=TOKEN):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Middleware gating
+# ---------------------------------------------------------------------------
+
+class TestConsentGateMiddleware:
+    def test_unauthenticated_request_passes_through(self, client):
+        # No credentials -> gate defers to the route's auth dependency.
+        assert client.get("/protected").status_code == 200
+
+    def test_unconsented_user_blocked_with_stable_body(self, client, fake_redis):
+        seed_principal(fake_redis, TOKEN, USER)
+        response = client.get("/protected", headers=bearer())
+        assert response.status_code == 403
+        assert response.json() == {"error": "consent_required", "required_version": CURRENT}
+
+    def test_consented_user_passes(self, client, fake_redis, gate_state):
+        seed_principal(fake_redis, TOKEN, USER)
+        gate_state["consents"].add((USER, CURRENT))
+        assert client.get("/protected", headers=bearer()).status_code == 200
+
+    def test_whitelisted_paths_pass_without_consent(self, client, fake_redis):
+        seed_principal(fake_redis, TOKEN, USER)
+        for path in ("/consent/status", "/auth/providers", "/user"):
+            assert client.get(path, headers=bearer()).status_code == 200, path
+
+    def test_get_only_exemption_does_not_cover_mutations_elsewhere(self, client, fake_redis):
+        seed_principal(fake_redis, TOKEN, USER)
+        # /user is exempt for GET, but /user-roles must stay gated.
+        assert client.post("/user-roles", headers=bearer()).status_code == 403
+
+    def test_docs_exemption_does_not_cover_documents_api(self, client, fake_redis):
+        seed_principal(fake_redis, TOKEN, USER)
+        assert client.get("/documents/some-doc", headers=bearer()).status_code == 403
+
+    def test_workspaces_not_exempted_by_ws(self, client, fake_redis):
+        seed_principal(fake_redis, TOKEN, USER)
+        assert client.get("/workspaces/roles", headers=bearer()).status_code == 403
+
+    def test_downstream_exception_propagates_and_runs_once(self, app, fake_redis, gate_state):
+        # The fail-open handler must not swallow endpoint errors or re-invoke
+        # the app (duplicate side effects).
+        seed_principal(fake_redis, TOKEN, USER)
+        gate_state["consents"].add((USER, CURRENT))
+        client = TestClient(app, raise_server_exceptions=True)
+        with pytest.raises(ValueError, match="endpoint blew up"):
+            client.get("/boom", headers=bearer())
+        assert app.state.protected_calls == 1
+
+    def test_options_preflight_passes(self, client, fake_redis):
+        seed_principal(fake_redis, TOKEN, USER)
+        response = client.options("/protected", headers=bearer())
+        assert response.status_code != 403
+
+    def test_cookie_token_resolution(self, client, fake_redis):
+        seed_principal(fake_redis, TOKEN, USER)
+        response = client.get("/protected", cookies={"ct_access_token": TOKEN})
+        assert response.status_code == 403
+        assert response.json()["error"] == "consent_required"
+
+    def test_sso_session_fallback_when_principal_cache_expired(self, client, fake_redis):
+        # No principal cache entry, but a live sso_session -> still resolved and gated.
+        fake_redis.store[f"sso_session:{hash_token(TOKEN)}"] = json.dumps({"user_id": USER})
+        assert client.get("/protected", headers=bearer()).status_code == 403
+
+    def test_api_token_db_fallback_gates_uncached_tokens(self, client, gate_state):
+        # No principal cache entry -> DB fallback resolves the token's user.
+        gate_state["api_tokens"][API_TOKEN] = {"user_id": USER, "is_admin": False, "is_service": False}
+        response = client.get("/protected", headers={"X-API-Token": API_TOKEN})
+        assert response.status_code == 403
+
+    def test_api_token_precedence_over_bearer(self, client, fake_redis, gate_state):
+        # Matches parse_authorization_header: X-API-Token wins over Authorization,
+        # so the gate judges the same identity the route will authenticate.
+        seed_principal(fake_redis, TOKEN, USER)  # unconsented SSO user
+        gate_state["api_tokens"][API_TOKEN] = {"user_id": OTHER_USER, "is_admin": False, "is_service": True}
+        response = client.get(
+            "/protected", headers={**bearer(), "X-API-Token": API_TOKEN}
+        )
+        assert response.status_code == 200  # service principal exempt
+
+    def test_service_principal_passes(self, client, fake_redis):
+        seed_principal(fake_redis, TOKEN, USER, is_service=True)
+        assert client.get("/protected", headers=bearer()).status_code == 200
+
+    def test_gate_inactive_without_policy_version(self, client, fake_redis, gate_state):
+        seed_principal(fake_redis, TOKEN, USER)
+        gate_state["version"] = None
+        assert client.get("/protected", headers=bearer()).status_code == 200
+
+    def test_gate_disabled_via_flag(self, fake_redis, gate_state):
+        app = FastAPI()
+        app.add_middleware(ConsentGateMiddleware, enabled=False)
+
+        @app.get("/protected")
+        def protected():
+            return {"ok": True}
+
+        seed_principal(fake_redis, TOKEN, USER)
+        assert TestClient(app).get("/protected", headers=bearer()).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Caching, version bump, withdrawal
+# ---------------------------------------------------------------------------
+
+class TestConsentCacheBehavior:
+    def test_gate_result_is_cached(self, client, fake_redis, gate_state):
+        seed_principal(fake_redis, TOKEN, USER)
+        gate_state["consents"].add((USER, CURRENT))
+        assert client.get("/protected", headers=bearer()).status_code == 200
+        assert fake_redis.store[consent_logic.consent_cache_key(USER, CURRENT)] == "1"
+
+        # DB flips, but the cached "1" still answers until invalidated.
+        gate_state["consents"].clear()
+        assert client.get("/protected", headers=bearer()).status_code == 200
+
+    def test_invalidation_regates_after_withdrawal(self, client, fake_redis, gate_state):
+        seed_principal(fake_redis, TOKEN, USER)
+        gate_state["consents"].add((USER, CURRENT))
+        assert client.get("/protected", headers=bearer()).status_code == 200
+
+        # Withdrawal: DB row withdrawn + cache invalidated (what the endpoint does).
+        gate_state["consents"].clear()
+        run(consent_logic.invalidate_consent_cache(USER, CURRENT))
+        assert client.get("/protected", headers=bearer()).status_code == 403
+
+    def test_version_bump_regates_users(self, client, fake_redis, gate_state):
+        seed_principal(fake_redis, TOKEN, USER)
+        gate_state["consents"].add((USER, CURRENT))
+        assert client.get("/protected", headers=bearer()).status_code == 200
+
+        # Publish a new version: DB changes + current-version cache invalidated.
+        # The per-user key includes the version, so the stale "1" is never read.
+        gate_state["version"] = NEXT
+        run(consent_logic.invalidate_current_version_cache())
+        response = client.get("/protected", headers=bearer())
+        assert response.status_code == 403
+        assert response.json()["required_version"] == NEXT
+
+    def test_giving_consent_unblocks_without_relogin(self, client, fake_redis, gate_state):
+        seed_principal(fake_redis, TOKEN, USER)
+        assert client.get("/protected", headers=bearer()).status_code == 403
+
+        # POST /consent: DB row created + gate cache refreshed (what the endpoint does).
+        gate_state["consents"].add((USER, CURRENT))
+        run(consent_logic.cache_consent_status(USER, CURRENT, True))
+        assert client.get("/protected", headers=bearer()).status_code == 200
+
+    def test_current_version_sentinel_round_trip(self, fake_redis):
+        run(consent_logic.cache_current_version(None))
+        assert run(consent_logic.get_cached_current_version()) == consent_logic.NO_VERSION_SENTINEL
+        run(consent_logic.cache_current_version(CURRENT))
+        assert run(consent_logic.get_cached_current_version()) == CURRENT
+
+    def test_resolve_current_version_caches_db_result(self, fake_redis, gate_state):
+        assert run(consent_logic.resolve_current_policy_version()) == CURRENT
+        # Cached now: a DB change without invalidation is not seen...
+        gate_state["version"] = NEXT
+        assert run(consent_logic.resolve_current_policy_version()) == CURRENT
+        # ...until the cache is invalidated (what publishing does).
+        run(consent_logic.invalidate_current_version_cache())
+        assert run(consent_logic.resolve_current_policy_version()) == NEXT
+
+
+# ---------------------------------------------------------------------------
+# Service-level logic (repositories mocked)
+# ---------------------------------------------------------------------------
+
+def make_service(active_consent=None):
+    service = ConsentService(MagicMock())
+    service.policy_versions = MagicMock()
+    service.consents = MagicMock()
+    service.consents.get_active_consent.return_value = active_consent
+    return service
+
+
+class TestConsentService:
+    def test_status_unconsented(self):
+        service = make_service()
+        status = service.get_status(USER, CURRENT)
+        assert status == {"required_version": CURRENT, "has_consented": False, "granted_at": None}
+
+    def test_status_consented(self):
+        active = SimpleNamespace(granted_at="2026-07-02T10:00:00Z")
+        service = make_service(active_consent=active)
+        status = service.get_status(USER, CURRENT)
+        assert status["has_consented"] is True
+        assert status["granted_at"] == active.granted_at
+
+    def test_status_without_configured_policy(self):
+        service = make_service()
+        status = service.get_status(USER, None)
+        assert status == {"required_version": None, "has_consented": True, "granted_at": None}
+
+    def test_record_consent_rejects_stale_version(self):
+        service = make_service()
+        with pytest.raises(BadRequestException):
+            service.record_consent(USER, "2020-01-01", required_version=CURRENT)
+
+    def test_record_consent_rejects_when_no_policy(self):
+        service = make_service()
+        with pytest.raises(BadRequestException):
+            service.record_consent(USER, CURRENT, required_version=None)
+
+    def test_record_consent_passes_proof_fields(self):
+        service = make_service()
+        service.record_consent(
+            USER, CURRENT, required_version=CURRENT,
+            ip_address="203.0.113.5", user_agent="pytest", purposes={"x": True},
+        )
+        service.consents.create_consent.assert_called_once_with(
+            user_id=USER,
+            policy_version=CURRENT,
+            ip_address="203.0.113.5",
+            user_agent="pytest",
+            purposes={"x": True},
+        )
+
+    def test_resolve_language_prefers_requested_then_fallback(self):
+        service = make_service()
+        policy = SimpleNamespace(version=CURRENT, languages=["de", "en"])
+        assert service.resolve_language(policy, "de") == "de"
+        assert service.resolve_language(policy, "fr") == "en"
+        policy_no_en = SimpleNamespace(version=CURRENT, languages=["de"])
+        assert service.resolve_language(policy_no_en, "fr") == "de"
+        with pytest.raises(NotFoundException):
+            service.resolve_language(SimpleNamespace(version=CURRENT, languages=[]), "de")
+
+
+class TestIpSanitization:
+    def test_valid_and_invalid_ips(self):
+        from computor_backend.api.consent import _valid_ip_or_none
+        assert _valid_ip_or_none("203.0.113.5") == "203.0.113.5"
+        assert _valid_ip_or_none(" 2001:db8::1 ") == "2001:db8::1"
+        # Client-controlled Forwarded/XFF garbage must become NULL, not a 500.
+        assert _valid_ip_or_none("unknown") is None
+        assert _valid_ip_or_none("_gazonk") is None
+        assert _valid_ip_or_none("") is None
+        assert _valid_ip_or_none(None) is None

--- a/computor-cli/src/computor_cli/cli.py
+++ b/computor-cli/src/computor_cli/cli.py
@@ -9,6 +9,7 @@ from computor_cli.documents import documents
 from computor_cli.service_cli import service
 from computor_cli.delete import delete
 from computor_cli.grading import grading
+from computor_cli.consent import consent
 
 
 @click.group()
@@ -35,6 +36,7 @@ cli.add_command(documents, "documents")
 cli.add_command(service, "service")
 cli.add_command(delete, "delete")
 cli.add_command(grading, "grading")
+cli.add_command(consent, "consent")
 
 if __name__ == '__main__':
     cli()

--- a/computor-cli/src/computor_cli/consent.py
+++ b/computor-cli/src/computor_cli/consent.py
@@ -1,0 +1,195 @@
+"""GDPR privacy-notice (consent policy) commands.
+
+Publish and inspect the versioned privacy notices that back the consent gate.
+A notice lives on disk as a ``data/consent/<version>/`` directory holding one
+``{lang}.md`` Markdown file per language (plus an optional ``policy.yaml`` for
+``effective_from`` / ``version`` / ``languages``). Publishing POSTs it to
+``/consent/policy-versions`` (admin only, append-only/write-once).
+
+See ``data/consent/README.md`` for the on-disk format.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import click
+import httpx
+import yaml
+
+from computor_cli.auth import authenticate
+
+
+def _load_policy_dir(path: Path):
+    """Read a ``data/consent/<version>/`` directory.
+
+    Returns ``(version, effective_from, texts)`` where ``texts`` maps a language
+    code to its Markdown notice. ``version`` defaults to the directory name and
+    ``effective_from`` to whatever ``policy.yaml`` declares (may be ``None``).
+    """
+    meta = {}
+    meta_file = path / "policy.yaml"
+    if meta_file.exists():
+        meta = yaml.safe_load(meta_file.read_text(encoding="utf-8")) or {}
+
+    version = str(meta.get("version") or path.name)
+    effective_from = meta.get("effective_from")
+
+    languages = meta.get("languages")
+    texts: dict[str, str] = {}
+    if languages:
+        for lang in languages:
+            f = path / f"{lang}.md"
+            if not f.exists():
+                raise click.ClickException(
+                    f"policy.yaml declares language '{lang}' but {f.name} is missing in {path}"
+                )
+            texts[lang] = f.read_text(encoding="utf-8")
+    else:
+        for f in sorted(path.glob("*.md")):
+            if f.name.lower() == "readme.md":
+                continue
+            texts[f.stem] = f.read_text(encoding="utf-8")
+
+    if not texts:
+        raise click.ClickException(f"No language Markdown files ('*.md') found in {path}")
+
+    return version, effective_from, texts
+
+
+def _err_detail(resp: httpx.Response) -> str:
+    try:
+        body = resp.json()
+        return body.get("detail") or body.get("error") or resp.text
+    except Exception:
+        return resp.text
+
+
+def _api_client(auth) -> httpx.Client:
+    """Authenticated httpx client, or a clean error if no token is configured.
+
+    ``@authenticate`` only guarantees a profile *file* exists; it may still carry
+    no token, so guard here rather than letting httpx crash on a None header.
+    """
+    if not auth.token:
+        click.secho("Not logged in. Run 'computor login' with an admin API token.", fg="red", err=True)
+        raise SystemExit(1)
+    return httpx.Client(base_url=auth.api_url, headers={"X-API-Token": auth.token}, timeout=30.0)
+
+
+@click.group()
+def consent():
+    """Publish and inspect GDPR privacy-notice (consent policy) versions."""
+    pass
+
+
+@consent.command()
+@click.argument(
+    "path",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+)
+@click.option(
+    "--effective-from",
+    "effective_from",
+    default=None,
+    help="ISO datetime when the version becomes current (overrides policy.yaml; "
+    "default: now). A future value schedules the version.",
+)
+@click.option("--dry-run", is_flag=True, help="Show what would be published without calling the API.")
+@authenticate
+def publish(path: Path, effective_from, dry_run, auth):
+    """Publish a privacy notice version from a data/consent/<version>/ directory.
+
+    Reads the {lang}.md files (and optional policy.yaml) and POSTs them to
+    /consent/policy-versions. Requires the _admin role. Append-only: a version
+    can be published exactly once; effective_from <= now re-gates every user who
+    has not consented to the new version.
+
+    \b
+    Examples:
+        ctutor consent publish data/consent/2026-07-05
+        ctutor consent publish data/consent/2026-07-05 --dry-run
+        ctutor consent publish data/consent/2026-07-05 --effective-from 2026-08-01T00:00:00Z
+    """
+    version, meta_effective, texts = _load_policy_dir(path)
+    eff = effective_from if effective_from is not None else meta_effective
+
+    payload: dict = {"version": version, "texts": texts}
+    if eff not in (None, ""):
+        payload["effective_from"] = eff.isoformat() if isinstance(eff, datetime) else str(eff)
+
+    click.echo(f"Version:        {version}")
+    click.echo(f"Effective from: {payload.get('effective_from', 'now')}")
+    click.echo(
+        "Languages:      "
+        + ", ".join(f"{lang} ({len(md)} chars)" for lang, md in sorted(texts.items()))
+    )
+
+    if dry_run:
+        click.secho("\n[dry-run] Nothing published.", fg="yellow")
+        return
+
+    try:
+        with _api_client(auth) as client:
+            resp = client.post("/consent/policy-versions", json=payload)
+    except httpx.HTTPError as e:
+        click.secho(f"Error contacting {auth.api_url}: {e}", fg="red", err=True)
+        raise SystemExit(1)
+
+    if resp.status_code == 201:
+        data = resp.json()
+        click.secho(
+            f"\n✅ Published policy version '{data['version']}' "
+            f"(effective {data.get('effective_from')}).",
+            fg="green",
+            bold=True,
+        )
+        click.echo(f"   languages: {', '.join(data.get('languages') or [])}")
+        click.secho(
+            "   ⚠  Users without consent for this version are now gated on their next request.",
+            fg="yellow",
+        )
+        return
+
+    if resp.status_code == 403:
+        click.secho("Error: publishing a policy version requires the _admin role.", fg="red", err=True)
+    elif resp.status_code == 401:
+        click.secho("Error: not authenticated. Run 'computor login' with an admin token.", fg="red", err=True)
+    else:
+        click.secho(f"Error {resp.status_code}: {_err_detail(resp)}", fg="red", err=True)
+    raise SystemExit(1)
+
+
+@consent.command("list")
+@authenticate
+def list_versions(auth):
+    """List published privacy notice versions (admin)."""
+    try:
+        with _api_client(auth) as client:
+            resp = client.get("/consent/policy-versions")
+    except httpx.HTTPError as e:
+        click.secho(f"Error contacting {auth.api_url}: {e}", fg="red", err=True)
+        raise SystemExit(1)
+
+    if resp.status_code == 403:
+        click.secho("Error: listing policy versions requires the _admin role.", fg="red", err=True)
+        raise SystemExit(1)
+    if resp.status_code != 200:
+        click.secho(f"Error {resp.status_code}: {_err_detail(resp)}", fg="red", err=True)
+        raise SystemExit(1)
+
+    versions = resp.json()
+    if not versions:
+        click.echo("No policy versions published yet.")
+        return
+
+    click.echo(f"\n{'Version':<20} {'Effective from':<28} {'Languages':<16} {'Created':<20}")
+    click.echo("-" * 84)
+    for v in versions:
+        langs = ", ".join(v.get("languages") or [])
+        created = str(v.get("created_at") or "")[:19]
+        click.echo(f"{v['version']:<20} {str(v.get('effective_from') or ''):<28} {langs:<16} {created:<20}")
+    click.echo()
+
+
+if __name__ == "__main__":
+    consent()

--- a/computor-types/src/computor_types/consent.py
+++ b/computor-types/src/computor_types/consent.py
@@ -1,0 +1,56 @@
+"""DTOs for the GDPR consent gate.
+
+Note on wording: depending on the legal basis declared in the privacy policy,
+"consent" here may be an informed acknowledgment (contract / public task /
+legitimate interest) rather than consent-as-legal-basis. The mechanism is the
+same; the UI copy must match the policy text.
+"""
+from datetime import datetime
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class ConsentStatusGet(BaseModel):
+    """Answer to 'may this user pass the consent gate right now?'."""
+    required_version: Optional[str] = Field(
+        None, description="Current policy version; null if no policy is configured (gate inactive)"
+    )
+    has_consented: bool
+    granted_at: Optional[datetime] = None
+
+
+class ConsentCreate(BaseModel):
+    policy_version: str = Field(..., description="Must match the current policy version")
+    purposes: Optional[Dict[str, bool]] = Field(
+        None, description="Granular opt-in purposes, if the policy defines any"
+    )
+
+
+class PolicyTextGet(BaseModel):
+    version: str
+    lang: str = Field(..., description="Language actually served (after fallback)")
+    languages: List[str] = Field(default_factory=list, description="Languages available for this version")
+    effective_from: Optional[datetime] = None
+    content: str = Field(..., description="Markdown text of the privacy notice")
+
+
+class PolicyVersionCreate(BaseModel):
+    """Admin: publish a new policy version (append-only; texts are write-once)."""
+    version: str = Field(..., min_length=1, max_length=64, description="e.g. 2026-07-04")
+    effective_from: Optional[datetime] = Field(
+        None, description="When this version becomes current; defaults to now. May be in the future (scheduled)."
+    )
+    texts: Dict[str, str] = Field(
+        ..., min_length=1, description="Mapping of language code -> Markdown notice text, e.g. {'de': ..., 'en': ...}"
+    )
+
+
+class PolicyVersionGet(BaseModel):
+    id: str
+    version: str
+    languages: List[str] = []
+    effective_from: datetime
+    content_hashes: Optional[Dict[str, str]] = None
+    created_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True}

--- a/computor-web/app/admin/consent/page.tsx
+++ b/computor-web/app/admin/consent/page.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import AuthenticatedLayout from '@/src/components/AuthenticatedLayout';
+import ListPageLayout, { ScrollArea } from '@/src/components/ListPageLayout';
+import PageHeader from '@/src/components/PageHeader';
+import ErrorBanner from '@/src/components/ErrorBanner';
+import Badge from '@/src/components/Badge';
+import ConfirmDialog from '@/src/components/ConfirmDialog';
+import { useAuth } from '@/src/contexts/AuthContext';
+import { usePermissions } from '@/src/hooks/usePermissions';
+import { useNotify } from '@/src/contexts/NotificationContext';
+import { api } from '@/src/utils/api';
+import type { PolicyVersionGet, PolicyVersionCreate } from 'types/generated';
+
+type LangRow = { lang: string; text: string; filename?: string };
+
+const inputCls =
+  'w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm';
+
+function fmtDate(s?: string | null): string {
+  return s ? new Date(s).toLocaleString() : '—';
+}
+
+export default function PrivacyNoticesPage() {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { isAdmin } = usePermissions();
+  const notify = useNotify();
+
+  const [versions, setVersions] = useState<PolicyVersionGet[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Publish form
+  const [version, setVersion] = useState('');
+  const [effectiveFrom, setEffectiveFrom] = useState('');
+  const [langs, setLangs] = useState<LangRow[]>([{ lang: 'en', text: '' }]);
+  const [publishing, setPublishing] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const fetchVersions = useCallback(async () => {
+    try {
+      const data = await api.get<PolicyVersionGet[]>('/consent/policy-versions');
+      setVersions(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load policy versions');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) return;
+    fetchVersions();
+  }, [authLoading, isAuthenticated, fetchVersions]);
+
+  // The current version = latest already-effective version; anything with a
+  // future effective_from is "scheduled".
+  const now = Date.now();
+  const currentVersion = versions
+    .filter((v) => new Date(v.effective_from).getTime() <= now)
+    .sort((a, b) => new Date(b.effective_from).getTime() - new Date(a.effective_from).getTime())[0]?.version;
+
+  const addLang = () => setLangs((ls) => [...ls, { lang: '', text: '' }]);
+  const removeLang = (i: number) => setLangs((ls) => ls.filter((_, idx) => idx !== i));
+  const setLangCode = (i: number, code: string) =>
+    setLangs((ls) => ls.map((l, idx) => (idx === i ? { ...l, lang: code } : l)));
+  const setLangText = (i: number, text: string) =>
+    setLangs((ls) => ls.map((l, idx) => (idx === i ? { ...l, text } : l)));
+
+  const onPickFile = async (i: number, e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const stem = file.name.replace(/\.(md|markdown)$/i, '');
+    setLangs((ls) =>
+      ls.map((l, idx) => (idx === i ? { ...l, text, filename: file.name, lang: l.lang.trim() || stem } : l)),
+    );
+    // allow re-picking the same file
+    e.target.value = '';
+  };
+
+  const filledLangs = langs.filter((l) => l.lang.trim() && l.text.trim());
+  const codes = filledLangs.map((l) => l.lang.trim());
+  const dupCode = codes.find((c, i) => codes.indexOf(c) !== i);
+  const validationError = !version.trim()
+    ? 'A version identifier is required (e.g. 2026-07-05).'
+    : filledLangs.length === 0
+    ? 'Add at least one language with notice text.'
+    : dupCode
+    ? `Duplicate language code: "${dupCode}".`
+    : versions.some((v) => v.version === version.trim())
+    ? `Version "${version.trim()}" already exists — versions are append-only.`
+    : null;
+
+  const doPublish = async () => {
+    setShowConfirm(false);
+    setPublishing(true);
+    try {
+      const texts: Record<string, string> = {};
+      for (const l of filledLangs) texts[l.lang.trim()] = l.text;
+      const body: PolicyVersionCreate = { version: version.trim(), texts };
+      if (effectiveFrom) body.effective_from = new Date(effectiveFrom).toISOString();
+      const created = await api.post<PolicyVersionGet>('/consent/policy-versions', body);
+      notify(`Published privacy notice version ${created.version}`, 'success');
+      setVersion('');
+      setEffectiveFrom('');
+      setLangs([{ lang: 'en', text: '' }]);
+      await fetchVersions();
+    } catch (err) {
+      notify(err instanceof Error ? err.message : 'Failed to publish policy version', 'error');
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  const onClickPublish = () => {
+    if (validationError) {
+      notify(validationError, 'error');
+      return;
+    }
+    setShowConfirm(true);
+  };
+
+  // Access control
+  if (!authLoading && !isAdmin) {
+    return (
+      <AuthenticatedLayout>
+        <div className="p-6">
+          <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+            <h2 className="text-lg font-semibold text-red-800">Access Denied</h2>
+            <p className="text-sm text-red-600 mt-2">Admin privileges are required to manage privacy notices.</p>
+          </div>
+        </div>
+      </AuthenticatedLayout>
+    );
+  }
+
+  return (
+    <AuthenticatedLayout>
+      <ListPageLayout>
+        <PageHeader
+          breadcrumbs={[{ label: 'Privacy Notices' }]}
+          title="Privacy Notices"
+          subtitle="Publish and review the GDPR consent policy versions that back the consent gate."
+        />
+
+        <ErrorBanner>{error}</ErrorBanner>
+
+        <ScrollArea className="space-y-6">
+          {/* Warning */}
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+            <h2 className="text-sm font-semibold text-amber-900 mb-1">Before you publish</h2>
+            <ul className="text-sm text-amber-800 space-y-1 list-disc list-inside">
+              <li>Versions are <strong>append-only</strong> — a version can be published once. Bump the version for any change.</li>
+              <li>Publishing with an effective date of now <strong>re-gates every user</strong> who hasn’t consented to the new version.</li>
+              <li>The VS Code extension has no consent handling yet — unconsented users will get errors there.</li>
+            </ul>
+          </div>
+
+          {/* Published versions */}
+          <div className="bg-white rounded-lg shadow border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Published versions</h2>
+            {loading ? (
+              <div className="text-sm text-gray-500">Loading…</div>
+            ) : versions.length === 0 ? (
+              <div className="text-sm text-gray-500 border border-dashed border-gray-300 rounded-lg p-6 text-center">
+                No privacy notice has been published yet. The consent gate stays inactive until the first version is published.
+              </div>
+            ) : (
+              <div className="border border-gray-200 rounded-lg divide-y">
+                {versions.map((v) => {
+                  const scheduled = new Date(v.effective_from).getTime() > now;
+                  const isCurrent = v.version === currentVersion;
+                  return (
+                    <div key={v.id} className="flex items-center justify-between px-4 py-3 gap-4">
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium text-gray-900 flex items-center gap-2">
+                          <span className="font-mono">{v.version}</span>
+                          {isCurrent && <Badge color="green" pill>current</Badge>}
+                          {scheduled && <Badge color="blue" pill>scheduled</Badge>}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          effective {fmtDate(v.effective_from)} · languages: {(v.languages || []).join(', ') || '—'} · published {fmtDate(v.created_at)}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Publish new */}
+          <div className="bg-white rounded-lg shadow border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Publish a new version</h2>
+
+            <div className="flex flex-wrap gap-4 mb-4">
+              <div className="flex-1 min-w-[12rem]">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Version</label>
+                <input
+                  className={inputCls}
+                  value={version}
+                  onChange={(e) => setVersion(e.target.value)}
+                  placeholder="e.g. 2026-07-05"
+                />
+              </div>
+              <div className="flex-1 min-w-[12rem]">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Effective from</label>
+                <input
+                  type="datetime-local"
+                  className={inputCls}
+                  value={effectiveFrom}
+                  onChange={(e) => setEffectiveFrom(e.target.value)}
+                />
+                <p className="text-xs text-gray-500 mt-1">Leave empty to become current immediately. A future date schedules it.</p>
+              </div>
+            </div>
+
+            <label className="block text-sm font-medium text-gray-700 mb-2">Notice text (Markdown, one per language)</label>
+            <div className="space-y-4">
+              {langs.map((l, i) => (
+                <div key={i} className="border border-gray-200 rounded-lg p-3">
+                  <div className="flex flex-wrap items-center gap-3 mb-2">
+                    <input
+                      className="w-28 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
+                      value={l.lang}
+                      onChange={(e) => setLangCode(i, e.target.value)}
+                      placeholder="lang (en)"
+                      aria-label="Language code"
+                    />
+                    <label className="px-3 py-2 text-sm font-medium text-blue-700 bg-blue-50 rounded-lg hover:bg-blue-100 cursor-pointer">
+                      {l.filename ? `Replace ${l.filename}` : 'Upload .md'}
+                      <input type="file" accept=".md,.markdown,text/markdown" className="hidden" onChange={(e) => onPickFile(i, e)} />
+                    </label>
+                    {langs.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => removeLang(i)}
+                        className="ml-auto text-sm text-red-600 hover:underline"
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                  <textarea
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm font-mono"
+                    rows={8}
+                    value={l.text}
+                    onChange={(e) => setLangText(i, e.target.value)}
+                    placeholder={'# Privacy notice\n\nUpload a .md file or paste the Markdown here…'}
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-3 flex items-center gap-4">
+              <button type="button" onClick={addLang} className="text-sm text-blue-600 hover:underline">
+                + Add language
+              </button>
+            </div>
+
+            <div className="mt-5 flex items-center gap-4">
+              <button
+                type="button"
+                onClick={onClickPublish}
+                disabled={publishing || !!validationError}
+                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              >
+                {publishing ? 'Publishing…' : 'Publish version'}
+              </button>
+              {validationError && <span className="text-sm text-gray-500">{validationError}</span>}
+            </div>
+          </div>
+        </ScrollArea>
+
+        <ConfirmDialog
+          open={showConfirm}
+          title="Publish privacy notice"
+          message={
+            effectiveFrom
+              ? `Publish version "${version.trim()}"? It becomes current at the scheduled time; users are re-gated then.`
+              : `Publish version "${version.trim()}"? It becomes current immediately and re-gates every user who has not consented to it. This cannot be undone (versions are append-only).`
+          }
+          confirmLabel="Publish"
+          variant="danger"
+          onConfirm={doPublish}
+          onCancel={() => setShowConfirm(false)}
+        />
+      </ListPageLayout>
+    </AuthenticatedLayout>
+  );
+}

--- a/computor-web/app/consent/page.tsx
+++ b/computor-web/app/consent/page.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { useAuth } from '@/src/contexts/AuthContext';
+import { API_BASE_URL, CONSENT_REDIRECT_KEY, apiGet, apiPost } from '@/src/utils/apiClient';
+import type { ConsentStatus, PolicyText } from '@/src/types/consent';
+
+// Deliberately a standalone page (no AuthenticatedLayout): the sidebar/topbar
+// fire API calls that are blocked by the consent gate, and this page must work
+// for exactly those users.
+export default function ConsentPage() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+
+  const [status, setStatus] = useState<ConsentStatus | null>(null);
+  const [policy, setPolicy] = useState<PolicyText | null>(null);
+  const [accepted, setAccepted] = useState(false); // MUST default to false (no pre-ticked boxes)
+  const [submitting, setSubmitting] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reviewMode, setReviewMode] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.push('/login');
+    }
+  }, [isAuthenticated, authLoading, router]);
+
+  const continueToApp = useCallback(() => {
+    const target = sessionStorage.getItem(CONSENT_REDIRECT_KEY) || '/dashboard';
+    sessionStorage.removeItem(CONSENT_REDIRECT_KEY);
+    router.replace(target);
+  }, [router]);
+
+  const fetchPolicy = useCallback(async (lang?: string) => {
+    const url = lang
+      ? `${API_BASE_URL}/consent/policy?lang=${encodeURIComponent(lang)}`
+      : `${API_BASE_URL}/consent/policy`;
+    const response = await apiGet(url);
+    if (!response.ok) {
+      throw new Error(`Failed to load the privacy notice (status ${response.status})`);
+    }
+    setPolicy(await response.json());
+  }, []);
+
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) return;
+
+    const review = new URLSearchParams(window.location.search).has('review');
+    setReviewMode(review);
+
+    async function init() {
+      try {
+        const statusResponse = await apiGet(`${API_BASE_URL}/consent/status`);
+        if (!statusResponse.ok) {
+          throw new Error(`Failed to load consent status (status ${statusResponse.status})`);
+        }
+        const statusData: ConsentStatus = await statusResponse.json();
+        setStatus(statusData);
+
+        // Nothing to consent to, or already consented and not reviewing:
+        // send the user back to where they came from.
+        if (!statusData.required_version || (statusData.has_consented && !review)) {
+          continueToApp();
+          return;
+        }
+
+        await fetchPolicy();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setLoading(false);
+      }
+    }
+    init();
+  }, [authLoading, isAuthenticated, continueToApp, fetchPolicy]);
+
+  const handleLanguageChange = async (lang: string) => {
+    try {
+      await fetchPolicy(lang);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!accepted || !status?.required_version) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await apiPost(`${API_BASE_URL}/consent`, {
+        policy_version: status.required_version,
+      });
+      if (response.status === 400) {
+        // The policy version changed while the page was open — the backend
+        // rejects the stale version. Reload the new notice for re-review.
+        const statusResponse = await apiGet(`${API_BASE_URL}/consent/status`);
+        if (statusResponse.ok) {
+          setStatus(await statusResponse.json());
+        }
+        await fetchPolicy(policy?.lang);
+        setAccepted(false);
+        throw new Error(
+          'The privacy notice was updated while you were reading it. Please review and accept the new version.'
+        );
+      }
+      if (!response.ok) {
+        throw new Error(`Failed to record consent (status ${response.status})`);
+      }
+      continueToApp();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-10 px-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Data Processing &amp; Privacy</h1>
+          {status?.required_version && (
+            <p className="mt-1 text-sm text-gray-500">
+              Privacy notice version <span className="font-mono">{status.required_version}</span>
+            </p>
+          )}
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p className="text-sm text-red-800">{error}</p>
+          </div>
+        )}
+
+        {reviewMode && status?.has_consented && (
+          <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+            <p className="text-sm text-green-800">
+              You accepted this privacy notice
+              {status.granted_at ? ` on ${new Date(status.granted_at).toLocaleString()}` : ''}. You
+              can withdraw your consent at any time in{' '}
+              <a href="/settings" className="underline font-medium">Settings</a>.
+            </p>
+          </div>
+        )}
+
+        <div className="bg-white rounded-lg shadow border border-gray-200 p-6 space-y-4">
+          <h2 className="text-xl font-semibold text-gray-900">How we process your data</h2>
+          <p className="text-gray-700">
+            We process your personal data to deliver the courses (Lehrveranstaltungen) in which
+            this platform is used — for example your name, e-mail address, course enrollments and
+            submissions. The details are described in the privacy notice below.
+          </p>
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <p className="text-sm text-blue-900">
+              <span className="font-semibold">Cookies:</span> this platform only uses strictly
+              necessary cookies for authentication (single sign-on session). These are required
+              for the platform to function and do not need your consent; they are listed here for
+              your information only.
+            </p>
+          </div>
+        </div>
+
+        <div className="bg-white rounded-lg shadow border border-gray-200 p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold text-gray-900">Privacy notice</h2>
+            {policy && policy.languages.length > 1 && (
+              <div className="flex gap-2">
+                {policy.languages.map((lang) => (
+                  <button
+                    key={lang}
+                    onClick={() => handleLanguageChange(lang)}
+                    className={`px-3 py-1 text-sm rounded-md border ${
+                      policy.lang === lang
+                        ? 'bg-blue-600 text-white border-blue-600'
+                        : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+                    }`}
+                  >
+                    {lang.toUpperCase()}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          {policy ? (
+            <div className="max-h-96 overflow-y-auto border border-gray-200 rounded-lg p-4">
+              <div className="prose prose-slate max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{policy.content}</ReactMarkdown>
+              </div>
+            </div>
+          ) : (
+            <p className="text-gray-600">The privacy notice could not be loaded.</p>
+          )}
+        </div>
+
+        {!(reviewMode && status?.has_consented) && (
+          <div className="bg-white rounded-lg shadow border border-gray-200 p-6 space-y-4">
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={accepted}
+                onChange={(e) => setAccepted(e.target.checked)}
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="text-gray-700">
+                I have read the privacy notice (version{' '}
+                <span className="font-mono">{status?.required_version}</span>) and agree to the
+                processing of my personal data as described in it.
+              </span>
+            </label>
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-gray-500">
+                You can withdraw your consent at any time in Settings.
+              </p>
+              <button
+                onClick={handleSubmit}
+                disabled={!accepted || submitting}
+                className="px-6 py-2 rounded-lg font-medium bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
+              >
+                {submitting ? 'Saving...' : 'Agree and continue'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/computor-web/app/settings/page.tsx
+++ b/computor-web/app/settings/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { api } from '@/src/utils/api';
 import { useAuth } from '@/src/contexts/AuthContext';
 import { usePermissions } from '@/src/hooks/usePermissions';
@@ -11,6 +12,7 @@ import ErrorBanner from '@/src/components/ErrorBanner';
 import ConfirmDeleteDialog from '@/src/components/ConfirmDeleteDialog';
 import { inputCls } from '@/src/components/FormPanel';
 import type { ApiTokenGet, ApiTokenCreateResponse, AccountGet } from 'types/generated';
+import type { ConsentStatus } from '@/src/types/consent';
 
 const KC_URL = process.env.NEXT_PUBLIC_KEYCLOAK_URL;
 const KC_REALM = process.env.NEXT_PUBLIC_KEYCLOAK_REALM || 'computor';
@@ -44,6 +46,7 @@ function fmtDate(s?: string | null): string {
 }
 
 export default function SettingsPage() {
+  const router = useRouter();
   const { user: authUser, isAuthenticated, isLoading: authLoading } = useAuth();
   const { isAdmin } = usePermissions();
 
@@ -51,6 +54,12 @@ export default function SettingsPage() {
   const [accounts, setAccounts] = useState<AccountRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Consent / privacy
+  const [consentStatus, setConsentStatus] = useState<ConsentStatus | null>(null);
+  const [consentLoading, setConsentLoading] = useState(true);
+  const [withdrawing, setWithdrawing] = useState(false);
+  const [confirmWithdraw, setConfirmWithdraw] = useState(false);
 
   // Token creation
   const [newName, setNewName] = useState('');
@@ -107,6 +116,33 @@ export default function SettingsPage() {
   }
 
   const activeTokens = tokens.filter((t) => !t.revoked_at);
+
+  useEffect(() => {
+    async function fetchConsentStatus() {
+      try {
+        setConsentStatus(await api.get<ConsentStatus>('/consent/status'));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load consent status');
+      } finally {
+        setConsentLoading(false);
+      }
+    }
+    fetchConsentStatus();
+  }, []);
+
+  const handleWithdraw = async () => {
+    setWithdrawing(true);
+    setError(null);
+    try {
+      await api.post('/consent/withdraw');
+      // Access is gated again; the consent page is the only place left to go.
+      router.push('/consent');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to withdraw consent');
+      setWithdrawing(false);
+      setConfirmWithdraw(false);
+    }
+  };
 
   return (
     <AuthenticatedLayout>
@@ -263,6 +299,72 @@ export default function SettingsPage() {
                       )}
                     </div>
                   ))}
+                </div>
+              )}
+            </Section>
+
+            {/* Privacy & Consent */}
+            <Section
+              title="Privacy & Consent"
+              description="Review the current privacy notice and manage your consent."
+            >
+              {consentLoading ? (
+                <div className="text-sm text-gray-500">Loading…</div>
+              ) : !consentStatus?.required_version ? (
+                <div className="text-sm text-gray-500">No privacy notice is currently configured.</div>
+              ) : (
+                <div className="space-y-4">
+                  <div className="text-sm text-gray-700 space-y-1">
+                    <p>
+                      Privacy notice version:{' '}
+                      <span className="font-mono">{consentStatus.required_version}</span>
+                    </p>
+                    {consentStatus.has_consented && consentStatus.granted_at ? (
+                      <p>Consent given on {new Date(consentStatus.granted_at).toLocaleString()}.</p>
+                    ) : (
+                      <p className="text-amber-700">You have not consented to the current privacy notice.</p>
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-3">
+                    <a
+                      href="/consent?review=1"
+                      className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 text-sm font-medium"
+                    >
+                      View privacy notice
+                    </a>
+
+                    {consentStatus.has_consented && (
+                      confirmWithdraw ? (
+                        <div className="flex flex-wrap items-center gap-3">
+                          <span className="text-sm text-gray-600">
+                            Withdrawing consent will block access to the platform until you consent again. Continue?
+                          </span>
+                          <button
+                            onClick={handleWithdraw}
+                            disabled={withdrawing}
+                            className="px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:bg-gray-300 text-sm font-medium"
+                          >
+                            {withdrawing ? 'Withdrawing…' : 'Yes, withdraw'}
+                          </button>
+                          <button
+                            onClick={() => setConfirmWithdraw(false)}
+                            disabled={withdrawing}
+                            className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 text-sm font-medium"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setConfirmWithdraw(true)}
+                          className="px-4 py-2 rounded-lg border border-red-300 text-red-700 hover:bg-red-50 text-sm font-medium"
+                        >
+                          Withdraw consent
+                        </button>
+                      )
+                    )}
+                  </div>
                 </div>
               )}
             </Section>

--- a/computor-web/src/api/client.ts
+++ b/computor-web/src/api/client.ts
@@ -1,5 +1,5 @@
 import { IAuthProvider } from '../interfaces/IAuthProvider';
-import { API_BASE_URL } from '../utils/apiClient';
+import { API_BASE_URL, isConsentRequired, redirectToConsent } from '../utils/apiClient';
 import { refreshOnce } from '../utils/tokenRefresh';
 import { clearStoredSession } from '../services/authStorage';
 
@@ -65,6 +65,11 @@ class APIClient {
    */
   private async handleResponse<T>(response: Response, method?: string): Promise<T> {
     if (!response.ok) {
+      // Consent gate: route to /consent, remembering the current route.
+      if (await isConsentRequired(response)) {
+        redirectToConsent();
+      }
+
       const error = await response.text();
       throw new Error(error || `HTTP error! status: ${response.status}`);
     }

--- a/computor-web/src/components/AuthenticatedLayout.tsx
+++ b/computor-web/src/components/AuthenticatedLayout.tsx
@@ -6,6 +6,14 @@ import { useAuth } from '../contexts/AuthContext';
 import Sidebar from './Sidebar';
 import TopBar from './TopBar';
 import MaintenanceBanner from './MaintenanceBanner';
+import { API_BASE_URL, apiGet, redirectToConsent } from '../utils/apiClient';
+import type { ConsentStatus } from '../types/consent';
+
+// Consent bootstrap check runs once per authenticated session per page load;
+// mid-session changes (withdrawal, policy version bump) are caught by the 403
+// consent_required interceptor in apiClient. Reset on logout so a different
+// user signing in without a full reload is checked again.
+let consentChecked = false;
 
 export default function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -13,9 +21,26 @@ export default function AuthenticatedLayout({ children }: { children: React.Reac
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
+      consentChecked = false;
       router.push('/login');
     }
   }, [isAuthenticated, isLoading, router]);
+
+  useEffect(() => {
+    if (isLoading || !isAuthenticated || consentChecked) return;
+    consentChecked = true;
+    apiGet(`${API_BASE_URL}/consent/status`)
+      .then(async (response) => {
+        if (!response.ok) return;
+        const status: ConsentStatus = await response.json();
+        if (status.required_version && !status.has_consented) {
+          redirectToConsent();
+        }
+      })
+      .catch(() => {
+        // Best-effort: the consent interceptor gates on the next API call anyway.
+      });
+  }, [isAuthenticated, isLoading]);
 
   if (isLoading) {
     return (

--- a/computor-web/src/components/Sidebar.tsx
+++ b/computor-web/src/components/Sidebar.tsx
@@ -85,6 +85,7 @@ const adminNavigation: NavItem[] = [
     icon: 'admin',
     subItems: [
       { id: 'sys-maintenance', label: 'Maintenance', path: '/admin/maintenance' },
+      { id: 'sys-consent', label: 'Privacy Notices', path: '/admin/consent' },
     ],
   },
 ];

--- a/computor-web/src/generated/types/common.ts
+++ b/computor-web/src/generated/types/common.ts
@@ -602,6 +602,43 @@ export interface CourseContentConfig {
 }
 
 /**
+ * Portable per-course git configuration for a deployment file.
+ * 
+ * Resolved server-side into a ``CourseGitBinding`` when the course is deployed
+ * (CLI, web upload, or VSCode). A git server is referenced by ``provider``
+ * (+ ``base_url`` for external instances) instead of a machine-specific
+ * ``git_server_id`` UUID, so the file stays portable across systems.
+ * 
+ * - In-system managed **Forgejo**: ``provider: forgejo`` (no ``base_url``);
+ * credentials are the system server's — nothing lives here.
+ * - External **GitLab**: ``provider: gitlab`` + ``base_url``; the course brings
+ * its own ``parent_group_id`` (its GitLab group is created under it) and
+ * ``token`` (a group access token, stored encrypted ON THE BINDING).
+ * - Pure **download**: ``delivery: download`` (with a ``provider`` to host the
+ * template archive, or none for an unbound course).
+ */
+export interface CourseGitConfig {
+  /** Assignment delivery: 'git' (fork/clone) or 'download' (archive) */
+  delivery?: "git" | "download";
+  /** Git provider. 'forgejo' with no base_url = the in-system managed Forgejo. */
+  provider?: "forgejo" | "gitlab" | null;
+  /** Git server base URL. Required for external GitLab; omit for the in-system managed Forgejo. */
+  base_url?: string | null;
+  /** GitLab parent group id/path the course group is created under (GitLab only). */
+  parent_group_id?: string | null;
+  /** GitLab group access token bound to this course (GitLab only; stored encrypted). Supports ${ENV_VAR} interpolation at deploy time. */
+  token?: string | null;
+  /** Explicit template repo/project ref (optional; auto-derived for managed servers). */
+  template_repo?: string | null;
+  /** Explicit template clone/web URL (optional). */
+  template_url?: string | null;
+  /** Default branch of the template (defaults to 'main'). */
+  default_branch?: string | null;
+  /** Allowed student-repo hosting modes: subset of ['managed', 'external', 'download']. */
+  student_repo_modes?: string[];
+}
+
+/**
  * Course configuration.
  */
 export interface CourseConfig {
@@ -621,6 +658,8 @@ export interface CourseConfig {
   content_types?: CourseContentTypeConfig[] | null;
   /** Course contents hierarchy (assignments, units, etc.) */
   contents?: CourseContentConfig[] | null;
+  /** Optional git configuration, bound to the course at deploy time. Omit to create an unbound course (configure git later in the UI). */
+  git?: CourseGitConfig | null;
   /** Course-specific settings */
   settings?: Record<string, unknown> | null;
 }
@@ -645,6 +684,8 @@ export interface HierarchicalCourseConfig {
   content_types?: CourseContentTypeConfig[] | null;
   /** Course contents hierarchy (assignments, units, etc.) */
   contents?: CourseContentConfig[] | null;
+  /** Optional git configuration, bound to the course at deploy time. Omit to create an unbound course (configure git later in the UI). */
+  git?: CourseGitConfig | null;
   /** Course-specific settings */
   settings?: Record<string, unknown> | null;
 }
@@ -1082,6 +1123,55 @@ export interface ComputorMeta {
   content?: ContentMetadata | null;
   /** Assignment-specific properties */
   properties?: ComputorMetaProperties | null;
+}
+
+/**
+ * Answer to 'may this user pass the consent gate right now?'.
+ */
+export interface ConsentStatusGet {
+  /** Current policy version; null if no policy is configured (gate inactive) */
+  required_version?: string | null;
+  has_consented: boolean;
+  granted_at?: string | null;
+}
+
+export interface ConsentCreate {
+  /** Must match the current policy version */
+  policy_version: string;
+  /** Granular opt-in purposes, if the policy defines any */
+  purposes?: Record<string, boolean> | null;
+}
+
+export interface PolicyTextGet {
+  version: string;
+  /** Language actually served (after fallback) */
+  lang: string;
+  /** Languages available for this version */
+  languages?: string[];
+  effective_from?: string | null;
+  /** Markdown text of the privacy notice */
+  content: string;
+}
+
+/**
+ * Admin: publish a new policy version (append-only; texts are write-once).
+ */
+export interface PolicyVersionCreate {
+  /** e.g. 2026-07-04 */
+  version: string;
+  /** When this version becomes current; defaults to now. May be in the future (scheduled). */
+  effective_from?: string | null;
+  /** Mapping of language code -> Markdown notice text, e.g. {'de': ..., 'en': ...} */
+  texts: Record<string, string>;
+}
+
+export interface PolicyVersionGet {
+  id: string;
+  version: string;
+  languages?: string[];
+  effective_from: string;
+  content_hashes?: Record<string, string> | null;
+  created_at?: string | null;
 }
 
 /**

--- a/computor-web/src/types/consent.ts
+++ b/computor-web/src/types/consent.ts
@@ -1,0 +1,16 @@
+// Shapes of the backend consent endpoints (ConsentStatusGet / PolicyTextGet
+// in computor-types/src/computor_types/consent.py).
+
+export interface ConsentStatus {
+  required_version: string | null;
+  has_consented: boolean;
+  granted_at: string | null;
+}
+
+export interface PolicyText {
+  version: string;
+  lang: string;
+  languages: string[];
+  effective_from: string | null;
+  content: string;
+}

--- a/computor-web/src/utils/apiClient.ts
+++ b/computor-web/src/utils/apiClient.ts
@@ -28,6 +28,53 @@ async function refreshAccessToken(): Promise<RefreshOutcome> {
   }
 }
 
+export const CONSENT_REDIRECT_KEY = 'consent_redirect';
+
+/**
+ * Navigate to the consent page, remembering the originally requested route
+ * so the consent page can return the user there afterwards. No-op on the
+ * consent page itself and during SSR. Shared by both HTTP layers and the
+ * AuthenticatedLayout bootstrap check.
+ */
+export function redirectToConsent(): void {
+  if (typeof window === 'undefined' || window.location.pathname.startsWith('/consent')) {
+    return;
+  }
+  sessionStorage.setItem(
+    CONSENT_REDIRECT_KEY,
+    window.location.pathname + window.location.search
+  );
+  window.location.href = '/consent';
+}
+
+/**
+ * True iff the response is the backend consent gate's stable 403 body
+ * {"error": "consent_required", ...}. Only JSON responses are parsed
+ * (via clone(), so the caller can still read the body).
+ */
+export async function isConsentRequired(response: Response): Promise<boolean> {
+  if (response.status !== 403) return false;
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) return false;
+  try {
+    const body = await response.clone().json();
+    return body?.error === 'consent_required';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Global consent interceptor: any consent-gate 403 routes the user to
+ * /consent. The 403 response is still returned to the caller.
+ */
+async function interceptConsentRequired(response: Response): Promise<Response> {
+  if (await isConsentRequired(response)) {
+    redirectToConsent();
+  }
+  return response;
+}
+
 /**
  * Enhanced fetch with automatic token refresh on 401
  *
@@ -55,13 +102,37 @@ export async function apiFetch(
   if (response.status === 401 && retryOn401) {
     const outcome = await refreshOnce(refreshAccessToken);
     if (outcome === 'refreshed') {
-      return fetch(url, fetchOptions);
+      return interceptConsentRequired(await fetch(url, fetchOptions));
     }
     // Refresh failed or backend unreachable: return the original 401 —
     // the AuthContext/pages decide whether that means logout.
     return response;
   }
 
-  return response;
+  return interceptConsentRequired(response);
+}
+
+/**
+ * GET helper over apiFetch — returns the raw Response (token refresh and the
+ * consent-gate interceptor are applied by apiFetch).
+ */
+export function apiGet(url: string, options: RequestInit = {}): Promise<Response> {
+  return apiFetch(url, { ...options, method: 'GET' });
+}
+
+/**
+ * POST helper over apiFetch. A plain-object body is JSON-encoded; pass a string
+ * or FormData through untouched. Returns the raw Response.
+ */
+export function apiPost(url: string, body?: unknown, options: RequestInit = {}): Promise<Response> {
+  const isRaw = body === undefined || typeof body === 'string' || body instanceof FormData;
+  return apiFetch(url, {
+    ...options,
+    method: 'POST',
+    headers: isRaw
+      ? options.headers ?? {}
+      : { 'Content-Type': 'application/json', ...(options.headers ?? {}) },
+    body: isRaw ? (body as BodyInit | undefined) : JSON.stringify(body),
+  });
 }
 

--- a/data/consent/.gitignore
+++ b/data/consent/.gitignore
@@ -1,0 +1,7 @@
+# Privacy-notice version directories (e.g. 2026-07-05/) are deployment-specific:
+# they hold the actual notice text and are auto-published at startup. Keep them
+# local — do NOT commit them.
+#
+# This directory itself stays tracked (.gitkeep + README.md) so its location and
+# expected format remain discoverable. See README.md for the layout.
+/*/

--- a/data/consent/README.md
+++ b/data/consent/README.md
@@ -1,0 +1,52 @@
+# Privacy notices (GDPR consent policy versions)
+
+This directory holds the **privacy-notice / consent policy versions** that back
+the consent gate (`computor-backend` `middleware/consent.py`). It sits parallel
+to `data/deployments/` but is **not** applied at startup — publishing a notice
+immediately re-gates every user, so it is always an explicit action via:
+
+- the CLI: `ctutor consent publish data/consent/<version>` , or
+- the web UI: **System → Privacy Notices → Publish** (admins only).
+
+Both call `POST /consent/policy-versions` (admin), which uploads the Markdown to
+MinIO (`policies/{version}/{lang}.md`) and inserts an **append-only** row.
+
+## Layout
+
+One directory per version. The directory name is the default version string.
+
+```
+data/consent/
+  2026-07-05/
+    policy.yaml        # optional metadata (see below)
+    en.md              # the notice, one Markdown file per language ({lang}.md)
+    de.md
+```
+
+### `policy.yaml` (all fields optional)
+
+```yaml
+# version: "2026-07-05"     # defaults to the directory name if omitted
+effective_from: null         # null / omitted = becomes current immediately (now).
+                             # An ISO datetime in the FUTURE schedules the version.
+# languages: [en, de]        # defaults to every {lang}.md present in the directory
+```
+
+### Language files
+
+Each `{lang}.md` is the full Markdown privacy notice for that language code
+(`en.md`, `de.md`, …). At least one is required. `README.md` is ignored.
+
+## Rules & cautions
+
+- **Append-only / write-once.** A `version` can be published exactly once; the
+  server rejects re-publishing an existing version. To change the text, publish
+  a **new** version (e.g. bump the date). Users must re-consent after a bump.
+- **Publishing gates users.** With `effective_from <= now`, every user who has
+  not consented to the new version is redirected to `/consent` on their next
+  request (within the ≤300 s cache TTL). Bump only for material changes.
+- **VS Code extension** has no consent handling yet — publishing a notice will
+  cause 403s there for unconsented users. Confirm the extension is handled
+  before publishing in production.
+- **Legal basis / wording** must match the policy text — see
+  `docs/consent-gate.md` before publishing the first production version.

--- a/docs/consent-gate.md
+++ b/docs/consent-gate.md
@@ -1,0 +1,175 @@
+# GDPR Consent Gate
+
+Blocks API access for authenticated users who have not consented to
+(acknowledged) the current privacy-policy version. Implements informed,
+versioned, auditable, withdrawable consent (GDPR Art. 7).
+
+## Legal-basis note — read before changing UI copy
+
+- **Strictly necessary authentication cookies** (Keycloak SSO session,
+  `ct_access_token`/`ct_refresh_token`) do **not** require consent under
+  ePrivacy/GDPR. The consent page presents them as **information only** —
+  never as an opt-in checkbox.
+- Whether this gate records *consent as a legal basis* (Art. 6(1)(a)) or an
+  *informed acknowledgment* of processing based on contract / public task /
+  legitimate interest depends on what the privacy-policy text declares. The
+  mechanism is identical; **the UI wording must match the policy text**.
+  Confirm the exact legal basis and wording with whoever owns the privacy
+  policy before the first production policy version is published.
+
+## Data model
+
+Migration: `computor-backend/.../alembic/versions/dd2e3f4a5b6c_add_consent_tables.py`
+
+- **`policy_versions`** — append-only, immutable. One row per version;
+  `languages text[]` lists the available language variants, `content_hashes`
+  stores a sha256 per language for tamper-evidence. The **current** version is
+  the latest row with `effective_from <= now()` — set `effective_from` in the
+  future to schedule a policy. Never UPDATE/DELETE rows; a change = a new row.
+- **`user_consents`** — audit trail (who, when, which version, ip, user-agent,
+  optional granular `purposes`). Valid consent = row with the current
+  `policy_version` and `withdrawn_at IS NULL`. Partial unique index
+  `(user_id, policy_version) WHERE withdrawn_at IS NULL` makes concurrent
+  first-consent idempotent. Withdrawal sets `withdrawn_at` (row is kept).
+  `policy_version` is a FK to `policy_versions.version`.
+
+**Deviation from the original task spec:** `user_consents.user_id` is the
+internal `user.id` UUID (FK, `ON DELETE CASCADE`), not the Keycloak `sub`.
+This backend resolves Keycloak identities to local users at login and only the
+internal id is available everywhere (Principal, Redis caches, triggers);
+storing `sub` would have broken referential integrity and local-account users.
+
+## Policy texts (MinIO)
+
+Markdown notices live in the default MinIO bucket under
+`policies/{version}/{lang}.md` (e.g. `policies/2026-07-04/de.md`).
+**Write-once is enforced by the DB row**: a version that exists in
+`policy_versions` can never be published again, so its objects are never
+rewritten. Orphaned objects from a *failed* publish (uploads succeeded, DB
+insert didn't) may be overwritten by a retry — otherwise a failed publish
+would burn the version name forever. Consider additionally enabling bucket
+versioning on MinIO in production. The DB row (`version`, `languages`,
+`content_hashes` — a sha256 per language for tamper-evidence) is the index;
+MinIO holds the content.
+
+## Endpoints (`/consent`, all authenticated, all whitelisted from the gate)
+
+Note: this app has no global `/api` prefix (routers mount at root, e.g.
+`/users`, `/auth`), so the consent routes live at `/consent`, not
+`/api/consent`.
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /consent/status` | `{required_version, has_consented, granted_at}` |
+| `POST /consent` | body `{policy_version, purposes?}`; records consent + ip/user-agent; 201 |
+| `POST /consent/withdraw` | sets `withdrawn_at`; user is gated again |
+| `GET /consent/policy?lang=de` | current version + Markdown text; falls back to `en`, then the first available language |
+| `GET /consent/policy-versions` | admin: list versions |
+| `POST /consent/policy-versions` | admin: publish `{version, effective_from?, texts: {lang: md}}` |
+
+## Middleware (`middleware/consent.py`)
+
+**Ordering:** auth in this codebase is a per-route dependency, not middleware,
+so no middleware ever sees a resolved Principal. The gate resolves the user
+itself via the shared `middleware/principal_lookup.py`. Registration order in
+`server.py` (outermost first):
+`CORS → Maintenance → ConsentGate → UploadSizeLimiter`. The gate must stay
+inside CORS so its 403 responses carry CORS headers. The downstream app is
+invoked outside the gate's try block, so endpoint exceptions propagate
+normally (they are never swallowed by the fail-open handler).
+
+**Identity resolution** (`middleware/principal_lookup.py`, shared logic that
+`MaintenanceMiddleware` can migrate to later): credential precedence mirrors
+`parse_authorization_header` exactly — `X-API-Token`, then `GLP-CREDS`, then
+`Authorization`, then the `ct_access_token` cookie only when no Authorization
+header is present — so the gate always judges the same identity the route
+authenticates. Sources: SSO tokens → principal cache, falling back to the
+`sso_session:{hash}` store; API tokens → principal cache, falling back to one
+indexed DB lookup (`api_token.token_hash` is a deterministic sha256), so
+infrequent API-token clients are still gated; GLP-CREDS → principal cache
+only.
+
+Flow: whitelisted path or OPTIONS → pass; unresolvable credentials → pass (the
+route's auth dependency 401s); service principals (`is_service`) → pass; no
+effective policy version → gate inactive; otherwise Redis-cached consent check
+(`consent:{user_id}:{version}`, TTL 300 s, DB fallback in a threadpool) and
+
+```json
+403 {"error": "consent_required", "required_version": "2026-07-04"}
+```
+
+**Whitelist:** exact `/`, `/consent`, `/docs`, `/redoc`, `/openapi.json`,
+`/extensions-public`, `/extensions-getting-started`; prefixes `/consent/`,
+`/auth/`, `/password/`, `/invites/` (public registration), `/docs/`; plus
+GET-only `/user` and `/user/views` (the web UI needs the signed-in identity to
+render the consent page). Prefixes end with `/` deliberately so they cannot
+cover sibling routes (`/docs` must not exempt `/documents`; a bare `/ws`
+prefix would have exempted `/workspaces/*` — WebSockets need no entry because
+non-HTTP scopes are skipped). The documents API (`/documents`) **is** gated.
+
+**Caching / invalidation:** the current version is resolved by
+`business_logic.consent.resolve_current_policy_version` — the same
+Redis-cached helper the consent endpoints use, so the gate and the API can
+never disagree about the required version (relevant around scheduled
+`effective_from` boundaries). Cached at `consent:current_version` (TTL 300 s,
+invalidated on publish). The per-user key includes the version, so a version
+bump auto-invalidates stale entries; `POST /consent` refreshes the key,
+withdraw deletes it. Policy Markdown is additionally cached at
+`consent:policytext:{version}:{lang}` (immutable content, TTL 1 h). On
+Redis/DB failure the gate **fails open** (logged) — an infra outage must not
+take down the API.
+
+**Kill switch:** `CONSENT_GATE_ENABLED=false` disables the middleware. The
+gate is also inactive as long as no `policy_versions` row is effective — a
+fresh deployment is not gated until the first policy is published.
+
+**Known limitation:** HTTP Basic credentials (dev `admin/admin`, some test
+suites) cannot be resolved without password verification and pass the gate;
+GLP-CREDS users are only gated while their principal cache entry (15 min TTL)
+is warm. All real clients (web, VS Code extension) use SSO tokens/cookies or
+API tokens and are fully gated.
+
+## Frontend (computor-web)
+
+- Interceptors in `src/utils/apiClient.ts` (`apiFetch`) and
+  `src/api/client.ts` (generated clients): any 403 with
+  `error === "consent_required"` stores the current route in
+  `sessionStorage['consent_redirect']` and navigates to `/consent`.
+- Bootstrap check once per page load in `AuthenticatedLayout` via
+  `GET /consent/status`.
+- `/consent` page: standalone (no sidebar/topbar — those fire gated calls),
+  renders processing info + cookie info (info-only), the Markdown notice with
+  language switcher, the version, and an **unchecked-by-default** checkbox.
+  On submit → `POST /consent` → returns to the originally requested route.
+  `/consent?review=1` shows the notice read-only after consent.
+- Withdraw: Settings → "Privacy & Consent" (status, view notice, withdraw with
+  confirmation; after withdrawal the user lands back on `/consent`).
+
+## ⚠️ Cross-client impact — VS Code extension (decide before merging)
+
+The VS Code extension hits the same API and will receive
+`403 {"error": "consent_required", "required_version": ...}` for unconsented
+users on every non-whitelisted call. **No extension-side handling exists yet.**
+Recommended minimal flow: detect the stable error body, show a notification
+("WISCode needs your consent — open the web UI"), deep-link to
+`{web}/consent`, and retry after the user returns. A headless consent path was
+deliberately not built — consent should be given on a page that shows the full
+notice. Track this as a follow-up issue for the extension before enabling the
+gate in production (i.e. before publishing the first policy version).
+
+## Ops: publishing a policy version
+
+```bash
+curl -X POST "$API/consent/policy-versions" \
+  -H 'Content-Type: application/json' -H "X-API-Token: $ADMIN_TOKEN" \
+  -d '{
+    "version": "2026-07-04",
+    "effective_from": null,
+    "texts": {"de": "# Datenschutzhinweis\n...", "en": "# Privacy notice\n..."}
+  }'
+```
+
+Publishing with `effective_from <= now()` re-gates **all** users who have not
+consented to the new version on their next request (within the ≤300 s cache
+TTL). Users must re-consent after every version bump — bump only for material
+changes.


### PR DESCRIPTION
## Summary

Brings the **GDPR consent gate** onto `release/2026.10`, plus a **file-based way to publish privacy notices** (CLI, admin web tab, and startup bootstrap).

The consent gate blocks API access for authenticated users who have not acknowledged the current privacy-notice version — informed, versioned, auditable, withdrawable consent (GDPR Art. 7). See `docs/consent-gate.md`.

## What's included (3 commits)

1. **`feat: add GDPR consent gate (backend + web)`** — middleware gate (`middleware/consent.py`), `/consent/*` endpoints, `policy_versions` / `user_consents` tables (MinIO-backed Markdown texts), and the web pieces (consent page, Settings → Privacy & Consent, 403-interceptor).
2. **`fix(backend): re-parent consent migration onto release/2026.10 head`** — points the consent migration's `down_revision` at the release head `c9a1b2d3e4f5` so there is a **single alembic head** (`dd2e3f4a5b6c → c9a1b2d3e4f5 → …`); consent tables are independent, so re-parenting is behaviourally a no-op.
3. **`feat(consent): file-based privacy notices — CLI, admin tab, startup bootstrap`**
   - `data/consent/<version>/{lang}.md` (+ optional `policy.yaml`) format; version dirs gitignored, location kept via `.gitkeep` + `README.md`.
   - CLI: `computor consent publish <dir> [--dry-run]` / `computor consent list`.
   - Web: admin-only **System → Privacy Notices** (`/admin/consent`) — list + publish (version + effective_from + per-language `.md`).
   - Backend: `ensure_bootstrap_policies()` publishes every `data/consent/*` version not already in the DB at startup (write-once, idempotent).

## Notes for reviewers

- **Publishing gates users.** A version with `effective_from <= now` re-gates every un-consented user on their next request. The **VS Code extension has no consent handling yet** — track before enabling in production.
- **Startup auto-publish** is on by default (`CONSENT_BOOTSTRAP_ENABLED=false` to disable; `CONSENT_DIR` overrides the directory). **Prod** must mount `data/consent` into the backend container (dev resolves it from the repo root automatically).
- The regenerated `src/generated/types/common.ts` also refreshed a stale, unrelated `CourseGitConfig` interface (rode along with `generate.sh types`).
- The privacy-notice *content* (`data/consent/2026-07-05/`) is intentionally **not** committed — it's deployment-specific and stays local.

## Verification

- Web `tsc --noEmit` clean; backend `py_compile`; alembic graph resolves to a single head.
- CLI: import/registration/`--help`/`--dry-run` on the seed; clean error when no token.
- Live: after publishing, the gate activates and unconsented users are redirected to `/consent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
