### PR TITLE
Coder: extension rollout (versioned images, fleet update) + sidebar fixes

### DIFF
--- a/computor-backend/src/computor_backend/api/coder.py
+++ b/computor-backend/src/computor_backend/api/coder.py
@@ -39,6 +39,7 @@ from computor_backend.coder.schemas import (
     WorkspaceActionResponse,
     WorkspaceDetails,
     WorkspaceListResponse,
+    WorkspaceRolloutRequest,
 )
 from computor_backend.tasks import get_task_executor, TaskSubmission
 from computor_types.tasks import TaskInfo
@@ -268,6 +269,26 @@ async def get_workspaces(
         )
     except CoderNotFoundError:
         return WorkspaceListResponse(workspaces=[], count=0)
+    except Exception as e:
+        raise _handle_coder_error(e) from e
+
+
+@router.get(
+    "/workspaces/all",
+    response_model=WorkspaceListResponse,
+    summary="List all workspaces (admin fleet view)",
+)
+async def list_all_workspaces_endpoint(
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    _settings: Annotated[CoderSettings, Depends(require_coder_enabled)],
+    client: Annotated[CoderClient, Depends(get_coder_client)],
+) -> WorkspaceListResponse:
+    """List every workspace on the server, across all users. Requires
+    workspace:manage — the fleet view behind the admin rollout."""
+    _check_workspace_access(permissions, "manage")
+    try:
+        workspaces = await client.list_all_workspaces()
+        return WorkspaceListResponse(workspaces=workspaces, count=len(workspaces))
     except Exception as e:
         raise _handle_coder_error(e) from e
 
