### PR TITLE
fix(matlab): slow submissions and 45s timeouts in the testing worker under R2025b

### DIFF
--- a/computor-backend/src/computor_backend/tasks/temporal_worker.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_worker.py
@@ -92,6 +92,20 @@ class TemporalWorker:
         # otherwise) and activity concurrency is unchanged.
         max_workers = get_worker_settings().activity_executor_max_workers
 
+        # Workers fronting a single non-reentrant resource (the MATLAB worker
+        # and its one shared engine) set this to 1; everyone else leaves it
+        # unset and keeps the SDK default. The pool is sized down to match,
+        # since it never needs more threads than the SDK will hand it work.
+        max_concurrent_activities = get_worker_settings().max_concurrent_activities
+        if max_concurrent_activities is not None:
+            max_workers = max(1, max_concurrent_activities)
+
+        worker_limits = (
+            {}
+            if max_concurrent_activities is None
+            else {"max_concurrent_activities": max_concurrent_activities}
+        )
+
         # Create a worker for each task queue
         for task_queue in self.task_queues:
             logger.info(f"Creating worker for queue: {task_queue}")
@@ -106,11 +120,13 @@ class TemporalWorker:
                 workflows=workflows,
                 activities=activities,
                 activity_executor=activity_executor,
+                **worker_limits,
             )
             self.workers.append(worker)
             logger.info(
                 f"Worker created for queue: {task_queue} "
-                f"(activity thread pool max_workers={max_workers})"
+                f"(activity thread pool max_workers={max_workers}, "
+                f"max_concurrent_activities={max_concurrent_activities or 'SDK default'})"
             )
 
         # Setup signal handlers

--- a/computor-backend/src/computor_backend/tasks/worker_settings.py
+++ b/computor-backend/src/computor_backend/tasks/worker_settings.py
@@ -98,6 +98,18 @@ class WorkerSettings(BaseSettings):
         default=100, validation_alias="TEMPORAL_ACTIVITY_EXECUTOR_MAX_WORKERS"
     )
 
+    # Cap on activities a worker runs at once. Unset means the SDK default of
+    # 100, which is right for workers whose activities are independent. It is
+    # wrong for a queue that fronts a single non-reentrant resource: the MATLAB
+    # worker drives one shared MATLAB engine over Pyro, and MATLAB executes one
+    # command at a time, so pulling 100 test activities only builds a queue
+    # inside the engine while each activity's own timeout counts down against
+    # the wait rather than the work. Set it to 1 there and scale that worker
+    # with replicas (MATLAB_TESTING_WORKER_REPLICAS), each with its own engine.
+    max_concurrent_activities: Optional[int] = Field(
+        default=None, validation_alias="TEMPORAL_MAX_CONCURRENT_ACTIVITIES"
+    )
+
     # --- Coder image / template build (tasks/temporal_coder_setup.py) -----
     # Old: os.environ.get("CODER_REGISTRY_HOST", registry_host)  -- env overrides
     #      a runtime parameter, so None == unset and the call site keeps the param.

--- a/computor-backend/src/computor_backend/testing/backends.py
+++ b/computor-backend/src/computor_backend/testing/backends.py
@@ -83,10 +83,20 @@ class MatlabTestingBackend(TestingBackend):
             # Connect to MATLAB server via Pyro
             matlab_server = Pyro5.api.Proxy(pyro_address)
 
-            # Get timeout from backend properties or test config (default: 5 minutes)
+            # Get timeout from backend properties or test config.
+            #
+            # The default has to cover the slowest legitimate example, not the
+            # median one. Graphics examples that build a video (make_movie2_d /
+            # make_movie3_d) render 75 frames through getframe, at ~110ms/frame
+            # headless under R2025b, and the suite runs the code twice -- once
+            # for the reference and once for the student -- so ~20s goes into
+            # rasterisation alone. The former 45s left no room for that plus a
+            # cold engine start, and a test killed on this timeout does not just
+            # fail: it marks the shared engine stuck and forces a restart, which
+            # then slows down every submission behind it.
             timeout_seconds = backend_properties.get(
                 "timeout_seconds",
-                test_job_config.get("timeout_seconds", 45)
+                test_job_config.get("timeout_seconds", 180)
             )
 
             logger.info(f"Executing MATLAB test with {timeout_seconds}s timeout")

--- a/docker/temporal-worker-matlab/matlab-server.py
+++ b/docker/temporal-worker-matlab/matlab-server.py
@@ -41,10 +41,32 @@ class MatlabServer(object):
     server_thread: Thread
     testing_environment_path: str
     _engine_stuck: bool = False  # Flag to track if engine needs restart
