### PR TITLE
fix: restart critical services after host reboot

### DIFF
--- a/computor-backend/src/computor_backend/tests/test_compose_restart_policies.py
+++ b/computor-backend/src/computor_backend/tests/test_compose_restart_policies.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.mark.unit
+def test_critical_services_restart_after_host_reboot() -> None:
+    repository_root = Path(__file__).resolve().parents[4]
+    compose_path = repository_root / "ops/docker/docker-compose.base.yaml"
+    services = yaml.safe_load(compose_path.read_text())["services"]
+
+    for service_name in ("postgres", "traefik"):
+        assert services[service_name]["restart"] == "unless-stopped"

--- a/ops/docker/docker-compose.base.yaml
+++ b/ops/docker/docker-compose.base.yaml
@@ -13,6 +13,7 @@ services:
   # dev mounts the socket directly; prod proxies it via tecnativa/docker-socket-proxy.
   traefik:
     image: traefik:v3.6.6
+    restart: unless-stopped
     security_opt:
       - "no-new-privileges:true"
     logging:
@@ -32,6 +33,7 @@ services:
   # PostgreSQL with multiple databases support
   postgres:
     image: postgres:16
+    restart: unless-stopped
     security_opt:
       - "no-new-privileges:true"
     logging:


### PR DESCRIPTION
## What changed

- set `restart: unless-stopped` for the PostgreSQL and Traefik services in the shared Compose base
- add a regression test covering both critical restart policies

## Why

The 2026-07-23 managed host reboot cleanly stopped the production stack. Services with restart policies returned automatically, but PostgreSQL and Traefik remained stopped because their effective Docker restart policy was `no`, leaving the API behind HTTP 502.

## Validation

- `docker compose -f ops/docker/docker-compose.base.yaml config --no-interpolate -q`
- targeted regression test: 1 passed
- `git diff --check`

After merge this commit will be forward-ported to `release/2026.10` and deployed to both mapped instances.