### PR TITLE
feat(consent): surface consent 403 with error envelope + /instance-info

### DIFF
--- a/computor-backend/error_registry.yaml
+++ b/computor-backend/error_registry.yaml
@@ -245,6 +245,27 @@ errors:
       - "Assign a role at or below your own privilege level"
     documentation_url: "/docs/permissions#role-assignment"
 
+  - code: AUTHZ_006
+    http_status: 403
+    category: authorization
+    severity: warning
+    title: "Privacy Policy Consent Required"
+    message:
+      plain: "You must accept the current privacy policy before you can continue."
+      markdown: "**Privacy Policy Consent Required**\n\nYou must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent."
+      html: "<strong>Privacy Policy Consent Required</strong><p>You must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.</p>"
+    internal_description: "The GDPR consent gate (ConsentGateMiddleware) blocked the request: the authenticated user has not consented to the current privacy-policy version."
+    affected_functions:
+      - "ConsentGateMiddleware"
+    common_causes:
+      - "User has never accepted the privacy policy"
+      - "A new privacy-policy version became effective and requires renewed consent"
+    resolution_steps:
+      - "Open the Computor web app"
+      - "Review and accept the current privacy policy on the consent page"
+      - "Retry the action"
+    documentation_url: "/docs/consent"
+
   - code: AUTHZ_010
     http_status: 403
     category: authorization

--- a/computor-backend/src/computor_backend/api/instance.py
+++ b/computor-backend/src/computor_backend/api/instance.py
@@ -1,0 +1,51 @@
+"""Instance info endpoint.
+
+Exposes the handful of public navigation URLs a client needs (the web app and
+the managed Forgejo git server) — nothing internal (no Coder/MinIO/Temporal).
+
+Requires authentication but is WHITELISTED in the consent gate
+(middleware/consent.py: EXEMPT_GET_PATHS_EXACT), so a consent-blocked client
+(e.g. the VSCode extension, which otherwise only sees an opaque 403) can still
+fetch this to learn where to go and accept the current privacy policy.
+"""
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from computor_backend.git_server.config import get_git_server_settings
+from computor_backend.permissions.auth import get_current_principal
+from computor_backend.permissions.principal import Principal
+from computor_backend.settings import settings
+from computor_types.instance import InstanceInfoGet
+
+instance_router = APIRouter()
+
+
+def _normalize_url(value: str | None) -> str | None:
+    """Trim trailing slashes and ensure a scheme (default https) so the value is
+    a well-formed base URL clients can open directly."""
+    url = (value or "").strip().rstrip("/")
+    if not url:
+        return None
+    if "://" not in url:
+        url = f"https://{url}"
+    return url
+
+
+@instance_router.get("/instance-info", response_model=InstanceInfoGet, tags=["instance"])
+async def get_instance_info(
+    principal: Annotated[Principal, Depends(get_current_principal)],
+) -> InstanceInfoGet:
+    """Public navigation URLs for this Computor instance."""
+    # The web app is served at the root of PUBLIC_DOMAIN; WEB_APP_URL overrides
+    # for split/dev deployments where that is not the case.
+    web_url = _normalize_url(settings.WEB_APP_URL or settings.PUBLIC_DOMAIN)
+
+    cfg = get_git_server_settings()
+    forgejo_url = (
+        _normalize_url(cfg.git_server_url)
+        if cfg.is_forgejo and cfg.git_server_url
+        else None
+    )
+
+    return InstanceInfoGet(web_url=web_url, forgejo_url=forgejo_url)

--- a/computor-backend/src/computor_backend/middleware/consent.py
+++ b/computor-backend/src/computor_backend/middleware/consent.py
@@ -28,7 +28,10 @@ Gate logic per request:
      so gate and API always agree on the required version. No version
      configured -> gate inactive, pass.
   6. Check consent (Redis `consent:{user_id}:{version}`, DB fallback).
-  7. No valid consent -> 403 {"error": "consent_required", "required_version": ...}.
+  7. No valid consent -> 403 {"error": "consent_required", "required_version": ...,
+     "error_code": "AUTHZ_006", "message": ...}. The `error`/`required_version`
+     keys are the stable web contract; `error_code`/`message` are the standard
+     error envelope so catalog-driven clients surface a real reason.
 
 Fail-open: on Redis/DB errors the request passes (logged). Consistent with
 MaintenanceMiddleware — an infrastructure outage must not take down the API.