+    _engine_initialized: bool = False  # initTest has run on the *current* engine
+
+    # Statements that isolate one submission from the next. Deliberately NOT
+    # `clear all`: the workspace has to be clean between students, the code
+    # cache does not. `clear all` empties both, so every framework class and the
+    # whole +yaml package gets re-parsed and re-JITted for each submission --
+    # measured at +1.8s on R2025b, against ~0.4s of actual test work for
+    # itpcp.pgph.mat.simple_plot. `builtin` is used because the test engine puts
+    # its own clear.m on the path, shadowing the built-in.
+    RESET_STATEMENTS = (
+        "cd ~",
+        "builtin('clear','variables')",
+        "builtin('clear','global')",
+        # A test that errors out before its teardown leaves its figures open,
+        # and the cost of creating a figure grows with how many already are.
+        "close all force",
+        # Only touches the path when a submission actually changed it.
+        "if ~isempty(getappdata(groot,'codeAbilityEnginePath')) &&"
+        " ~strcmp(path,getappdata(groot,'codeAbilityEnginePath')),"
+        " path(getappdata(groot,'codeAbilityEnginePath')); end",
+    )
 
     def __init__(self,  worker_path: str):
       self.testing_environment_path = worker_path
       self._engine_stuck = False
+      self._engine_initialized = False
       self.connect()
 
     def _force_restart_engine(self):
@@ -109,6 +131,28 @@ class MatlabServer(object):
 
       print("FORCE RESTART: Cleanup complete, starting fresh engine...", flush=True)
       self._engine_stuck = False
+      self._engine_initialized = False
+
+    def _initialize_engine(self):
+      """Bring a freshly started engine up to a runnable state.
+
+      This is where `clear all` belongs: it is the one place a clean class and
+      function cache is actually wanted, and the cost is paid once per engine
+      rather than once per submission (see RESET_STATEMENTS).
+      """
+      init_file = f"{self.testing_environment_path}/initTest.m"
+      print(f"Initializing test environment at {init_file}", flush=True)
+      initErg = self.engine.evalc(f"clear all;cd ~;run {init_file}")
+      # Remember the search path initTest built, so a submission that mangles it
+      # (addpath/rmpath/restoredefaultpath in student code) cannot break every
+      # later submission that shares this engine.
+      self.engine.eval("setappdata(groot,'codeAbilityEnginePath',path);", nargout=0)
+      self._engine_initialized = True
+      print(f'Initialization complete: {initErg}', flush=True)
+
+    def _reset_workspace(self):
+      """Clean the workspace between submissions, keeping the code cache warm."""
+      self.engine.eval(";".join(MatlabServer.RESET_STATEMENTS) + ";", nargout=0)
 
     def connect(self):
       # Check if we need to force restart due to previous timeout
@@ -122,6 +166,10 @@ class MatlabServer(object):
       while attempts < retries:
         try:
           if self.engine is None:
+            # Whatever engine we end up on below is not one we have run
+            # initTest against yet -- including an already-shared engine we
+            # merely reconnect to.
+            self._engine_initialized = False
             engines = matlab.engine.find_matlab()
             print(f"Found existing MATLAB engines: {engines}", flush=True)
             if engine_name in engines:
@@ -151,13 +199,15 @@ class MatlabServer(object):
           else:
             print('Engine is already available!', flush=True)
 
-          print(f"Initializing test environment at {self.testing_environment_path}/initTest.m", flush=True)
-          initErg = self.engine.evalc(f"clear all;cd ~;run {self.testing_environment_path}/initTest.m")
-          print(f'Initialization complete: {initErg}', flush=True)
+          if self._engine_initialized:
+            self._reset_workspace()
+          else:
+            self._initialize_engine()
           return
 
         except Exception as e:
           attempts += 1
+          self._engine_initialized = False
           print(f'Failed connection attempt #{attempts}/{retries}: {type(e).__name__}: {str(e)}', flush=True)
 
           # Clean up failed engine to ensure fresh start on retry

--- a/docker/temporal-worker-matlab/matlab-server.py
+++ b/docker/temporal-worker-matlab/matlab-server.py
@@ -6,7 +6,7 @@ import json
 import matlab
 import matlab.engine
 import subprocess
-from threading import Thread
+from threading import RLock, Thread
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from Pyro5.api import expose, Daemon
 from computor_types.repositories import Repository
@@ -67,6 +67,13 @@ class MatlabServer(object):
       self.testing_environment_path = worker_path
       self._engine_stuck = False
       self._engine_initialized = False