@@ -560,6 +581,42 @@ async def push_coder_templates(
     return CoderAdminTaskResponse(
         workflow_id=workflow_id,
         task_name="push_coder_templates",
+        status="submitted",
+    )
+
+
+@router.post(
+    "/admin/templates/rollout",
+    response_model=CoderAdminTaskResponse,
+    summary="Roll existing workspaces onto the active template version",
+)
+async def rollout_workspaces_endpoint(
+    request: WorkspaceRolloutRequest,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    settings: Annotated[CoderSettings, Depends(require_coder_enabled)],
+) -> CoderAdminTaskResponse:
+    """
+    Roll every existing workspace onto its template's active version — running
+    ones are rebuilt now, stopped ones adopt it on their next start. Run this
+    after a template push to propagate a new workspace image/extension to the
+    whole fleet. Requires workspace:manage permission.
+    """
+    _check_workspace_access(permissions, "manage")
+
+    executor = get_task_executor()
+    submission = TaskSubmission(
+        task_name="rollout_workspaces",
+        parameters={
+            "templates": request.templates,
+            "templates_dir": settings.templates_dir,
+        },
+        queue="coder-tasks",
+    )
+    workflow_id = await executor.submit_task(submission)
+
+    return CoderAdminTaskResponse(
+        workflow_id=workflow_id,
+        task_name="rollout_workspaces",
         status="submitted",
     )
 

--- a/computor-backend/src/computor_backend/api/coder.py
+++ b/computor-backend/src/computor_backend/api/coder.py
@@ -512,6 +512,7 @@ async def build_workspace_images(
         "templates": request.templates,
         "templates_dir": settings.templates_dir,
         "registry_host": settings.registry_host,
+        "image_tag": request.image_tag,
     }
     submission = TaskSubmission(
         task_name="build_workspace_images",
@@ -547,6 +548,7 @@ async def push_coder_templates(
     params = _build_template_parameters(settings)
     params["templates"] = request.templates
     params["build_images"] = request.build_images
+    params["image_tag"] = request.image_tag
 
     submission = TaskSubmission(
         task_name="push_coder_templates",

--- a/computor-backend/src/computor_backend/coder/client.py
+++ b/computor-backend/src/computor_backend/coder/client.py
@@ -573,9 +573,66 @@ class CoderClient:
 
         raise CoderTemplateNotFoundError(template_name)
 
+    async def get_template_active_version(self, template_name: str) -> str:
+        """Return the active (latest published) template version id by name.
+
+        This is the version a fleet rollout moves workspaces onto.
+
+        Raises:
+            CoderTemplateNotFoundError: If template not found
+            CoderAPIError: If the template has no active version
+        """
+        for tpl in await self.list_templates():
+            if tpl.name == template_name:
+                if not tpl.active_version_id:
+                    raise CoderAPIError(f"Template '{template_name}' has no active version")
+                return tpl.active_version_id
+        raise CoderTemplateNotFoundError(template_name)
+
     # -------------------------------------------------------------------------
     # Workspace operations
     # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_workspace_summary(ws: dict) -> CoderWorkspace:
+        """Build a CoderWorkspace from a Coder /workspaces list entry."""
+        latest = ws.get("latest_build") or {}
+        return CoderWorkspace(
+            id=ws["id"],
+            name=ws["name"],
+            owner_id=ws["owner_id"],
+            owner_name=ws.get("owner_name"),
+            template_id=ws["template_id"],
+            template_name=ws.get("template_display_name") or ws.get("template_name"),
+            template_version_id=latest.get("template_version_id"),
+            template_version_name=latest.get("template_version_name"),
+            latest_build_status=latest.get("status"),
+            created_at=ws.get("created_at"),
+            updated_at=ws.get("updated_at"),
+        )
+
+    async def list_all_workspaces(self, limit: int = 1000) -> list[CoderWorkspace]:
+        """List every workspace on the server (admin-only fleet view).
+
+        Uses the same /workspaces endpoint as ``get_user_workspaces`` but with
+        no owner filter, so an admin session sees all users' workspaces.
+        """
+        token = await self._get_session_token()
+        client = await self._ensure_client()
+
+        resp = await client.get(
+            "/api/v2/workspaces",
+            headers={"Coder-Session-Token": token},
+            params={"limit": limit},
+        )
+
+        if resp.status_code != 200:
+            raise CoderAPIError(
+                "Failed to list all workspaces",
+                status_code=resp.status_code,
+            )
+
+        return [self._parse_workspace_summary(ws) for ws in resp.json().get("workspaces", [])]
 
     async def get_workspace(
         self,
@@ -636,22 +693,7 @@ class CoderClient:
             )
 
         data = resp.json()
-        workspaces = data.get("workspaces", [])
-
-        return [
-            CoderWorkspace(
-                id=ws["id"],
-                name=ws["name"],
-                owner_id=ws["owner_id"],
-                owner_name=ws.get("owner_name"),
-                template_id=ws["template_id"],
-                template_name=ws.get("template_display_name") or ws.get("template_name"),
-                latest_build_status=ws.get("latest_build", {}).get("status"),
-                created_at=ws.get("created_at"),
-                updated_at=ws.get("updated_at"),
-            )
-            for ws in workspaces
-        ]
+        return [self._parse_workspace_summary(ws) for ws in data.get("workspaces", [])]
 
     async def workspace_exists(
         self,
@@ -1054,6 +1096,94 @@ class CoderClient:
             logger.info(f"Workspace {workspace_id}: token update build initiated")
         else:
             logger.error(f"Failed to update workspace token: {resp.status_code} - {resp.text}")
+        return success
+
+    async def _get_build_param(
+        self, build_id: str, name: str, token: str
+    ) -> Optional[str]:
+        """Read one rich-parameter value from a workspace build so it can be
+        preserved across a new build (omitted params reset to their default)."""
+        client = await self._ensure_client()
+        resp = await client.get(
+            f"/api/v2/workspacebuilds/{build_id}/parameters",
+            headers=self._get_headers(token),
+        )
+        if resp.status_code != 200:
+            return None
+        for p in resp.json():
+            if p.get("name") == name:
+                return p.get("value")
+        return None
+
+    async def set_workspace_auto_update(
+        self, workspace_id: str, always: bool = True
+    ) -> bool:
+        """Set a workspace's automatic-updates policy so it adopts the template's
+        active version on its next start. Best-effort."""
+        token = await self._get_session_token()
+        client = await self._ensure_client()
+        resp = await client.put(
+            f"/api/v2/workspaces/{workspace_id}/autoupdates",
+            headers=self._get_headers(token),
+            json={"automatic_updates": "always" if always else "never"},
+        )
+        return resp.status_code in (200, 204)
+
+    async def update_workspace_to_version(
+        self,
+        workspace_id: str,
+        template_version_id: str,
+    ) -> bool:
+        """Rebuild a workspace onto a specific template version (fleet update),
+        preserving its computor_auth_token so the extension stays authenticated.
+
+        Issues a ``start`` build on the new version — for workspaces to update
+        immediately. For stopped workspaces prefer ``set_workspace_auto_update``
+        so they adopt the new version on next start rather than being
+        force-started.
+        """
+        token = await self._get_session_token()
+        client = await self._ensure_client()
+
+        resp = await client.get(
+            f"/api/v2/workspaces/{workspace_id}",
+            headers=self._get_headers(token),
+        )
+        if resp.status_code != 200:
+            logger.error(
+                f"Failed to load workspace {workspace_id} for version update: {resp.status_code}"
+            )
+            return False
+        latest = (resp.json() or {}).get("latest_build") or {}
+
+        # Preserve the current auth token; omitting it resets the param to its
+        # "" default and de-authenticates the extension.
+        rich_params: list[dict] = []
+        build_id = latest.get("id")
+        if build_id:
+            current_token = await self._get_build_param(build_id, "computor_auth_token", token)
+            if current_token is not None:
+                rich_params.append({"name": "computor_auth_token", "value": current_token})
+
+        resp = await client.post(
+            f"/api/v2/workspaces/{workspace_id}/builds",
+            headers=self._get_headers(token),
+            json={
+                "template_version_id": template_version_id,
+                "transition": "start",
+                "rich_parameter_values": rich_params,
+            },
+            timeout=self.settings.workspace_timeout,
+        )
+        success = resp.status_code in (200, 201)
+        if success:
+            logger.info(
+                f"Workspace {workspace_id}: update to version {template_version_id} initiated"
+            )
+        else:
+            logger.error(
+                f"Failed to update workspace {workspace_id} to version: {resp.status_code} - {resp.text}"
+            )
         return success
 
     # -------------------------------------------------------------------------

--- a/computor-backend/src/computor_backend/coder/client.py
+++ b/computor-backend/src/computor_backend/coder/client.py
@@ -606,6 +606,7 @@ class CoderClient:
             template_name=ws.get("template_display_name") or ws.get("template_name"),
             template_version_id=latest.get("template_version_id"),
             template_version_name=latest.get("template_version_name"),
+            latest_build_transition=latest.get("transition"),
             latest_build_status=latest.get("status"),
             created_at=ws.get("created_at"),
             updated_at=ws.get("updated_at"),

--- a/computor-backend/src/computor_backend/coder/schemas.py
+++ b/computor-backend/src/computor_backend/coder/schemas.py
@@ -108,6 +108,9 @@ class CoderWorkspace(BaseModel):
     template_version_name: Optional[str] = Field(
         None, description="Human-readable template version name of the latest build"
     )
+    latest_build_transition: Optional[str] = Field(
+        None, description="Transition of the latest build: start | stop | delete"
+    )
     latest_build_status: Optional[WorkspaceBuildStatus] = Field(
         None,
         description="Latest build status"
@@ -212,6 +215,15 @@ class TemplatePushRequest(BaseModel):
     image_tag: Optional[str] = Field(
         None,
         description="Immutable image tag the pushed template version pins to (and builds, when build_images). None = auto-generated from the run time.",
+    )
+
+
+class WorkspaceRolloutRequest(BaseModel):
+    """Request to roll existing workspaces onto their template's active version."""
+
+    templates: Optional[list[str]] = Field(
+        None,
+        description="Template names to roll out (e.g. ['python3.13']). None = all templates."
     )
 
 

--- a/computor-backend/src/computor_backend/coder/schemas.py
+++ b/computor-backend/src/computor_backend/coder/schemas.py
@@ -186,6 +186,10 @@ class ImageBuildRequest(BaseModel):
         None,
         description="Template names to build (e.g. ['python3.13', 'matlab']). None = all templates."
     )
+    image_tag: Optional[str] = Field(
+        None,
+        description="Immutable image tag to publish alongside :latest (e.g. 'v20260706-1400'). None = auto-generated from the run time.",
+    )
 
 
 class TemplatePushRequest(BaseModel):
@@ -198,6 +202,10 @@ class TemplatePushRequest(BaseModel):
     build_images: bool = Field(
         False,
         description="Build workspace images before pushing templates."
+    )
+    image_tag: Optional[str] = Field(
+        None,
+        description="Immutable image tag the pushed template version pins to (and builds, when build_images). None = auto-generated from the run time.",
     )
 
 

--- a/computor-backend/src/computor_backend/coder/schemas.py
+++ b/computor-backend/src/computor_backend/coder/schemas.py
@@ -102,6 +102,12 @@ class CoderWorkspace(BaseModel):
     owner_name: Optional[str] = Field(None, description="Owner username")
     template_id: str = Field(..., description="Template ID")
     template_name: Optional[str] = Field(None, description="Template name")
+    template_version_id: Optional[str] = Field(
+        None, description="Template version the latest build ran (for fleet/update views)"
+    )
+    template_version_name: Optional[str] = Field(
+        None, description="Human-readable template version name of the latest build"
+    )
     latest_build_status: Optional[WorkspaceBuildStatus] = Field(
         None,
         description="Latest build status"

--- a/computor-backend/src/computor_backend/tasks/temporal_coder_setup.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_coder_setup.py
@@ -507,6 +507,134 @@ class PushCoderTemplatesWorkflow(BaseWorkflow):
         )
 
 
+@activity.defn(name="rollout_template_workspaces")
+async def rollout_template_workspaces(
+    template_key: str,
+    templates_dir: str,
+) -> Dict[str, Any]:
+    """Roll every workspace of one template onto its active version.
+
+    Policy: enable automatic updates for every workspace (so stopped ones adopt
+    the active version on their next start), and additionally issue an immediate
+    update build for workspaces that are currently up. In-progress, stopped and
+    failed workspaces are left to auto-update rather than being force-started.
+    """
+    from computor_backend.coder.client import CoderClient
+
+    discovered = _discover_templates(templates_dir)
+    info = discovered.get(template_key)
+    if not info:
+        return {"success": False, "template": template_key, "error": f"Unknown template: {template_key}"}
+    coder_template_name = info["coder_template_name"]
+
+    updated_now = 0
+    auto_on_start = 0
+    already_current = 0
+    errors: List[str] = []
+
+    try:
+        async with CoderClient() as client:
+            version_id = await client.get_template_active_version(coder_template_name)
+            targets = [
+                w for w in await client.list_all_workspaces()
+                if w.template_name == coder_template_name
+            ]
+
+            for w in targets:
+                try:
+                    # Always enable auto-update so a stopped/failed workspace
+                    # adopts this version on its next start.
+                    await client.set_workspace_auto_update(w.id, True)
+
+                    if w.template_version_id == version_id:
+                        already_current += 1
+                        continue
+
+                    status = w.latest_build_status.value if w.latest_build_status else ""
+                    is_up = w.latest_build_transition == "start" and status in ("succeeded", "running")
+                    if is_up:
+                        if await client.update_workspace_to_version(w.id, version_id):
+                            updated_now += 1
+                        else:
+                            errors.append(w.name)
+                    else:
+                        auto_on_start += 1
+                except Exception as e:  # noqa: BLE001 - collect per-workspace failures
+                    errors.append(f"{w.name}: {e}")
+
+        return {
+            "success": len(errors) == 0,
+            "template": coder_template_name,
+            "active_version": version_id,
+            "targets": len(targets),
+            "updated_now": updated_now,
+            "auto_update_on_start": auto_on_start,
+            "already_current": already_current,
+            "errors": errors,
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.exception(f"Rollout failed for {template_key}")
+        return {"success": False, "template": template_key, "error": str(e)}
+
+
+@register_task
+@workflow.defn(name="rollout_workspaces", sandboxed=False)
+class RolloutWorkspacesWorkflow(BaseWorkflow):
+    """Roll existing workspaces onto their template's active version."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "rollout_workspaces"
+
+    @classmethod
+    def get_task_queue(cls) -> str:
+        return "coder-tasks"
+
+    @classmethod
+    def get_execution_timeout(cls) -> timedelta:
+        return timedelta(minutes=40)
+
+    @workflow.run
+    async def run(self, parameters: Dict[str, Any]) -> WorkflowResult:
+        templates_dir = parameters.get("templates_dir", "/templates")
+        requested = parameters.get("templates")
+
+        template_keys = await workflow.execute_activity(
+            discover_template_keys,
+            args=[templates_dir, requested],
+            start_to_close_timeout=timedelta(seconds=30),
+        )
+        if not template_keys:
+            return WorkflowResult(
+                status="failed",
+                result=None,
+                error="No valid templates found in " + templates_dir,
+                metadata={"workflow_type": "rollout_workspaces"},
+            )
+
+        results = []
+        for key in template_keys:
+            result = await workflow.execute_activity(
+                rollout_template_workspaces,
+                args=[key, templates_dir],
+                start_to_close_timeout=timedelta(minutes=20),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=5),
+                    backoff_coefficient=2.0,
+                    maximum_attempts=2,
+                ),
+            )
+            results.append(result)
+
+        failed = [r for r in results if not r.get("success")]
+        return WorkflowResult(
+            status="completed_with_errors" if failed else "completed",
+            result={"rollouts": results},
+            error=(f"{len(failed)} rollout(s) had errors" if failed else None),
+            metadata={"workflow_type": "rollout_workspaces"},
+        )
+
+
 @activity.defn(name="discover_template_keys")
 async def discover_template_keys(
     templates_dir: str,
@@ -525,10 +653,12 @@ async def discover_template_keys(
 WORKFLOWS = [
     BuildWorkspaceImagesWorkflow,
     PushCoderTemplatesWorkflow,
+    RolloutWorkspacesWorkflow,
 ]
 
 ACTIVITIES = [
     build_workspace_image,
     discover_template_keys,
     push_coder_template,
+    rollout_template_workspaces,
 ]

--- a/computor-backend/src/computor_backend/tasks/temporal_coder_setup.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_coder_setup.py
@@ -89,9 +89,16 @@ async def build_workspace_image(
     template_key: str,
     templates_dir: str,
     registry_host: str,
+    image_tag: str = "latest",
 ) -> Dict[str, Any]:
     """
     Build a workspace Docker image and push it to the local registry.
+
+    Pushes two tags: the moving ``:latest`` and an immutable ``:<image_tag>``.
+    The versioned tag is what a Coder template version pins to, so rebuilt
+    workspaces actually pull the new image (a moved ``:latest`` would not be
+    re-pulled by the docker provider's ``keep_locally`` image resource) and a
+    rollback target exists.
 
     Uses the Docker SDK (already a dependency) to build and push.
     """
@@ -113,7 +120,11 @@ async def build_workspace_image(
         logger.warning(f"No Dockerfile found at {dockerfile_path}, skipping {template_key}")
         return {"success": True, "template": template_key, "skipped": True, "reason": "No Dockerfile"}
 
-    tag = f"{registry_host}/{info['image_name']}:latest"
+    repo = f"{registry_host}/{info['image_name']}"
+    # Always publish :latest; add the versioned tag when it is distinct.
+    push_tags = ["latest"]
+    if image_tag and image_tag != "latest":
+        push_tags.append(image_tag)
 
     # Collect build args from environment variables
     buildargs = {}
@@ -122,24 +133,39 @@ async def build_workspace_image(
         if val:
             buildargs[env_name] = val
 
-    logger.info(f"Building image {tag} from {build_dir}" + (f" (build_args: {list(buildargs.keys())})" if buildargs else ""))
+    logger.info(
+        f"Building image {repo} tags={push_tags} from {build_dir}"
+        + (f" (build_args: {list(buildargs.keys())})" if buildargs else "")
+    )
 
     try:
         client = docker_sdk.DockerClient(base_url="unix://" + os.environ.get("DOCKER_SOCKET_PATH", "/var/run/docker.sock"))
 
-        # Build
-        image, build_logs = client.images.build(path=build_dir, tag=tag, rm=True, buildargs=buildargs or None)
+        # Build (tagged with the first tag), then apply the remaining tags to the
+        # same image id so every tag is byte-identical.
+        image, build_logs = client.images.build(
+            path=build_dir, tag=f"{repo}:{push_tags[0]}", rm=True, buildargs=buildargs or None
+        )
         for chunk in build_logs:
             if "stream" in chunk:
                 line = chunk["stream"].strip()
                 if line:
                     logger.info(f"[build:{template_key}] {line}")
 
-        # Push
-        push_output = client.images.push(registry_host + "/" + info["image_name"], tag="latest")
-        logger.info(f"Push output for {template_key}: {push_output}")
+        for extra in push_tags[1:]:
+            image.tag(repo, tag=extra)
 
-        return {"success": True, "template": template_key, "image": tag}
+        # Push every tag
+        for t in push_tags:
+            push_output = client.images.push(repo, tag=t)
+            logger.info(f"Push output for {template_key} ({repo}:{t}): {push_output}")
+
+        return {
+            "success": True,
+            "template": template_key,
+            "image": f"{repo}:{image_tag}",
+            "tags": push_tags,
+        }
 
     except Exception as e:
         logger.exception(f"Failed to build/push image for {template_key}")
@@ -158,10 +184,19 @@ async def push_coder_template(
     dev_forward_ports: str,
     ttl_ms: int,
     activity_bump_ms: int,
+    registry_host: str = "localhost:5000",
+    image_tag: str = "latest",
 ) -> Dict[str, Any]:
     """
     Push a Coder template (Terraform config) using the coder CLI,
     then set TTL via the Coder REST API.
+
+    Pins the template's ``workspace_image`` variable to the immutable
+    ``<registry>/<image>:<image_tag>`` ref so this new template version is tied
+    to a specific image build (and so rolling workspaces onto it actually
+    changes the running image). ``registry_host`` here is the provisioner's view
+    of the registry (matches the template's default host), NOT the worker's push
+    host, so it is intentionally not overridden by CODER_REGISTRY_HOST.
     """
     import httpx
 
@@ -202,12 +237,15 @@ async def push_coder_template(
     env["CODER_SESSION_TOKEN"] = session_token
     env["CODER_URL"] = coder_url
 
+    image_ref = f"{registry_host}/{info['image_name']}:{image_tag}"
+
     cmd = [
         "coder", "templates", "push", coder_template_name,
         "--directory", template_dir,
         "--variable", f"computor_backend_internal={backend_internal_url}",
         "--variable", f"computor_backend_url={backend_external_url}",
         "--variable", f"dev_forward_ports={dev_forward_ports}",
+        "--variable", f"workspace_image={image_ref}",
         "--yes",
     ]
     logger.info(f"Running: {' '.join(cmd)}")
@@ -259,7 +297,12 @@ async def push_coder_template(
             "warning": f"Template pushed but TTL update failed: {e}",
         }
 
-    return {"success": True, "template": template_key, "coder_template": coder_template_name}
+    return {
+        "success": True,
+        "template": template_key,
+        "coder_template": coder_template_name,
+        "image": image_ref,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +332,8 @@ class BuildWorkspaceImagesWorkflow(BaseWorkflow):
         templates_dir = parameters.get("templates_dir", "/templates")
         registry_host = parameters.get("registry_host", "localhost:5000")
         requested = parameters.get("templates")
+        # One immutable image tag per run; workflow.now() is replay-deterministic.
+        image_tag = parameters.get("image_tag") or ("v" + workflow.now().strftime("%Y%m%d-%H%M%S"))
 
         # Discovery happens inside the activity (which runs on the worker).
         # The workflow just needs to know which keys to iterate over.
@@ -316,7 +361,7 @@ class BuildWorkspaceImagesWorkflow(BaseWorkflow):
         for key in template_keys:
             result = await workflow.execute_activity(
                 build_workspace_image,
-                args=[key, templates_dir, registry_host],
+                args=[key, templates_dir, registry_host, image_tag],
                 start_to_close_timeout=timedelta(minutes=15),
                 retry_policy=RetryPolicy(
                     initial_interval=timedelta(seconds=5),
@@ -330,14 +375,14 @@ class BuildWorkspaceImagesWorkflow(BaseWorkflow):
         if failed:
             return WorkflowResult(
                 status="completed_with_errors",
-                result={"builds": results},
+                result={"builds": results, "image_tag": image_tag},
                 error=f"{len(failed)} build(s) failed",
                 metadata={"workflow_type": "build_workspace_images"},
             )
 
         return WorkflowResult(
             status="completed",
-            result={"builds": results},
+            result={"builds": results, "image_tag": image_tag},
             metadata={"workflow_type": "build_workspace_images"},
         )
 
@@ -372,6 +417,9 @@ class PushCoderTemplatesWorkflow(BaseWorkflow):
         dev_forward_ports = parameters.get("dev_forward_ports", "")
         ttl_ms = parameters.get("ttl_ms", 3600000)  # 1 hour default
         activity_bump_ms = parameters.get("activity_bump_ms", 3600000)
+        # One immutable image tag for this run, shared by the build and the
+        # template's pinned workspace_image. workflow.now() is replay-safe.
+        image_tag = parameters.get("image_tag") or ("v" + workflow.now().strftime("%Y%m%d-%H%M%S"))
 
         if not coder_admin_email or not coder_admin_password:
             return WorkflowResult(
@@ -404,7 +452,7 @@ class PushCoderTemplatesWorkflow(BaseWorkflow):
             for key in template_keys:
                 await workflow.execute_activity(
                     build_workspace_image,
-                    args=[key, templates_dir, registry_host],
+                    args=[key, templates_dir, registry_host, image_tag],
                     start_to_close_timeout=timedelta(minutes=15),
                     retry_policy=RetryPolicy(
                         initial_interval=timedelta(seconds=5),
@@ -431,6 +479,8 @@ class PushCoderTemplatesWorkflow(BaseWorkflow):
                     dev_forward_ports,
                     ttl_ms,
                     activity_bump_ms,
+                    registry_host,
+                    image_tag,
                 ],
                 start_to_close_timeout=timedelta(minutes=10),
                 retry_policy=RetryPolicy(
@@ -445,14 +495,14 @@ class PushCoderTemplatesWorkflow(BaseWorkflow):
         if failed:
             return WorkflowResult(
                 status="completed_with_errors",
-                result={"pushes": results},
+                result={"pushes": results, "image_tag": image_tag},
                 error=f"{len(failed)} push(es) failed",
                 metadata={"workflow_type": "push_coder_templates"},
             )
 
         return WorkflowResult(
             status="completed",
-            result={"pushes": results},
+            result={"pushes": results, "image_tag": image_tag},
             metadata={"workflow_type": "push_coder_templates"},
         )
 

--- a/computor-web/app/workspaces/admin/fleet/page.tsx
+++ b/computor-web/app/workspaces/admin/fleet/page.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import AuthenticatedLayout from '@/src/components/AuthenticatedLayout';
+import ListPageLayout, { ScrollPanel, ListLoading } from '@/src/components/ListPageLayout';
+import { useResource } from '@/src/hooks/useResource';
+import { useNotify } from '@/src/contexts/NotificationContext';
+import PageHeader from '@/src/components/PageHeader';
+import ErrorBanner from '@/src/components/ErrorBanner';
+import Badge from '@/src/components/Badge';
+import { inputCls } from '@/src/components/FormPanel';
+import WorkspaceStatusBadge from '@/src/components/workspaces/WorkspaceStatusBadge';
+import { CoderClient } from '@/src/clients/CoderClient';
+import { TaskStatus } from '@/src/types/workspaces';
+import type { CoderWorkspace, CoderTemplate, TaskInfo } from '@/src/types/workspaces';
+
+const coderClient = new CoderClient();
+
+const TERMINAL = new Set<TaskStatus>([TaskStatus.FINISHED, TaskStatus.FAILED, TaskStatus.CANCELLED]);
+
+type RunningTask = { label: string; workflowId: string; status: TaskStatus };
+
+function ownerName(w: CoderWorkspace): string {
+  return w.owner_name || w.owner_id;
+}
+
+export default function WorkspaceFleetPage() {
+  const notify = useNotify();
+
+  const { data, loading, error, reload } = useResource(async () => {
+    const [ws, tmpl] = await Promise.all([
+      coderClient.listAllWorkspaces(),
+      coderClient.listTemplates(),
+    ]);
+    return { workspaces: ws.workspaces, templates: tmpl.templates };
+  }, []);
+
+  const workspaces = useMemo(() => data?.workspaces ?? [], [data]);
+  const templates = useMemo(() => data?.templates ?? [], [data]);
+
+  // Active template version per template id → lets us flag workspaces still on
+  // an older version (i.e. not yet carrying the newest extension).
+  const activeVersionByTemplate = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const t of templates as CoderTemplate[]) {
+      if (t.active_version_id) m.set(t.id, t.active_version_id);
+    }
+    return m;
+  }, [templates]);
+
+  const isOutdated = useCallback(
+    (w: CoderWorkspace): boolean => {
+      const active = activeVersionByTemplate.get(w.template_id);
+      return !!active && !!w.template_version_id && w.template_version_id !== active;
+    },
+    [activeVersionByTemplate],
+  );
+
+  const outdatedCount = workspaces.filter(isOutdated).length;
+
+  // ---- admin task (build/push/rollout) with status polling -----------------
+  const [imageTag, setImageTag] = useState('');
+  const [task, setTask] = useState<RunningTask | null>(null);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const busy = !!task && !TERMINAL.has(task.status);
+
+  useEffect(() => {
+    if (!task || TERMINAL.has(task.status)) return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const info: TaskInfo = await coderClient.getAdminTask(task.workflowId);
+        if (cancelled) return;
+        setTask((prev) => (prev && prev.workflowId === task.workflowId ? { ...prev, status: info.status } : prev));
+        if (info.status === TaskStatus.FINISHED) {
+          notify(`${task.label} finished.`, 'success');
+          reload();
+        } else if (info.status === TaskStatus.FAILED || info.status === TaskStatus.CANCELLED) {
+          notify(`${task.label} ${info.status}${info.error ? `: ${info.error}` : ''}.`, 'error');
+        } else {
+          pollRef.current = setTimeout(tick, 3000);
+        }
+      } catch {
+        if (!cancelled) pollRef.current = setTimeout(tick, 3000);
+      }
+    };
+    pollRef.current = setTimeout(tick, 2000);
+    return () => {
+      cancelled = true;
+      if (pollRef.current) clearTimeout(pollRef.current);
+    };
+  }, [task, notify, reload]);
+
+  async function runBuildPush() {
+    try {
+      const res = await coderClient.pushTemplates({ build_images: true, image_tag: imageTag.trim() || null });
+      setTask({ label: 'Build & push', workflowId: res.workflow_id, status: TaskStatus.STARTED });
+      notify('Building image and pushing a new template version…', 'success');
+    } catch (e) {
+      notify(e instanceof Error ? e.message : 'Failed to start build & push', 'error');
+    }
+  }
+
+  async function runRollout() {
+    try {
+      const res = await coderClient.rolloutWorkspaces({});
+      setTask({ label: 'Rollout', workflowId: res.workflow_id, status: TaskStatus.STARTED });
+      notify('Rolling out the active version to all workspaces…', 'success');
+    } catch (e) {
+      notify(e instanceof Error ? e.message : 'Failed to start rollout', 'error');
+    }
+  }
+
+  return (
+    <AuthenticatedLayout>
+      <ListPageLayout>
+        <PageHeader
+          breadcrumbs={[
+            { label: 'Workspaces', href: '/workspaces' },
+            { label: 'Administration', href: '/workspaces/admin' },
+            { label: 'Fleet' },
+          ]}
+          title="Workspace Fleet"
+          subtitle="Every workspace across all users, and rolling a new extension out to them."
+          actions={
+            <button
+              onClick={() => reload()}
+              disabled={loading}
+              className="px-3 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+            >
+              Refresh
+            </button>
+          }
+        />
+
+        <ErrorBanner>{error}</ErrorBanner>
+
+        {/* Extension rollout controls */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6 space-y-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">Update the workspace extension</h2>
+            <p className="text-sm text-gray-500 mt-1">
+              The VSCode extension is baked into the workspace image. To ship a new version:{' '}
+              <strong>build &amp; push</strong> a new image/template version, then <strong>roll it out</strong> —
+              running workspaces rebuild now, stopped ones adopt it on their next start. Home directories are
+              preserved.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="w-64">
+              <label htmlFor="image-tag" className="block text-xs font-medium text-gray-700 mb-1">
+                Image tag (optional)
+              </label>
+              <input
+                id="image-tag"
+                value={imageTag}
+                onChange={(e) => setImageTag(e.target.value)}
+                placeholder="auto (from run time)"
+                className={inputCls}
+                disabled={busy}
+              />
+            </div>
+            <button
+              onClick={runBuildPush}
+              disabled={busy}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50"
+            >
+              Build &amp; push new version
+            </button>
+            <button
+              onClick={runRollout}
+              disabled={busy}
+              className="px-4 py-2 text-sm font-medium text-white bg-emerald-600 rounded-lg hover:bg-emerald-700 disabled:opacity-50"
+            >
+              Roll out to all workspaces
+            </button>
+            {task && (
+              <span className="text-sm text-gray-600">
+                {task.label}: <span className="font-medium">{task.status}</span>
+                {busy && <span className="text-gray-400"> — this can take a few minutes…</span>}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Fleet table */}
+        <div className="shrink-0 text-sm text-gray-600">
+          {loading ? '—' : `${workspaces.length} workspaces`}
+          {outdatedCount > 0 && (
+            <span className="text-amber-700"> · {outdatedCount} on an older version</span>
+          )}
+        </div>
+
+        {loading ? (
+          <ListLoading>Loading fleet…</ListLoading>
+        ) : (
+          <ScrollPanel>
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50 sticky top-0 z-10">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Workspace</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Template</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Version</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {workspaces.map((w) => {
+                  const outdated = isOutdated(w);
+                  return (
+                    <tr key={w.id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 text-sm text-gray-900">{ownerName(w)}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600">{w.name}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600">{w.template_name || '—'}</td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm text-gray-600">{w.template_version_name || '—'}</span>
+                          {outdated ? (
+                            <Badge color="yellow">outdated</Badge>
+                          ) : (
+                            w.template_version_id && <Badge color="green">latest</Badge>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <WorkspaceStatusBadge status={w.latest_build_status} size="sm" />
+                      </td>
+                    </tr>
+                  );
+                })}
+                {workspaces.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">
+                      No workspaces.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </ScrollPanel>
+        )}
+
+        <div className="shrink-0">
+          <Link href="/workspaces/admin" className="text-sm text-blue-600 hover:underline">
+            ← Back to workspace administration
+          </Link>
+        </div>
+      </ListPageLayout>
+    </AuthenticatedLayout>
+  );
+}

--- a/computor-web/app/workspaces/admin/page.tsx
+++ b/computor-web/app/workspaces/admin/page.tsx
@@ -155,6 +155,14 @@ export default function WorkspaceAdminPage() {
           breadcrumbs={[{ label: 'Workspaces', href: '/workspaces' }, { label: 'Administration' }]}
           title="Workspace Administration"
           subtitle="Manage workspace roles and user access"
+          actions={
+            <Link
+              href="/workspaces/admin/fleet"
+              className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+            >
+              Fleet &amp; rollout
+            </Link>
+          }
         />
 
         {/* Assign Role Form */}

--- a/computor-web/src/clients/CoderClient.ts
+++ b/computor-web/src/clients/CoderClient.ts
@@ -11,6 +11,11 @@ import type {
   WorkspaceActionResponse,
   WorkspaceProvisionRequest,
   ProvisionResult,
+  ImageBuildRequest,
+  TemplatePushRequest,
+  WorkspaceRolloutRequest,
+  CoderAdminTaskResponse,
+  TaskInfo,
 } from '@/src/types/workspaces';
 import { APIClient, apiClient } from 'api/client';
 import { BaseEndpointClient } from '@/src/generated/clients/baseClient';
@@ -83,5 +88,42 @@ export class CoderClient extends BaseEndpointClient {
    */
   async deleteWorkspace({ username, workspaceName }: { username: string; workspaceName: string }): Promise<WorkspaceActionResponse> {
     return this.client.delete<WorkspaceActionResponse>(this.buildPath('workspaces', username, workspaceName));
+  }
+
+  // --- Admin: fleet view + extension rollout (workspace:manage) ---
+
+  /**
+   * List every workspace on the server, across all users (admin fleet view).
+   */
+  async listAllWorkspaces(): Promise<WorkspaceListResponse> {
+    return this.client.get<WorkspaceListResponse>(this.buildPath('workspaces', 'all'));
+  }
+
+  /**
+   * Build workspace Docker images (optionally a specific image tag).
+   */
+  async buildImages(body: ImageBuildRequest = {}): Promise<CoderAdminTaskResponse> {
+    return this.client.post<CoderAdminTaskResponse>(this.buildPath('admin', 'images', 'build'), body);
+  }
+
+  /**
+   * Push Coder templates (optionally building images first).
+   */
+  async pushTemplates(body: TemplatePushRequest = {}): Promise<CoderAdminTaskResponse> {
+    return this.client.post<CoderAdminTaskResponse>(this.buildPath('admin', 'templates', 'push'), body);
+  }
+
+  /**
+   * Roll existing workspaces onto their template's active version.
+   */
+  async rolloutWorkspaces(body: WorkspaceRolloutRequest = {}): Promise<CoderAdminTaskResponse> {
+    return this.client.post<CoderAdminTaskResponse>(this.buildPath('admin', 'templates', 'rollout'), body);
+  }
+
+  /**
+   * Poll the status of an admin task (image build / template push / rollout).
+   */
+  async getAdminTask(workflowId: string): Promise<TaskInfo> {
+    return this.client.get<TaskInfo>(this.buildPath('admin', 'tasks', workflowId));
   }
 }

--- a/computor-web/src/components/Sidebar.tsx
+++ b/computor-web/src/components/Sidebar.tsx
@@ -49,6 +49,7 @@ const workspacesNavigation: NavItem[] = [
     icon: 'workspaces',
     ownPage: true,
     subItems: [
+      { id: 'ws-list', label: 'Workspaces', path: '/workspaces' },
       { id: 'ws-templates', label: 'Templates', path: '/workspaces/templates' },
       { id: 'ws-provision', label: 'Provision', path: '/workspaces/provision' },
       { id: 'ws-admin', label: 'Administration', path: '/workspaces/admin' },

--- a/computor-web/src/components/Sidebar.tsx
+++ b/computor-web/src/components/Sidebar.tsx
@@ -284,6 +284,15 @@ export default function Sidebar() {
       const sectionActive = hasSubItems
         ? navItem.subItems!.some((s) => pathMatches(s.path, pathname))
         : false;
+      // Only the MOST specific matching sub-item is active. Several sub-item
+      // paths can prefix-match the route at once (a group's self-referential
+      // first item like "/workspaces" is a prefix of "/workspaces/templates"),
+      // so pick the longest match instead of lighting up every prefix.
+      const activeSubPath = hasSubItems
+        ? navItem.subItems!
+            .filter((s) => pathMatches(s.path, pathname))
+            .reduce<string | null>((best, s) => (s.path.length > (best?.length ?? -1) ? s.path : best), null)
+        : null;
       // While a child is the active page the section stays expanded — it can't
       // be collapsed out from under the selected item.
       const isExpanded = expandedViews[navItem.id] || sectionActive;
@@ -335,7 +344,7 @@ export default function Sidebar() {
           {!collapsed && isExpanded && navItem.subItems && (
             <div className="ml-8 space-y-1">
               {navItem.subItems.map((subItem) => {
-                const isSubActive = pathname === subItem.path || pathname.startsWith(subItem.path + '/');
+                const isSubActive = subItem.path === activeSubPath;
 
                 return (
                   <Link

--- a/computor-web/src/types/workspaces.ts
+++ b/computor-web/src/types/workspaces.ts
@@ -57,6 +57,9 @@ export interface CoderWorkspace {
   owner_name?: string | null;
   template_id: string;
   template_name?: string | null;
+  template_version_id?: string | null;
+  template_version_name?: string | null;
+  latest_build_transition?: string | null;
   latest_build_status?: WorkspaceBuildStatus | null;
   created_at?: string | null;
   updated_at?: string | null;
@@ -132,4 +135,44 @@ export interface WorkspaceProvisionRequest {
   email?: string | null;
   template?: WorkspaceTemplate;
   workspace_name?: string | null;
+}
+
+// --- Admin: image build / template push / fleet rollout ---
+
+export interface ImageBuildRequest {
+  templates?: string[] | null;
+  image_tag?: string | null;
+}
+
+export interface TemplatePushRequest {
+  templates?: string[] | null;
+  build_images?: boolean;
+  image_tag?: string | null;
+}
+
+export interface WorkspaceRolloutRequest {
+  templates?: string[] | null;
+}
+
+export interface CoderAdminTaskResponse {
+  workflow_id: string;
+  task_name: string;
+  status: string;
+}
+
+export enum TaskStatus {
+  QUEUED = 'queued',
+  STARTED = 'started',
+  FINISHED = 'finished',
+  FAILED = 'failed',
+  DEFERRED = 'deferred',
+  CANCELLED = 'cancelled',
+}
+
+export interface TaskInfo {
+  task_id: string;
+  task_name: string;
+  status: TaskStatus;
+  error?: string | null;
+  progress?: Record<string, unknown> | null;
 }


### PR DESCRIPTION
Fleet-wide workspace/extension update for Coder, plus sidebar fixes. Backend compiles + import-tested; web `tsc --noEmit` clean. Not yet smoke-tested against a live Coder stack (none available in dev).

## Extension rollout (the "iterate extension → everyone gets the new container" loop)
- **Versioned image tags** — builds publish `:latest` *and* an immutable `:<tag>`; template push pins `workspace_image` to that ref. Fixes the `:latest` + `keep_locally` no-re-pull trap and enables rollback.
- **Client methods** — `get_template_active_version`, `list_all_workspaces` (admin fleet), `update_workspace_to_version` (preserves `computor_auth_token`), `set_workspace_auto_update`.
- **Rollout workflow** `rollout_workspaces` + `POST /coder/admin/templates/rollout` (workspace:manage): running workspaces rebuild now, stopped ones adopt the active version on next start; home volumes preserved.
- **Fleet list** `GET /coder/workspaces/all` (workspace:manage).
- **Web** `/workspaces/admin/fleet`: all workspaces across users with outdated/latest flags + Build&Push / Roll-out actions (task polling).

## Sidebar fixes
- Self-referential **Workspaces** sub-item (the `/workspaces` list was unreachable from the sidebar; the group link fell through to Templates).
- Only the **most specific** sub-item is highlighted (prefix matching lit up the self-referential first item alongside the real page — also affected the Users group).

Verify on a live instance: /workspaces/admin/fleet → Build & push → workspaces show "outdated" → Roll out → they flip to "latest".

🤖 Generated with [Claude Code](https://claude.com/claude-code)