### PR TITLE
fix: restart critical services after host reboot

### DIFF
--- a/computor-backend/src/computor_backend/tests/test_compose_restart_policies.py
+++ b/computor-backend/src/computor_backend/tests/test_compose_restart_policies.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.mark.unit
+def test_critical_services_restart_after_host_reboot() -> None:
+    repository_root = Path(__file__).resolve().parents[4]
+    compose_path = repository_root / "ops/docker/docker-compose.base.yaml"
+    services = yaml.safe_load(compose_path.read_text())["services"]
+
+    for service_name in ("postgres", "traefik"):
+        assert services[service_name]["restart"] == "unless-stopped"

--- a/ops/docker/docker-compose.base.yaml
+++ b/ops/docker/docker-compose.base.yaml
@@ -20,6 +20,7 @@ services:
   # dev mounts the socket directly; prod proxies it via tecnativa/docker-socket-proxy.
   traefik:
     image: traefik:v3.6.6
+    restart: unless-stopped
     security_opt:
       - "no-new-privileges:true"
     logging:
@@ -43,6 +44,7 @@ services:
   # PostgreSQL with multiple databases support
   postgres:
     image: postgres:16
+    restart: unless-stopped
     security_opt:
       - "no-new-privileges:true"
     logging:


### PR DESCRIPTION
## What changed

Forward-port of the production reboot hotfix from #197:

- set `restart: unless-stopped` for PostgreSQL and Traefik in the shared Compose base
- carry the regression test that protects both policies

## Why

`release/2026.10` had the same omission as `main`, so its instances were also vulnerable to leaving the database and ingress stopped after a host reboot.

## Validation

- `docker compose -f ops/docker/docker-compose.base.yaml config --no-interpolate -q`
- targeted regression test: 1 passed
- `git diff --check`