+      # There is one MATLAB session behind this object and MATLAB executes one
+      # command at a time, so submissions are serialised no matter what. Making
+      # that explicit buys two things the implicit version does not: a timeout
+      # measures how long a test *ran* rather than how long it queued, and
+      # _force_restart_engine() can no longer pkill MATLAB out from under a
+      # submission that is still executing in it.
+      self._engine_lock = RLock()
       self.connect()
 
     def _force_restart_engine(self):
@@ -249,12 +256,13 @@ class MatlabServer(object):
       sys.exit(2)
 
     def evalc(self, arg):
-        self.connect()
+        with self._engine_lock:
+            self.connect()
 
-        print(f"Evaluating command: {arg}", flush=True)
-        result = self.engine.evalc(arg)
-        print(f"Result: {result}", flush=True)
-        return result
+            print(f"Evaluating command: {arg}", flush=True)
+            result = self.engine.evalc(arg)
+            print(f"Result: {result}", flush=True)
+            return result
 
     def test_student_example(self, test_file, spec_file, timeout_seconds=300):
         """
@@ -266,6 +274,13 @@ class MatlabServer(object):
             submit: Submission identifier
             timeout_seconds: Maximum execution time in seconds (default: 300 = 5 minutes)
         """
+        # Held across connect() and the test itself, so a restart triggered by
+        # one submission's timeout cannot land while another is mid-test.
+        with self._engine_lock:
+            return self._run_student_example(test_file, spec_file, timeout_seconds)
+
+    def _run_student_example(self, test_file, spec_file, timeout_seconds):
+        """Body of test_student_example; callers must hold ``_engine_lock``."""
         try:
            self.connect()
         except Exception as e:

--- a/docker/temporal-worker-matlab/matlab-server.py
+++ b/docker/temporal-worker-matlab/matlab-server.py
@@ -83,11 +83,30 @@ class MatlabServer(object):
         finally:
           self.engine = None
 
-      # Kill any MATLAB processes forcefully - use killall as backup
+      # Kill any MATLAB processes forcefully - use killall as backup.
+      #
+      # MathWorksServiceHost is deliberately NOT killed here. It is a
+      # container-wide daemon shared by every MATLAB session (it also fronts
+      # the license checkout), not part of the stuck session, and taking it
+      # down just means the replacement engine has to cold-start it again:
+      # measured at 4.3s -> 6.9s per restart in the R2025b worker. The startup
+      # path below still clears it, where a clean slate is actually wanted.
       print("Killing MATLAB processes...", flush=True)
       os.system("pkill -9 -f MATLAB 2>/dev/null || true")
-      os.system("pkill -9 -f MathWorksServiceHost 2>/dev/null || true")
       os.system("killall -9 MATLAB 2>/dev/null || true")
+
+      # R2025b starts a private Xvfb (3840x2160x24) plus a fluxbox for it, as
+      # children of the MATLAB session. Neither matches `pkill -f MATLAB`, so
+      # without this they survive every restart and pile up for the lifetime of
+      # the container -- one framebuffer's worth of memory each. Safe to do
+      # here because the session that owned them is already gone and the
+      # replacement engine starts its own.
+      #
+      # The bracket around the first letter is the usual self-exclusion trick:
+      # the shell os.system() spawns carries the pattern in its own command
+      # line, and would otherwise match it.
+      os.system("pkill -9 -f 'sys/[X]vfb/glnxa64/bin/Xvfb' 2>/dev/null || true")
+      os.system("pkill -9 -f 'sys/[f]luxbox/glnxa64/bin/fluxbox' 2>/dev/null || true")
 
       # Clean up stale session files
       import glob

--- a/ops/docker/docker-compose.matlab.yaml
+++ b/ops/docker/docker-compose.matlab.yaml
@@ -44,6 +44,11 @@ services:
       - TEMPORAL_HOST=temporal
       - TEMPORAL_PORT=7233
       - TEMPORAL_NAMESPACE=default
+      # This replica owns exactly one MATLAB engine, and MATLAB runs one command
+      # at a time. Pulling more than one test activity at a time would only
+      # queue them inside that engine while their timeouts count down. Scale
+      # throughput with MATLAB_TESTING_WORKER_REPLICAS, not with concurrency.
+      - TEMPORAL_MAX_CONCURRENT_ACTIVITIES=1
       - PYTHONPATH=/home/matlab/computor-backend/src
       - API_URL=${API_URL}
       - API_TOKEN=${MATLAB_WORKER_TOKEN:?}