@@ -75,6 +78,9 @@ EXEMPT_PATH_PREFIXES = (
 EXEMPT_GET_PATHS_EXACT = (
     "/user",
     "/user/views",
+    "/instance-info",      # web app / git-server URLs — lets a consent-blocked
+                           # client (e.g. the VSCode extension) find the web app
+                           # to accept the policy.
 )
 
 
@@ -112,8 +118,21 @@ class ConsentGateMiddleware:
             response = JSONResponse(
                 status_code=403,
                 content={
+                    # Stable web contract — apiClient.isConsentRequired keys on
+                    # `error`; do not rename. `required_version` tells the client
+                    # which policy version to present.
                     "error": "consent_required",
                     "required_version": required_version,
+                    # Standard error envelope (error_code + message) so
+                    # catalog-driven clients (e.g. the VSCode extension) render a
+                    # real reason instead of a bare "HTTP 403: Forbidden". See
+                    # AUTHZ_006 in error_registry.yaml.
+                    "error_code": "AUTHZ_006",
+                    "message": (
+                        f"You must review and accept the current privacy policy "
+                        f"(version {required_version}) before you can continue. "
+                        f"Open the Computor web app to give your consent."
+                    ),
                 },
             )
             await response(scope, receive, send)

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -80,6 +80,7 @@ from computor_backend.api.workspace_roles import workspace_roles_router
 from computor_backend.api.maintenance import maintenance_router
 from computor_backend.api.invites import invites_router
 from computor_backend.api.consent import consent_router
+from computor_backend.api.instance import instance_router
 from computor_backend.api.accounts import accounts_router
 from computor_backend.api.documents import documents_router
 from computor_backend.exceptions import register_exception_handlers
@@ -576,6 +577,14 @@ app.include_router(
     consent_router,
     prefix="/consent",
     tags=["consent", "gdpr"]
+)
+
+# Public instance navigation URLs (web app + managed Forgejo). Also whitelisted
+# in ConsentGateMiddleware so a consent-blocked client can discover where to
+# accept the privacy policy.
+app.include_router(
+    instance_router,
+    tags=["instance"]
 )
 
 app.include_router(

--- a/computor-backend/src/computor_backend/settings.py
+++ b/computor-backend/src/computor_backend/settings.py
@@ -36,6 +36,18 @@ class BackendSettings:
         # Extension public download URL
         self.EXTENSION_PUBLIC_DOWNLOAD_URL = os.environ.get("EXTENSION_PUBLIC_DOWNLOAD_URL", None)
 
+        # Public base URL of the whole deployment (full URL incl. scheme, e.g.
+        # https://computor.example.org). The web app is served at its root, the
+        # API at $PUBLIC_DOMAIN/api, etc. Primary source for the web app URL
+        # surfaced by GET /instance-info (so clients like the VSCode extension
+        # can deep-link users to the consent page).
+        self.PUBLIC_DOMAIN = os.environ.get("PUBLIC_DOMAIN", None)
+
+        # Optional override for the web app URL when it is NOT at the root of
+        # PUBLIC_DOMAIN (split deployment) or in dev (PUBLIC_DOMAIN empty, web on
+        # localhost:3000). When unset, /instance-info uses PUBLIC_DOMAIN.
+        self.WEB_APP_URL = os.environ.get("WEB_APP_URL", None)
+
         # WebSocket settings
         self.WS_MAX_CONNECTIONS_PER_USER = int(os.environ.get("WS_MAX_CONNECTIONS_PER_USER", "10"))
         self.WS_MAX_TOTAL_CONNECTIONS = int(os.environ.get("WS_MAX_TOTAL_CONNECTIONS", "10000"))

--- a/computor-types/src/computor_types/generated/error_codes.py
+++ b/computor-types/src/computor_types/generated/error_codes.py
@@ -21,6 +21,7 @@ class ErrorCode(str, Enum):
     AUTHZ_003 = "AUTHZ_003"  # Course Access Denied
     AUTHZ_004 = "AUTHZ_004"  # Insufficient Course Role
     AUTHZ_005 = "AUTHZ_005"  # Role Escalation Denied
+    AUTHZ_006 = "AUTHZ_006"  # Privacy Policy Consent Required
     AUTHZ_010 = "AUTHZ_010"  # Service Account Required
     VAL_001 = "VAL_001"  # Invalid Request Data
     VAL_002 = "VAL_002"  # Missing Required Field
@@ -109,6 +110,7 @@ ERROR_CATEGORIES = {
     ErrorCode.AUTHZ_003: "authorization",
     ErrorCode.AUTHZ_004: "authorization",
     ErrorCode.AUTHZ_005: "authorization",
+    ErrorCode.AUTHZ_006: "authorization",
     ErrorCode.AUTHZ_010: "authorization",
     ErrorCode.VAL_001: "validation",
     ErrorCode.VAL_002: "validation",

--- a/computor-types/src/computor_types/instance.py
+++ b/computor-types/src/computor_types/instance.py
@@ -1,0 +1,28 @@
+"""Instance/deployment info exposed to authenticated clients.
+
+Surfaced by ``GET /instance-info`` so clients (notably the VSCode extension)
+can deep-link users to the web app and the git server. The endpoint is
+whitelisted in the consent gate, so a consent-blocked-but-authenticated client
+can still discover where to go to give consent.
+
+Deliberately minimal: only the URLs a client legitimately needs to navigate.
+No internal service URLs (Coder, MinIO, Temporal, Keycloak admin, …).
+"""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class InstanceInfoGet(BaseModel):
+    """Public navigation URLs for this Computor instance."""
+
+    web_url: Optional[str] = Field(
+        None,
+        description="Public base URL of the Computor web app "
+        "(e.g. https://computor.example.org); null if not configured.",
+    )
+    forgejo_url: Optional[str] = Field(
+        None,
+        description="Public base URL of the managed Forgejo git server; "
+        "null if no managed Forgejo is configured.",
+    )

--- a/computor-web/src/generated/errors/ERROR_CODES.md
+++ b/computor-web/src/generated/errors/ERROR_CODES.md
@@ -1,7 +1,7 @@
 # Error Code Reference
 
 **Auto-generated documentation**
-**Total errors:** 70
+**Total errors:** 71
 
 To regenerate: `bash generate_error_codes.sh`
 
@@ -360,6 +360,33 @@ User attempted to assign a course role higher than their own privilege level
 **Resolution Steps:**
 1. Request a user with higher privileges to perform this action
 2. Assign a role at or below your own privilege level
+
+---
+
+### AUTHZ_006 - Privacy Policy Consent Required
+
+**HTTP Status:** `403`  
+**Severity:** `warning`  
+**Category:** `authorization`  
+**Documentation:** [/docs/consent](/docs/consent)  
+
+**Description:**  
+The GDPR consent gate (ConsentGateMiddleware) blocked the request: the authenticated user has not consented to the current privacy-policy version.
+
+**User Message:**  
+> You must accept the current privacy policy before you can continue.
+
+**Affected Functions:**
+- `ConsentGateMiddleware`
+
+**Common Causes:**
+- User has never accepted the privacy policy
+- A new privacy-policy version became effective and requires renewed consent
+
+**Resolution Steps:**
+1. Open the Computor web app
+2. Review and accept the current privacy policy on the consent page
+3. Retry the action
 
 ---
 

--- a/computor-web/src/generated/errors/error-catalog.json
+++ b/computor-web/src/generated/errors/error-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "error_count": 70,
+  "error_count": 71,
   "errors": {
     "AUTH_001": {
       "code": "AUTH_001",
@@ -280,6 +280,33 @@
       "resolution_steps": [
         "Request a user with higher privileges to perform this action",
         "Assign a role at or below your own privilege level"
+      ]
+    },
+    "AUTHZ_006": {
+      "code": "AUTHZ_006",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "warning",
+      "title": "Privacy Policy Consent Required",
+      "message": {
+        "plain": "You must accept the current privacy policy before you can continue.",
+        "markdown": "**Privacy Policy Consent Required**\n\nYou must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.",
+        "html": "<strong>Privacy Policy Consent Required</strong><p>You must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/consent",
+      "internal_description": "The GDPR consent gate (ConsentGateMiddleware) blocked the request: the authenticated user has not consented to the current privacy-policy version.",
+      "affected_functions": [
+        "ConsentGateMiddleware"
+      ],
+      "common_causes": [
+        "User has never accepted the privacy policy",
+        "A new privacy-policy version became effective and requires renewed consent"
+      ],
+      "resolution_steps": [
+        "Open the Computor web app",
+        "Review and accept the current privacy policy on the consent page",
+        "Retry the action"
       ]
     },
     "AUTHZ_010": {

--- a/computor-web/src/generated/errors/error-catalog.vscode.json
+++ b/computor-web/src/generated/errors/error-catalog.vscode.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "error_count": 70,
+  "error_count": 71,
   "errors": {
     "AUTH_001": {
       "code": "AUTH_001",
@@ -129,6 +129,19 @@
         "plain": "You cannot assign a role higher than your own.",
         "markdown": "**Role Escalation Denied**\n\nYou cannot assign the role '{target_role}'. Your role '{user_role}' can only assign roles at or below your privilege level.",
         "html": "<strong>Role Escalation Denied</strong><p>You cannot assign the role <code>{target_role}</code>. Your role <code>{user_role}</code> can only assign roles at or below your privilege level.</p>"
+      },
+      "retry_after": null
+    },
+    "AUTHZ_006": {
+      "code": "AUTHZ_006",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "warning",
+      "title": "Privacy Policy Consent Required",
+      "message": {
+        "plain": "You must accept the current privacy policy before you can continue.",
+        "markdown": "**Privacy Policy Consent Required**\n\nYou must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.",
+        "html": "<strong>Privacy Policy Consent Required</strong><p>You must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.</p>"
       },
       "retry_after": null
     },

--- a/computor-web/src/generated/types/common.ts
+++ b/computor-web/src/generated/types/common.ts
@@ -2173,6 +2173,16 @@ export interface TestCreate {
 }
 
 /**
+ * Public navigation URLs for this Computor instance.
+ */
+export interface InstanceInfoGet {
+  /** Public base URL of the Computor web app (e.g. https://computor.example.org); null if not configured. */
+  web_url?: string | null;
+  /** Public base URL of the managed Forgejo git server; null if no managed Forgejo is configured. */
+  forgejo_url?: string | null;
+}
+
+/**
  * Payload describing a manual submission request.
  */
 export interface SubmissionCreate {
@@ -4289,4 +4299,4 @@ export type ErrorCategory = "authentication" | "authorization" | "validation" | 
 
 export type GradingStatus = 0 | 1 | 2 | 3;
 
-export type ErrorCode = "AUTH_001" | "AUTH_002" | "AUTH_003" | "AUTH_004" | "AUTH_005" | "AUTHZ_001" | "AUTHZ_002" | "AUTHZ_003" | "AUTHZ_004" | "AUTHZ_005" | "AUTHZ_010" | "VAL_001" | "VAL_002" | "VAL_003" | "VAL_004" | "NF_001" | "NF_002" | "NF_003" | "NF_004" | "NF_010" | "CONFLICT_001" | "CONFLICT_002" | "RATE_001" | "RATE_002" | "RATE_003" | "CONTENT_001" | "CONTENT_002" | "CONTENT_003" | "CONTENT_004" | "CONTENT_005" | "CONTENT_006" | "CONTENT_007" | "VERSION_001" | "DEPLOY_001" | "DEPLOY_002" | "DEPLOY_003" | "DEPLOY_004" | "DEPLOY_005" | "SUBMIT_001" | "SUBMIT_002" | "SUBMIT_003" | "SUBMIT_004" | "SUBMIT_005" | "SUBMIT_006" | "SUBMIT_007" | "SUBMIT_008" | "TASK_001" | "TASK_002" | "TASK_003" | "TASK_004" | "GITLAB_001" | "GITLAB_002" | "GITLAB_003" | "GITLAB_004" | "GITLAB_005" | "GITLAB_006" | "GITLAB_007" | "GITLAB_008" | "EXT_001" | "EXT_002" | "EXT_003" | "EXT_004" | "EXT_005" | "EXT_006" | "DB_001" | "DB_002" | "DB_003" | "INT_001" | "INT_002" | "NIMPL_001";
+export type ErrorCode = "AUTH_001" | "AUTH_002" | "AUTH_003" | "AUTH_004" | "AUTH_005" | "AUTHZ_001" | "AUTHZ_002" | "AUTHZ_003" | "AUTHZ_004" | "AUTHZ_005" | "AUTHZ_006" | "AUTHZ_010" | "VAL_001" | "VAL_002" | "VAL_003" | "VAL_004" | "NF_001" | "NF_002" | "NF_003" | "NF_004" | "NF_010" | "CONFLICT_001" | "CONFLICT_002" | "RATE_001" | "RATE_002" | "RATE_003" | "CONTENT_001" | "CONTENT_002" | "CONTENT_003" | "CONTENT_004" | "CONTENT_005" | "CONTENT_006" | "CONTENT_007" | "VERSION_001" | "DEPLOY_001" | "DEPLOY_002" | "DEPLOY_003" | "DEPLOY_004" | "DEPLOY_005" | "SUBMIT_001" | "SUBMIT_002" | "SUBMIT_003" | "SUBMIT_004" | "SUBMIT_005" | "SUBMIT_006" | "SUBMIT_007" | "SUBMIT_008" | "TASK_001" | "TASK_002" | "TASK_003" | "TASK_004" | "GITLAB_001" | "GITLAB_002" | "GITLAB_003" | "GITLAB_004" | "GITLAB_005" | "GITLAB_006" | "GITLAB_007" | "GITLAB_008" | "EXT_001" | "EXT_002" | "EXT_003" | "EXT_004" | "EXT_005" | "EXT_006" | "DB_001" | "DB_002" | "DB_003" | "INT_001" | "INT_002" | "NIMPL_001";

--- a/computor-web/src/generated/types/error-codes.ts
+++ b/computor-web/src/generated/types/error-codes.ts
@@ -70,6 +70,7 @@ export const ErrorCodes = {
   AUTHZ_003: "AUTHZ_003", // Course Access Denied
   AUTHZ_004: "AUTHZ_004", // Insufficient Course Role
   AUTHZ_005: "AUTHZ_005", // Role Escalation Denied
+  AUTHZ_006: "AUTHZ_006", // Privacy Policy Consent Required
   AUTHZ_010: "AUTHZ_010", // Service Account Required
   VAL_001: "VAL_001", // Invalid Request Data
   VAL_002: "VAL_002", // Missing Required Field
@@ -293,6 +294,20 @@ export const ERROR_DEFINITIONS: Record<string, ErrorDefinition> = {
     },
     retryAfter: undefined,
     documentationUrl: "/docs/permissions#role-assignment",
+  },
+  AUTHZ_006: {
+    code: "AUTHZ_006",
+    httpStatus: 403,
+    category: ErrorCategory.AUTHORIZATION,
+    severity: ErrorSeverity.WARNING,
+    title: "Privacy Policy Consent Required",
+    message: {
+      plain: "You must accept the current privacy policy before you can continue.",
+      markdown: "**Privacy Policy Consent Required**\n\nYou must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.",
+      html: "<strong>Privacy Policy Consent Required</strong><p>You must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.</p>",
+    },
+    retryAfter: undefined,
+    documentationUrl: "/docs/consent",
   },
   AUTHZ_010: {
     code: "AUTHZ_010",


### PR DESCRIPTION
## Why
The consent gate returned a bespoke `403 {"error":"consent_required",...}` that bypassed the standard error envelope, so clients (VSCode extension) only saw an opaque "HTTP 403: Forbidden" with no reason.

## What
- `error_registry.yaml`: add `AUTHZ_006` "Privacy Policy Consent Required"; regenerate catalogs.
- `middleware/consent.py`: 403 body now **additively** carries `error_code` + version-specific `message` (keeps `error`/`required_version` web contract). Whitelist `/instance-info`.
- New consent-exempt `GET /instance-info` (`InstanceInfoGet`): returns `web_url` (from `PUBLIC_DOMAIN`, `WEB_APP_URL` override) + `forgejo_url` (public `GIT_SERVER_URL`), so a consent-blocked client can deep-link to the consent page. No internal service URLs.

Pairs with computor-vsc-extension PR of the same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)