### PR DESCRIPTION
Fixes computor-org/issues#310.

Since the R2024b → R2025b bump, submissions on the `testing-matlab` queue were slow and
intermittently hit the execution timeout, which marked the shared engine stuck and forced a
restart — slowing down every submission behind it.

This is the **submission testing** path (Temporal `testing-matlab` → `temporal-worker-matlab`
→ Pyro → shared MATLAB engine → `CodeAbilityTestSuite`). It does **not** touch the MATLAB
Coder workspaces (`ops/coder/templates/matlab-*`), which are unaffected.

## Root causes and fixes

**1. `clear all` before every submission — 86% of the wall time** (`b06a0ff3`)

`connect()` ran `clear all;cd ~;run initTest.m` per submission. `clear all` empties the
class/function cache along with the workspace, so every framework class and the whole `+yaml`
package was re-parsed and re-JITted for each student. Measured on `simple_plot`:

| per submission (warm engine) | time |
|---|---|
| as shipped: `clear all` + `run initTest` + suite | **2.77s** |
| `clear variables` + suite | 0.41s |
| suite alone | 0.40s |

The full init now runs **once per engine**; between submissions we do
`builtin('clear','variables'/'global')` + `close all force` + a guard that repairs the search
path if a submission mangled it. `builtin` because the test engine puts its own `clear.m` on
the path. Isolation is unchanged — only the code cache survives.

**2. Default timeout 45s → 180s** (`15448400`)

Movie examples (`make_movie2_d`/`make_movie3_d`) render 75 frames through `getframe` at
~110-160 ms/frame headless, and the suite runs the code **twice** (reference and student), so
~24s goes into rasterization alone. 45s left no room for that plus a cold engine start. Per
service/job overrides already existed; only the default was wrong.

**3. Restart path** (`97ca2e1a`)

- Stop killing `MathWorksServiceHost`. It is a container-wide daemon that also fronts license
  checkout, not part of the stuck session; killing it cost **+2.7s per restart** (4.3s → 6.9s).
  `pkill -f MATLAB` already reaps the per-session MSH `client-v1`.
- Reap the private **Xvfb (3840x2160x24) + fluxbox** R2025b starts per engine. Neither matches
  `pkill -f MATLAB`, so they leaked on every restart *and* on graceful `quit()`. Uses the
  bracket trick (`sys/[X]vfb/...`) so `pkill` doesn't match its own shell.

**4. One submission at a time** (`37372dcd`)

Pyro5's daemon is threaded and the worker had no `max_concurrent_activities` (SDK default 100)
against a **single** engine, so a timeout could `pkill` MATLAB out from under a submission
still executing in it. Adds an engine lock plus a new `TEMPORAL_MAX_CONCURRENT_ACTIVITIES`,
set to `1` for the MATLAB worker only. Unset elsewhere keeps the SDK default — verified: the
coder and default workers still log `max_concurrent_activities=SDK default`. Scale this worker
with `MATLAB_TESTING_WORKER_REPLICAS` (one engine each), not with threads.

## Verification

Rebuilt `computor-base` + the worker image, then ran real submissions through the API
(`POST /tests`), not a synthetic harness — plain, graphics, and `getframe` cases:

| example | result | duration |
|---|---|---|
| `cell_training_1` (no graphics) | 1/7 — genuine student-code failure, correctly reported | 6.2s |
| `plot_hyperbolic_functions` | **7/7 PASSED** | 15.8s |
| `make_movie2_d` | **5/5 PASSED** | 27.6s |

`make_movie2_d` breakdown: `exec=11.95s` for one run of the student code (75 `getframe`
calls), inside a 25.2s test group because reference and student both run.

Across all three, on one engine: **0 restart/stuck events**, every submission on the cheap
reset path (`Engine is already available!`), exactly one MATLAB + one Xvfb + one fluxbox
afterwards (no leak), zero figures left open, `180s` reaching the Pyro call.

Per-submission cost measured at **2.77s → 0.61s**.

## Not fixed (deliberate)

- A restart still costs ~13s (engine start + first-suite class loading). Inherent to starting
  R2025b — this removes the *causes* of restarts, not the cost of one.
- `getframe` is still ~110-160 ms/frame. Movie examples now fit comfortably in 180s instead of
  blowing 45s, but they are not fast. The renderer is not tunable: R2025b refuses
  `Renderer='opengl'` headless and falls back to painters either way.

Caveat: no R2024b install or image remains on the host, so the releases could not be A/B'd.
The numbers say where the time goes today, not how much slower R2025b is than R2024b.
