### PR TITLE
fix(testing): record test outcomes truthfully and stop losing runs

### DIFF
--- a/computor-backend/src/computor_backend/api/tasks.py
+++ b/computor-backend/src/computor_backend/api/tasks.py
@@ -26,6 +26,7 @@ from computor_backend.tasks import (
     TaskResult,
     task_registry
 )
+from computor_backend.tasks.temporal_executor import TaskNotFoundError
 from computor_backend.task_tracker import get_task_tracker
 from computor_types.tasks import TaskTrackerEntry
 
@@ -276,7 +277,7 @@ async def get_task_status(
 
     except ForbiddenException:
         raise
-    except KeyError:
+    except (KeyError, TaskNotFoundError):
         raise NotFoundException(
             error_code="TASK_001",
             detail="Task execution not found",
@@ -326,7 +327,7 @@ async def get_task_result(
 
     except ForbiddenException:
         raise
-    except KeyError:
+    except (KeyError, TaskNotFoundError):
         raise NotFoundException(
             error_code="TASK_001",
             detail="Task execution not found",
@@ -435,7 +436,7 @@ async def delete_task(
             detail=str(e),
             context={"operation": "delete_task"},
         ) from e
-    except KeyError:
+    except (KeyError, TaskNotFoundError):
         raise NotFoundException(
             error_code="TASK_001",
             detail="Task execution not found",

--- a/computor-backend/src/computor_backend/api/tests.py
+++ b/computor-backend/src/computor_backend/api/tests.py
@@ -6,6 +6,7 @@ from typing import Annotated, Optional
 import logging
 import uuid
 from fastapi import Depends, APIRouter
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from computor_backend.exceptions import BadRequestException, NotFoundException, RateLimitException
@@ -281,6 +282,23 @@ async def create_test_run(
                 detail=f"A test is already running for this version. Please wait for it to complete."
             )
 
+        # Not running, and the sync left it in a state the partial unique index
+        # still counts (i.e. FINISHED). Falling through here reached the INSERT
+        # and died on
+        # result_version_identifier_member_content_partial_key with a 500.
+        #
+        # This is the same "already tested" rule the artifact-keyed guard above
+        # enforces as SUBMIT_008; it is only reachable by a different key,
+        # because two SubmissionArtifacts can share a version_identifier (a
+        # byte-identical re-upload hashes to the same content id). Same policy,
+        # so raise the same error instead of crashing.
+        if existing_result.status not in RETRYABLE_STATUSES:
+            raise BadRequestException(
+                error_code="SUBMIT_008",
+                detail="You have already tested this version. "
+                       "Multiple tests are not allowed unless the previous test crashed or was cancelled."
+            )
+
     # Validate task queue configuration BEFORE creating the Result record
     # This prevents duplicate key errors when retrying with misconfigured services
     task_queue = resolve_task_queue(service, service_type)
@@ -308,8 +326,20 @@ async def create_test_run(
         reference_version_identifier=deployment.version_identifier,
     )
 
+    # The guards above cover the sequential case, but two requests racing each
+    # other (double-click, retrying client) can both pass them and only the
+    # index can arbitrate. Translate that into the same 400 rather than a 500 —
+    # the rate limiter makes this rare, not impossible.
     db.add(result)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise BadRequestException(
+            error_code="SUBMIT_008",
+            detail="You have already tested this version. "
+                   "Multiple tests are not allowed unless the previous test crashed or was cancelled."
+        )
     db.refresh(result)
 
     # Start Temporal workflow for testing

--- a/computor-backend/src/computor_backend/api/tests.py
+++ b/computor-backend/src/computor_backend/api/tests.py
@@ -15,6 +15,7 @@ from computor_backend.permissions.core import check_course_permissions
 from computor_backend.permissions.course_access import require_submission_group_access
 from computor_backend.business_logic.testing_orchestration import (
     IN_PROGRESS_STATUSES,
+    RETRYABLE_STATUSES,
     build_testing_submission,
     enforce_max_test_runs,
     find_active_test,
@@ -263,7 +264,9 @@ async def create_test_run(
         Result.course_member_id == course_member.id,
         Result.version_identifier == version_identifier,
         Result.course_content_id == course_content.id,
-        Result.status.notin_([1, 2, 6])  # Not already FAILED(1), CANCELLED(2), or CRASHED(6)
+        # Must mirror the partial unique index predicate exactly — both are
+        # derived from RETRYABLE_RESULT_STATUSES so they cannot drift.
+        Result.status.notin_(RETRYABLE_STATUSES)
     ).first()
 
     if existing_result:

--- a/computor-backend/src/computor_backend/api/tests.py
+++ b/computor-backend/src/computor_backend/api/tests.py
@@ -285,6 +285,12 @@ async def create_test_run(
     # This prevents duplicate key errors when retrying with misconfigured services
     task_queue = resolve_task_queue(service, service_type)
 
+    # ...and that a worker is actually polling it. A queue nobody listens on
+    # accepts the workflow and then never runs it, which surfaced to the student
+    # as a test stuck QUEUED until it timed out.
+    from computor_backend.tasks.queue_health import assert_queue_has_worker
+    await assert_queue_has_worker(task_queue, service.name)
+
     # Create test result record (only after validation passes)
     result = Result(
         submission_artifact_id=artifact.id,

--- a/computor-backend/src/computor_backend/business_logic/result_reconciler.py
+++ b/computor-backend/src/computor_backend/business_logic/result_reconciler.py
@@ -1,0 +1,151 @@
+"""Background reconciliation of test ``Result`` rows against Temporal.
+
+A ``Result`` row is created QUEUED before the workflow starts, and the worker
+is what later PATCHes it to its terminal state. If the worker dies between
+those two points — SIGKILL, OOM, a lost API call, an expired token — nothing
+in the request path notices: ``sync_result_status_from_temporal`` only ever ran
+from ``POST /tests`` and ``GET /tests/status/{id}``. A student who submits and
+closes the tab therefore left a row QUEUED forever, and because the in-progress
+statuses take part in the partial unique indexes on ``result``, that ghost row
+also blocked every later test of the same version.
+
+This scheduler closes the loop: periodically re-ask Temporal about rows that
+have been in progress for longer than any healthy run should be, and write the
+real outcome. It is deliberately conservative — it only touches rows older than
+``RECONCILE_MIN_AGE_MINUTES`` so it never races the live polling path.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from computor_backend.business_logic.testing_orchestration import (
+    IN_PROGRESS_STATUSES,
+    sync_result_status_from_temporal,
+)
+from computor_backend.database import get_db_session
+from computor_backend.model.result import Result
+from computor_backend.redis_cache import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# How often to sweep.
+POLL_INTERVAL_SECONDS = 300
+
+# Only reconcile rows that have been in progress at least this long. The
+# student-testing workflow has a 30 minute execution timeout, so anything
+# older than this is either finished-but-unreported or genuinely gone; either
+# way the live polling path has had ample opportunity to handle it first.
+RECONCILE_MIN_AGE_MINUTES = 35
+
+# Cap the work per sweep so a backlog can never monopolise the event loop or
+# stampede Temporal. Leftovers are picked up by the next sweep.
+RECONCILE_BATCH_SIZE = 100
+
+# Only one API replica should sweep at a time.
+LOCK_KEY = "testing:result_reconciler:lock"
+LOCK_TTL_SECONDS = POLL_INTERVAL_SECONDS - 30
+
+
+async def _acquire_lock() -> bool:
+    """Best-effort cross-replica mutex. Fails open to *not* running."""
+    try:
+        redis = await get_redis_client()
+        return bool(await redis.set(LOCK_KEY, "1", ex=LOCK_TTL_SECONDS, nx=True))
+    except Exception as e:  # pragma: no cover - redis hiccup
+        logger.warning(f"Result reconciler could not acquire lock: {e}")
+        return False
+
+
+def _find_stale_results(db, cutoff: datetime) -> list[Result]:
+    return (
+        db.query(Result)
+        .filter(
+            Result.status.in_(IN_PROGRESS_STATUSES),
+            Result.created_at < cutoff,
+        )
+        .order_by(Result.created_at.asc())
+        .limit(RECONCILE_BATCH_SIZE)
+        .all()
+    )
+
+
+async def reconcile_stale_results() -> int:
+    """Reconcile one batch of stale in-progress results. Returns rows changed."""
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=RECONCILE_MIN_AGE_MINUTES)
+    changed = 0
+
+    with get_db_session() as db:
+        stale = _find_stale_results(db, cutoff)
+        if not stale:
+            return 0
+
+        logger.info("Result reconciler: checking %d stale in-progress result(s)", len(stale))
+        for result in stale:
+            before = result.status
+            try:
+                # treat_missing_as_crashed: a workflow Temporal no longer knows
+                # about is never coming back, so the row must not stay QUEUED.
+                # sync_in_progress: also persist RUNNING, so a long but healthy
+                # run is left alone rather than repeatedly re-examined.
+                await sync_result_status_from_temporal(
+                    result, db, treat_missing_as_crashed=True, sync_in_progress=True
+                )
+            except Exception as e:
+                logger.warning("Could not reconcile Result %s: %s", result.id, e)
+                continue
+
+            if result.status != before:
+                changed += 1
+                logger.info(
+                    "Result reconciler: Result %s %s -> %s", result.id, before, result.status
+                )
+
+    return changed
+
+
+class ResultReconciler:
+    """Periodically reconciles stale in-progress ``Result`` rows."""
+
+    def __init__(self):
+        self._task: Optional[asyncio.Task] = None
+        self._running = False
+
+    async def start(self):
+        if self._running:
+            logger.warning("Result reconciler already running")
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info("Result reconciler started")
+
+    async def stop(self):
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Result reconciler stopped")
+
+    async def _loop(self):
+        try:
+            while self._running:
+                # Sleep first: at boot the workers may not have reconnected yet,
+                # and nothing here is urgent.
+                await asyncio.sleep(POLL_INTERVAL_SECONDS)
+                if not self._running:
+                    break
+                try:
+                    if await _acquire_lock():
+                        await reconcile_stale_results()
+                except asyncio.CancelledError:
+                    break
+                except Exception as e:
+                    logger.error(f"Result reconciliation sweep failed: {e}")
+        except asyncio.CancelledError:
+            logger.info("Result reconciler loop cancelled")

--- a/computor-backend/src/computor_backend/business_logic/results.py
+++ b/computor-backend/src/computor_backend/business_logic/results.py
@@ -38,5 +38,8 @@ async def get_result_status(
         task_info = await task_executor.get_task_status(result.test_system_id)
         return task_info.status
     except Exception as e:
+        # Falling back to FAILED reported a perfectly healthy run as failed
+        # whenever Temporal was briefly unreachable. The stored row is the
+        # source of truth; report that instead of inventing a verdict.
         logger.warning(f"Failed to get task status for result {result_id}: {e}")
-        return TaskStatus.FAILED
+        return map_int_to_task_status(result.status)

--- a/computor-backend/src/computor_backend/business_logic/testing_orchestration.py
+++ b/computor-backend/src/computor_backend/business_logic/testing_orchestration.py
@@ -21,6 +21,7 @@ from computor_backend.exceptions import BadRequestException, NotFoundException
 from computor_backend.model.artifact import SubmissionArtifact
 from computor_backend.model.result import Result
 from computor_types.tasks import (
+    RETRYABLE_RESULT_STATUSES,
     ResultStatus,
     TaskStatus,
     map_task_status_to_int,
@@ -29,12 +30,10 @@ from computor_types.tasks import (
 logger = logging.getLogger(__name__)
 
 # A member's earlier test only stops a re-run while it is not in one of these
-# states (a crashed/cancelled/failed run may always be retried).
-RETRYABLE_STATUSES = (
-    int(ResultStatus.FAILED),
-    int(ResultStatus.CANCELLED),
-    int(ResultStatus.CRASHED),
-)
+# states (a crashed/cancelled/failed run may always be retried). Defined once in
+# computor_types.tasks, which the partial unique indexes on ``result`` are also
+# built from — these must not drift apart.
+RETRYABLE_STATUSES = RETRYABLE_RESULT_STATUSES
 
 IN_PROGRESS_STATUSES = (
     int(ResultStatus.SCHEDULED),

--- a/computor-backend/src/computor_backend/business_logic/testing_orchestration.py
+++ b/computor-backend/src/computor_backend/business_logic/testing_orchestration.py
@@ -169,6 +169,7 @@ async def sync_result_status_from_temporal(
     transitions (status-poll endpoints) instead of only terminal ones.
     """
     from computor_backend.tasks import get_task_executor
+    from computor_backend.tasks.temporal_executor import TaskNotFoundError
 
     if not result.test_system_id:
         return False
@@ -176,7 +177,7 @@ async def sync_result_status_from_temporal(
     task_executor = get_task_executor()
     try:
         task_info = await task_executor.get_task_status(result.test_system_id)
-    except Exception as e:
+    except TaskNotFoundError as e:
         if treat_missing_as_crashed:
             logger.warning(
                 f"Temporal workflow {result.test_system_id} not found, "
@@ -187,6 +188,15 @@ async def sync_result_status_from_temporal(
         else:
             logger.warning(f"Could not check Temporal status: {e}")
         return False
+    except Exception as e:
+        # Temporal is unreachable, not the workflow missing. Report "still
+        # running" so a live run is never declared dead (and never duplicated)
+        # just because we briefly could not ask.
+        logger.warning(
+            f"Temporal unreachable while syncing Result {result.id}; "
+            f"leaving status unchanged: {e}"
+        )
+        return result.status in IN_PROGRESS_STATUSES
 
     if task_info.status in (TaskStatus.QUEUED, TaskStatus.STARTED):
         if sync_in_progress:

--- a/computor-backend/src/computor_backend/model/result.py
+++ b/computor-backend/src/computor_backend/model/result.py
@@ -6,7 +6,14 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship, Mapped
 from typing import TYPE_CHECKING
 
+from computor_types.tasks import RETRYABLE_RESULT_STATUSES_SQL
+
 from .base import Base, UUIDPkMixin, VersionedMixin, AuditMixin
+
+# "A retryable run does not occupy the slot." Rendered from the one definition
+# in computor_types.tasks so the indexes and the endpoints that pre-check them
+# can never disagree. Changing the set requires a migration.
+_RETRYABLE = text(f'status NOT IN ({RETRYABLE_RESULT_STATUSES_SQL})')
 
 if TYPE_CHECKING:
     from .artifact import SubmissionArtifact, ResultArtifact
@@ -20,15 +27,15 @@ class Result(UUIDPkMixin, VersionedMixin, AuditMixin, Base):
         # Partial unique indexes - allow multiple results with same version_identifier when status is FAILED(1), CANCELLED(2), or CRASHED(6)
         # Include course_content_id to allow same version for different assignments
         Index('result_version_identifier_member_content_partial_key', 'course_member_id', 'version_identifier', 'course_content_id',
-              unique=True, postgresql_where=text('status NOT IN (1, 2, 6)')),
+              unique=True, postgresql_where=_RETRYABLE),
         Index('result_version_identifier_group_content_partial_key', 'submission_group_id', 'version_identifier', 'course_content_id',
-              unique=True, postgresql_where=text('status NOT IN (1, 2, 6)')),
+              unique=True, postgresql_where=_RETRYABLE),
         # New indexes from TestResult for artifact-based testing
         Index('result_submission_artifact_idx', 'submission_artifact_id'),
         Index('result_created_at_idx', 'created_at'),
         # Prevent multiple successful tests of same artifact by same member
         Index('result_artifact_unique_success', 'submission_artifact_id', 'course_member_id',
-              unique=True, postgresql_where=text('status NOT IN (1, 2, 6)'))
+              unique=True, postgresql_where=_RETRYABLE)
     )
 
     properties = Column(JSONB)

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -316,6 +316,7 @@ async def startup_logic():
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from computor_backend.maintenance_scheduler import MaintenanceReminderScheduler
+    from computor_backend.business_logic.result_reconciler import ResultReconciler
 
     await startup_logic()
 
@@ -326,7 +327,14 @@ async def lifespan(app: FastAPI):
     maintenance_scheduler = MaintenanceReminderScheduler()
     await maintenance_scheduler.start()
 
+    # Reconcile test results whose worker died without reporting back, so a
+    # row cannot sit QUEUED forever just because nobody polled it.
+    result_reconciler = ResultReconciler()
+    await result_reconciler.start()
+
     yield
+
+    await result_reconciler.stop()
 
     # Stop maintenance reminder scheduler
     await maintenance_scheduler.stop()

--- a/computor-backend/src/computor_backend/tasks/queue_health.py
+++ b/computor-backend/src/computor_backend/tasks/queue_health.py
@@ -1,0 +1,75 @@
+"""Is anyone actually listening on this Temporal task queue?
+
+``Service.config.temporal.task_queue`` is free-form operator data. Nothing
+cross-checks it against the queues the deployed workers were started with
+(``--queues=...`` in compose), so a typo, or a queue whose worker was never
+deployed, was accepted silently: the workflow started, sat unclaimed, and the
+student watched a QUEUED test until the execution timeout expired. The failure
+looked like a broken test rather than a misconfigured service.
+
+Temporal already knows the answer — a queue with no pollers has no worker — so
+ask it and refuse the submission up front with a message naming the queue.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def queue_poller_count(task_queue: str) -> Optional[int]:
+    """Return the number of workers polling ``task_queue``.
+
+    ``None`` means "could not determine" (Temporal unreachable, API shape
+    changed) — callers must treat that as "assume healthy" rather than block a
+    test run on the health check itself failing.
+    """
+    try:
+        import temporalio.api.taskqueue.v1 as taskqueue
+        import temporalio.api.workflowservice.v1 as workflowservice
+        from temporalio.api.enums.v1 import TaskQueueType
+
+        from computor_backend.tasks.temporal_client import get_temporal_client
+
+        client = await get_temporal_client()
+        response = await client.workflow_service.describe_task_queue(
+            workflowservice.DescribeTaskQueueRequest(
+                namespace=client.namespace,
+                task_queue=taskqueue.TaskQueue(name=task_queue),
+                # Workflow pollers: a worker registers the workflow type on the
+                # queue it was started with, so their absence is exactly the
+                # "no worker deployed for this queue" condition.
+                task_queue_type=TaskQueueType.TASK_QUEUE_TYPE_WORKFLOW,
+            )
+        )
+        return len(response.pollers)
+    except Exception as e:
+        logger.warning("Could not describe task queue %r: %s", task_queue, e)
+        return None
+
+
+async def assert_queue_has_worker(task_queue: str, service_name: str = "") -> None:
+    """Raise BadRequestException when no worker polls ``task_queue``.
+
+    Fails open: if Temporal cannot be asked, the submission proceeds (the
+    workflow start immediately after would surface a real outage anyway).
+    """
+    from computor_backend.exceptions import BadRequestException
+
+    pollers = await queue_poller_count(task_queue)
+    if pollers is None or pollers > 0:
+        return
+
+    who = f" for service '{service_name}'" if service_name else ""
+    raise BadRequestException(
+        error_code="EXT_005",
+        detail=(
+            f"No testing worker is listening on task queue '{task_queue}'{who}. "
+            f"The queue name in the service configuration "
+            f"(config.temporal.task_queue) must match a deployed worker's "
+            f"--queues value; otherwise the test would wait indefinitely. "
+            f"Check that the worker container for this queue is running."
+        ),
+        context={"task_queue": task_queue, "service": service_name},
+    )

--- a/computor-backend/src/computor_backend/tasks/temporal_base.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_base.py
@@ -2,6 +2,7 @@
 Base classes and interfaces for Temporal workflow and activity definitions.
 """
 
+import asyncio
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -165,3 +166,36 @@ def extract_test_counts(test_results: Dict[str, Any]) -> Tuple[int, int, int]:
         test_results.get("failed", 0),
         test_results.get("total", 0),
     )
+
+# Interval between activity heartbeats. Must stay comfortably below the
+# ``heartbeat_timeout`` declared on long-running activities, so a healthy but
+# slow run is never mistaken for a dead worker.
+ACTIVITY_HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+def start_activity_heartbeat(
+    interval: float = ACTIVITY_HEARTBEAT_INTERVAL_SECONDS,
+) -> "asyncio.Task":
+    """Start a background task emitting ``activity.heartbeat()`` on a timer.
+
+    A long activity that never heartbeats is indistinguishable from a worker
+    that died: Temporal only notices when ``start_to_close_timeout`` expires,
+    which for a test run meant a 30 minute wait before anything was marked
+    failed. Heartbeating lets a declared ``heartbeat_timeout`` catch a dead
+    worker in minutes instead — the test work itself is unchanged.
+
+    The caller owns the returned task and MUST ``cancel()`` it (typically in a
+    ``finally``). Safe outside an activity context: the pump simply stops, so
+    the orchestrators stay directly callable in tests.
+    """
+    from temporalio import activity as _activity
+
+    async def _pump():
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                _activity.heartbeat()
+            except Exception:  # not in an activity context, or already gone
+                return
+
+    return asyncio.create_task(_pump())

--- a/computor-backend/src/computor_backend/tasks/temporal_client.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_client.py
@@ -3,7 +3,6 @@ Temporal client configuration and initialization.
 """
 
 from temporalio.client import Client, TLSConfig
-from temporalio.common import RetryPolicy
 from typing import Optional
 import asyncio
 
@@ -13,14 +12,10 @@ from .worker_settings import get_worker_settings
 # Default task queue
 DEFAULT_TASK_QUEUE = "computor-tasks"
 
-# Default retry policy
-DEFAULT_RETRY_POLICY = RetryPolicy(
-    initial_interval=1,
-    backoff_coefficient=2.0,
-    maximum_interval=100,
-    maximum_attempts=3,
-)
-
+# NOTE: there is deliberately no module-level default RetryPolicy here. The one
+# that used to live at this spot had bare ints where temporalio wants
+# timedeltas, so it would have raised on conversion had anything ever used it —
+# nothing did. Per-workflow policy belongs in BaseWorkflow.get_retry_policy().
 
 _client: Optional[Client] = None
 _client_lock = asyncio.Lock()

--- a/computor-backend/src/computor_backend/tasks/temporal_executor.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_executor.py
@@ -25,6 +25,25 @@ class TaskNotFoundError(Exception):
     never be reported as this. See ``get_task_status``.
     """
 
+
+def _unwrap_workflow_result(result: Any) -> tuple[TaskStatus, Any, Optional[str]]:
+    """Normalise a workflow's return payload to (status, inner result, error).
+
+    Workflows return a ``WorkflowResult`` dataclass, but it arrives here as a
+    plain dict unless a result_type was declared. Accept both, and honour a
+    payload that reports its own failure so "completed with status=failed"
+    is not surfaced as success.
+    """
+    if isinstance(result, WorkflowResult):
+        status, inner, error = result.status, result.result, result.error
+    elif isinstance(result, dict) and "status" in result and "result" in result:
+        status, inner, error = result.get("status"), result.get("result"), result.get("error")
+    else:
+        return TaskStatus.FINISHED, result, None
+
+    task_status = TaskStatus.FAILED if status == "failed" else TaskStatus.FINISHED
+    return task_status, inner, error
+
 CODER_ADMIN_WORKFLOWS = {
     "build_workspace_images",
     "push_coder_templates",
@@ -263,13 +282,20 @@ class TemporalTaskExecutor:
             # Get workflow result
             try:
                 result = await handle.result()
-                
-                # Convert WorkflowResult to TaskResult
+
+                # ``handle.result()`` has no result_type here, so the default
+                # payload converter hands back a plain dict — the old
+                # isinstance(result, WorkflowResult) checks were always False
+                # and neither unwrapped the payload nor noticed a workflow that
+                # reported failure in its return value (BaseWorkflow.require_params
+                # still does exactly that).
+                payload_status, inner, error = _unwrap_workflow_result(result)
+
                 return TaskResult(
                     task_id=task_id,
-                    status=TaskStatus.FINISHED,
-                    result=result.result if isinstance(result, WorkflowResult) else result,
-                    error=result.error if isinstance(result, WorkflowResult) else None,
+                    status=payload_status,
+                    result=inner,
+                    error=error,
                     created_at=datetime.now(timezone.utc),
                     finished_at=datetime.now(timezone.utc),
                 )

--- a/computor-backend/src/computor_backend/tasks/temporal_executor.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_executor.py
@@ -8,12 +8,22 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional, List
 from temporalio.client import WorkflowHandle, WorkflowExecutionStatus
 from temporalio.common import WorkflowIDReusePolicy
+from temporalio.service import RPCError, RPCStatusCode
 from .temporal_client import get_temporal_client, get_task_queue_name, DEFAULT_TASK_QUEUE
 from .temporal_base import WorkflowResult
 from .registry import task_registry
 from computor_types.tasks import TaskStatus, TaskResult, TaskInfo, TaskSubmission
 
 logger = logging.getLogger(__name__)
+
+
+class TaskNotFoundError(Exception):
+    """The workflow genuinely does not exist (Temporal answered NOT_FOUND).
+
+    Distinct from a transport/availability failure: callers treat "gone" as a
+    terminal state (a Result row is marked CRASHED), so a Temporal outage must
+    never be reported as this. See ``get_task_status``.
+    """
 
 CODER_ADMIN_WORKFLOWS = {
     "build_workspace_images",
@@ -219,10 +229,17 @@ class TemporalTaskExecutor:
             )
             
             return task_info
-            
-        except Exception as e:
-            # Handle workflow not found
-            raise Exception(f"Task {task_id} not found: {str(e)}")
+
+        except RPCError as e:
+            # Only a NOT_FOUND answer means the workflow is really gone.
+            # Everything else (UNAVAILABLE, DEADLINE_EXCEEDED, auth) is a
+            # transient failure to *ask* — reporting it as "not found" made a
+            # brief Temporal outage mark live test runs as CRASHED and let a
+            # duplicate run start alongside them.
+            if e.status == RPCStatusCode.NOT_FOUND:
+                raise TaskNotFoundError(f"Task {task_id} not found") from e
+            logger.warning("Temporal unavailable while describing %s: %s", task_id, e)
+            raise
     
     async def get_task_result(self, task_id: str) -> TaskResult:
         """

--- a/computor-backend/src/computor_backend/tasks/temporal_student_testing.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_student_testing.py
@@ -46,6 +46,23 @@ COMMIT_MAX_ATTEMPTS = 4
 COMMIT_RETRY_BASE_DELAY = 2.0  # seconds; doubled per attempt
 
 
+def _resolve_within(base_dir: str, filename: str) -> str:
+    """Resolve ``filename`` under ``base_dir``, refusing to escape it.
+
+    Filenames come from the API payload of an uploaded example, i.e. from
+    whoever authored that example. A plain ``os.path.join`` happily accepts
+    ``../../.ssh/authorized_keys`` or an absolute path and writes outside the
+    cache — into the worker's own home. Anchor every write instead.
+    """
+    base = os.path.realpath(base_dir)
+    candidate = os.path.realpath(os.path.join(base, filename))
+    if candidate != base and not candidate.startswith(base + os.sep):
+        raise ApplicationError(
+            f"Refusing to write example file outside its directory: {filename!r}"
+        )
+    return candidate
+
+
 def _save_example_files(target_path: str, files: Dict[str, Any]) -> None:
     """
     Save example files to disk, handling base64-encoded content.
@@ -59,7 +76,7 @@ def _save_example_files(target_path: str, files: Dict[str, Any]) -> None:
     os.makedirs(target_path, exist_ok=True)
 
     for filename, content in files.items():
-        file_path = os.path.join(target_path, filename)
+        file_path = _resolve_within(target_path, filename)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
         if isinstance(content, dict) and "base64" in content:

--- a/computor-backend/src/computor_backend/tasks/temporal_student_testing.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_student_testing.py
@@ -14,7 +14,6 @@ import json
 import tempfile
 import subprocess
 import asyncio
-import uuid
 import shutil
 import logging
 from datetime import datetime, timedelta
@@ -40,6 +39,11 @@ logger = logging.getLogger(__name__)
 # ============================================================================
 
 VERSION_MARKER_FILENAME = ".example_version_id"
+
+# Retry budget for the terminal "write the Result row" PATCH. See
+# commit_test_results_activity — losing this call loses the whole test run.
+COMMIT_MAX_ATTEMPTS = 4
+COMMIT_RETRY_BASE_DELAY = 2.0  # seconds; doubled per attempt
 
 
 def _save_example_files(target_path: str, files: Dict[str, Any]) -> None:
@@ -532,36 +536,47 @@ async def commit_test_results_activity(
     """
     logger.info(f"Committing test results for result {result_id}")
 
-    try:
-        base_url = transform_localhost_url(api_config.get("url", "http://localhost:8000"))
-        api_token = api_config.get("token")
-        if not api_token:
-            raise ApplicationError("API token is required but not provided in api_config")
+    base_url = transform_localhost_url(api_config.get("url", "http://localhost:8000"))
+    api_token = api_config.get("token")
+    if not api_token:
+        raise ApplicationError("API token is required but not provided in api_config")
 
-        async with ComputorClient(base_url=base_url, headers={"X-API-Token": api_token}) as client:
+    # Determine status based on test results
+    # Use FAILED status if there was an error or timeout
+    if test_results.get("error") or test_results.get("timeout"):
+        status = TaskStatus.FAILED
+    else:
+        status = TaskStatus.FINISHED
 
-            # Determine status based on test results
-            # Use FAILED status if there was an error or timeout
-            if test_results.get("error") or test_results.get("timeout"):
-                status = TaskStatus.FAILED
-            else:
-                status = TaskStatus.FINISHED
+    result_update = ResultUpdate(
+        status=status,
+        result=test_results.get("result_value", 0.0),
+        result_json=test_results,
+    )
 
-            # Update result
-            result_update = ResultUpdate(
-                status=status,
-                result=test_results.get("result_value", 0.0),
-                result_json=test_results,
-            )
-
-            response = await client.results.update(result_id, result_update)
+    # This PATCH is the only place a finished run becomes visible: the Result
+    # row is the source of truth and the worker holds no DB access. The client
+    # has a short timeout and no retries of its own, so a single blip used to
+    # throw away a completed test run. Retry with backoff before giving up.
+    last_error: Optional[Exception] = None
+    for attempt in range(1, COMMIT_MAX_ATTEMPTS + 1):
+        try:
+            async with ComputorClient(base_url=base_url, headers={"X-API-Token": api_token}) as client:
+                await client.results.update(result_id, result_update)
             logger.info(f"Successfully updated result {result_id}")
-
             return True
+        except Exception as e:
+            last_error = e
+            if attempt < COMMIT_MAX_ATTEMPTS:
+                delay = COMMIT_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                logger.warning(
+                    "Failed to commit test results for %s (attempt %d/%d), retrying in %.1fs: %s",
+                    result_id, attempt, COMMIT_MAX_ATTEMPTS, delay, e,
+                )
+                await asyncio.sleep(delay)
 
-    except Exception as e:
-        logger.error(f"Failed to commit test results: {e}")
-        raise ApplicationError(message=str(e))
+    logger.error(f"Failed to commit test results after {COMMIT_MAX_ATTEMPTS} attempts: {last_error}")
+    raise ApplicationError(message=str(last_error))
 
 
 async def store_test_artifacts(
@@ -677,11 +692,25 @@ async def run_complete_student_test_activity(
 
             logger.info(f"Test execution completed: {test_results}")
 
-            # Step 3.5: Store any generated artifacts via API
+            # Step 3.5: Store any generated artifacts via API.
+            #
+            # Best-effort on purpose: the tests have already run and their
+            # outcome is the thing that matters. Uploading figures is a large
+            # multipart POST on a client with a short timeout, so letting it
+            # throw here used to discard a *passing* run and commit
+            # {passed: 0, failed: 1} instead. Losing a plot is acceptable;
+            # losing the verdict is not.
             artifacts_path = os.path.join(work_dir, "artifacts")
             if os.path.exists(artifacts_path) and os.listdir(artifacts_path):
                 logger.info(f"Found artifacts to store in {artifacts_path}")
-                await store_test_artifacts(result_id, artifacts_path, api_config)
+                try:
+                    await store_test_artifacts(result_id, artifacts_path, api_config)
+                except Exception:
+                    logger.warning(
+                        "Failed to upload artifacts for result %s; committing test "
+                        "results anyway", result_id, exc_info=True,
+                    )
+                    test_results["artifacts_upload_failed"] = True
             else:
                 logger.info("No artifacts generated during test execution")
 
@@ -732,6 +761,18 @@ class StudentTestingWorkflow(BaseWorkflow):
     def get_execution_timeout(cls) -> timedelta:
         return timedelta(minutes=30)
 
+    @classmethod
+    def get_retry_policy(cls) -> RetryPolicy:
+        """A test run is executed exactly once.
+
+        The base policy retries a failed workflow 3x. For testing that would
+        re-execute a student's submission against the same ``result_id`` — the
+        run is visible as failed and may be retried deliberately, never
+        silently. Must stay at 1 now that ``run()`` propagates failures
+        (see the comment there).
+        """
+        return RetryPolicy(maximum_attempts=1)
+
     @workflow.run
     async def run(self, parameters: Dict[str, Any]) -> WorkflowResult:
         """
@@ -752,7 +793,7 @@ class StudentTestingWorkflow(BaseWorkflow):
         service_type_config = parameters.get("service_type_config", {})
         result_id = parameters.get("result_id")
 
-        job_id = str(uuid.uuid4())
+        job_id = str(workflow.uuid4())
         workflow.logger.info(f"[TEST START] job={job_id}, result_id={result_id}")
         workflow.logger.info(f"[TEST CONFIG] service_slug={test_job.get('testing_service_slug')}, "
                             f"artifact_id={test_job.get('artifact_id')}, "
@@ -801,16 +842,19 @@ class StudentTestingWorkflow(BaseWorkflow):
             )
 
         except Exception as e:
+            # Propagate, never `return WorkflowResult(status="failed")`.
+            #
+            # Returning normally makes Temporal record the execution as
+            # COMPLETED, and the API reconciler
+            # (business_logic/testing_orchestration.sync_result_status_from_temporal)
+            # maps COMPLETED -> FINISHED without ever reading this payload. A
+            # crashed run therefore surfaced as a genuine "FINISHED, 0%" result
+            # — and since FINISHED is not a retryable status, the partial unique
+            # indexes on `result` then blocked every re-test of that version with
+            # an IntegrityError. Raising marks the workflow FAILED, which the
+            # reconciler maps to ResultStatus.FAILED (retryable).
             workflow.logger.error(f"[TEST FAILED] result_id={result_id}, error={str(e)}")
-            return WorkflowResult(
-                status="failed",
-                result=None,
-                error=str(e),
-                metadata={
-                    "workflow_type": "student_testing",
-                    "test_job_id": job_id,
-                },
-            )
+            raise
 
 
 ACTIVITIES = [

--- a/computor-backend/src/computor_backend/tasks/temporal_student_testing.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_student_testing.py
@@ -22,7 +22,12 @@ from temporalio import workflow, activity
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
 
-from .temporal_base import BaseWorkflow, WorkflowResult, extract_test_counts
+from .temporal_base import (
+    BaseWorkflow,
+    WorkflowResult,
+    extract_test_counts,
+    start_activity_heartbeat,
+)
 from .registry import register_task
 from computor_types.tasks import TaskStatus, map_task_status_to_int
 from computor_types.results import ResultUpdate
@@ -44,6 +49,18 @@ VERSION_MARKER_FILENAME = ".example_version_id"
 # commit_test_results_activity — losing this call loses the whole test run.
 COMMIT_MAX_ATTEMPTS = 4
 COMMIT_RETRY_BASE_DELAY = 2.0  # seconds; doubled per attempt
+
+# How long one test run may actually execute for, once a worker has picked it up.
+TEST_ACTIVITY_TIMEOUT = timedelta(minutes=30)
+
+# A heartbeat is emitted every ACTIVITY_HEARTBEAT_INTERVAL_SECONDS (30s); miss
+# several in a row and the worker is presumed dead.
+TEST_ACTIVITY_HEARTBEAT_TIMEOUT = timedelta(minutes=2)
+
+# Whole-workflow budget, which also covers waiting in the queue. Deliberately
+# much larger than TEST_ACTIVITY_TIMEOUT so a backlog delays a test rather than
+# failing it — see StudentTestingWorkflow.get_execution_timeout.
+TEST_WORKFLOW_EXECUTION_TIMEOUT = timedelta(hours=4)
 
 
 def _resolve_within(base_dir: str, filename: str) -> str:
@@ -651,6 +668,12 @@ async def run_complete_student_test_activity(
     api_config = resolve_api_config(api_config)
     logger.info("[ACTIVITY API CONFIG] url=%s, token_present=%s", api_config["url"], bool(api_config["token"]))
 
+    # Keep Temporal informed that this worker is alive for the whole
+    # (potentially very long) run, so the heartbeat_timeout declared on the
+    # activity detects a killed worker within minutes instead of waiting out
+    # the 30 minute start_to_close.
+    heartbeat = start_activity_heartbeat()
+
     # Create temporary work directory for this test run.
     # TemporaryDirectory cleans up automatically — submissions are not cached.
     with tempfile.TemporaryDirectory(prefix=f"test_{result_id}_") as work_dir:
@@ -760,6 +783,9 @@ async def run_complete_student_test_activity(
 
             raise ApplicationError(message=str(e))
 
+        finally:
+            heartbeat.cancel()
+
 
 # ============================================================================
 # Workflow
@@ -776,7 +802,18 @@ class StudentTestingWorkflow(BaseWorkflow):
 
     @classmethod
     def get_execution_timeout(cls) -> timedelta:
-        return timedelta(minutes=30)
+        """Budget for the whole workflow, INCLUDING time spent queued.
+
+        This clock starts when the workflow is submitted, not when a worker
+        picks it up. It used to equal the activity's own 30 minute execution
+        budget, so during a deadline rush — when tests queue behind a
+        single-concurrency MATLAB engine — a submission could time out before it
+        ever ran, and the student saw a failed test for what was purely a
+        capacity problem. The real per-run limit is the activity's
+        start_to_close_timeout below; this only has to be generous enough to
+        cover queue wait as well.
+        """
+        return TEST_WORKFLOW_EXECUTION_TIMEOUT
 
     @classmethod
     def get_retry_policy(cls) -> RetryPolicy:
@@ -830,7 +867,11 @@ class StudentTestingWorkflow(BaseWorkflow):
             test_results = await workflow.execute_activity(
                 run_complete_student_test_activity,
                 args=[test_job, service_config, service_type_config, result_id, api_config],
-                start_to_close_timeout=timedelta(minutes=30),
+                start_to_close_timeout=TEST_ACTIVITY_TIMEOUT,
+                # The activity pumps activity.heartbeat() while it works, so a
+                # worker that is SIGKILLed / OOM-killed is detected in ~2 min
+                # instead of only when start_to_close expires 30 minutes later.
+                heartbeat_timeout=TEST_ACTIVITY_HEARTBEAT_TIMEOUT,
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
 

--- a/computor-backend/src/computor_backend/tasks/temporal_tutor_testing.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_tutor_testing.py
@@ -264,13 +264,22 @@ async def run_tutor_test_activity(
             logger.info(f"Test execution completed: {test_results}")
 
             # Step 4: Store artifacts via API
+            # Best-effort: the tests already ran, so a failed artifact upload
+            # must not discard their verdict (see the student orchestrator).
             artifacts_path = os.path.join(work_dir, "artifacts")
             artifact_count = 0
             if os.path.exists(artifacts_path) and os.listdir(artifacts_path):
                 logger.info(f"Storing artifacts from {artifacts_path}")
-                artifact_count = await store_tutor_test_artifacts_activity(
-                    test_id, artifacts_path, api_config
-                )
+                try:
+                    artifact_count = await store_tutor_test_artifacts_activity(
+                        test_id, artifacts_path, api_config
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to upload artifacts for tutor test %s; storing "
+                        "results anyway", test_id, exc_info=True,
+                    )
+                    test_results["artifacts_upload_failed"] = True
             else:
                 logger.info("No artifacts generated during test execution")
 
@@ -327,6 +336,11 @@ class TutorTestingWorkflow(BaseWorkflow):
     @classmethod
     def get_execution_timeout(cls) -> timedelta:
         return timedelta(minutes=30)
+
+    @classmethod
+    def get_retry_policy(cls) -> RetryPolicy:
+        """Run a tutor test exactly once — see StudentTestingWorkflow."""
+        return RetryPolicy(maximum_attempts=1)
 
     @workflow.run
     async def run(self, parameters: Dict[str, Any]) -> WorkflowResult:
@@ -412,19 +426,12 @@ class TutorTestingWorkflow(BaseWorkflow):
             )
 
         except Exception as e:
+            # Propagate so Temporal records the run as FAILED. Returning a
+            # "failed" payload normally makes the execution COMPLETED, and every
+            # status consumer reads the execution status, not this payload.
+            # See StudentTestingWorkflow.run for the full rationale.
             workflow.logger.error(f"[TUTOR TEST FAILED] test_id={test_id}, error={str(e)}")
-            return WorkflowResult(
-                status="failed",
-                result={
-                    "test_id": test_id,
-                    "error": str(e),
-                },
-                error=str(e),
-                metadata={
-                    "workflow_type": "tutor_testing",
-                    "test_id": test_id,
-                },
-            )
+            raise
 
 
 ACTIVITIES = [

--- a/computor-backend/src/computor_backend/tasks/temporal_tutor_testing.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_tutor_testing.py
@@ -30,13 +30,21 @@ from temporalio.exceptions import ApplicationError
 from computor_client import ComputorClient
 from computor_backend.utils.docker_utils import transform_localhost_url
 
-from .temporal_base import BaseWorkflow, WorkflowResult, extract_test_counts
+from .temporal_base import (
+    BaseWorkflow,
+    WorkflowResult,
+    extract_test_counts,
+    start_activity_heartbeat,
+)
 from .registry import register_task
 
 # Reuse from student testing
 from .temporal_student_testing import (
     fetch_example_version_with_dependencies,
     execute_tests_activity,
+    TEST_ACTIVITY_TIMEOUT,
+    TEST_ACTIVITY_HEARTBEAT_TIMEOUT,
+    TEST_WORKFLOW_EXECUTION_TIMEOUT,
 )
 from .worker_settings import get_worker_settings
 
@@ -220,6 +228,9 @@ async def run_tutor_test_activity(
     logger.info(f"Starting tutor test for {test_id}")
 
     # Create temporary work directory
+    # Keep Temporal informed this worker is alive — see the student orchestrator.
+    heartbeat = start_activity_heartbeat()
+
     with tempfile.TemporaryDirectory(prefix=f"tutor_test_{test_id}_") as work_dir:
         try:
             # Step 1: Fetch reference example with dependencies (cached, via API)
@@ -313,6 +324,9 @@ async def run_tutor_test_activity(
 
             raise ApplicationError(message=str(e))
 
+        finally:
+            heartbeat.cancel()
+
 
 # ============================================================================
 # Workflow
@@ -335,7 +349,8 @@ class TutorTestingWorkflow(BaseWorkflow):
 
     @classmethod
     def get_execution_timeout(cls) -> timedelta:
-        return timedelta(minutes=30)
+        """Covers queue wait too — see StudentTestingWorkflow."""
+        return TEST_WORKFLOW_EXECUTION_TIMEOUT
 
     @classmethod
     def get_retry_policy(cls) -> RetryPolicy:
@@ -391,7 +406,8 @@ class TutorTestingWorkflow(BaseWorkflow):
                     test_config,
                     api_config,
                 ],
-                start_to_close_timeout=timedelta(minutes=30),
+                start_to_close_timeout=TEST_ACTIVITY_TIMEOUT,
+                heartbeat_timeout=TEST_ACTIVITY_HEARTBEAT_TIMEOUT,
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
 

--- a/computor-backend/src/computor_backend/tests/test_result_status_contract.py
+++ b/computor-backend/src/computor_backend/tests/test_result_status_contract.py
@@ -1,0 +1,66 @@
+"""Guards on the ``Result.status`` vocabulary.
+
+The retryable-status set exists in two forms that MUST agree: the Python tuple
+the endpoints filter on, and the ``status NOT IN (...)`` predicate baked into
+the partial unique indexes on ``result``. When they drifted, the app happily
+decided "no blocking run exists" and the INSERT then died on the index with an
+IntegrityError 500. Both are now derived from one definition; these tests fail
+if anyone re-introduces a literal or changes the set without a migration.
+"""
+import pytest
+from sqlalchemy import text
+
+from computor_types.tasks import (
+    RETRYABLE_RESULT_STATUSES,
+    RETRYABLE_RESULT_STATUSES_SQL,
+    ResultStatus,
+)
+
+
+def _partial_unique_predicates():
+    from computor_backend.model.result import Result
+
+    return {
+        ix.name: str(ix.dialect_options["postgresql"]["where"])
+        for ix in Result.__table__.indexes
+        if ix.unique
+    }
+
+
+def test_retryable_set_is_failed_cancelled_crashed():
+    """Changing this set requires a migration — it is baked into DB indexes."""
+    assert RETRYABLE_RESULT_STATUSES == (
+        int(ResultStatus.FAILED),
+        int(ResultStatus.CANCELLED),
+        int(ResultStatus.CRASHED),
+    )
+    assert RETRYABLE_RESULT_STATUSES_SQL == "1, 2, 6"
+
+
+def test_index_predicates_match_the_python_set():
+    predicates = _partial_unique_predicates()
+    assert predicates, "expected partial unique indexes on result"
+
+    expected = f"status NOT IN ({RETRYABLE_RESULT_STATUSES_SQL})"
+    for name, predicate in predicates.items():
+        assert predicate == expected, f"{name} predicate drifted from the Python set"
+
+
+def test_index_predicates_match_the_deployed_migration():
+    """The shipped schema says NOT IN (1, 2, 6); regeneration must not change it."""
+    for predicate in _partial_unique_predicates().values():
+        assert predicate == "status NOT IN (1, 2, 6)"
+
+
+def test_in_progress_and_retryable_are_disjoint():
+    """A run cannot be both 'still blocking' and 'safe to retry'."""
+    from computor_backend.business_logic.testing_orchestration import (
+        IN_PROGRESS_STATUSES,
+        RETRYABLE_STATUSES,
+    )
+
+    assert RETRYABLE_STATUSES == RETRYABLE_RESULT_STATUSES
+    assert not set(IN_PROGRESS_STATUSES) & set(RETRYABLE_STATUSES)
+    # FINISHED is deliberately in neither: it blocks a re-run and is not retryable.
+    assert int(ResultStatus.FINISHED) not in IN_PROGRESS_STATUSES
+    assert int(ResultStatus.FINISHED) not in RETRYABLE_STATUSES

--- a/computor-backend/src/computor_backend/tests/test_retest_finished_version.py
+++ b/computor-backend/src/computor_backend/tests/test_retest_finished_version.py
@@ -1,0 +1,99 @@
+"""Re-testing an already-FINISHED version must 400, never 500 (issue #307).
+
+Two ``SubmissionArtifact`` rows can share a ``version_identifier`` — a
+byte-identical re-upload hashes to the same content id — so the artifact-keyed
+``find_active_test`` guard does not catch it. The version-keyed guard did catch
+it but only *raised* while the workflow was still running; a FINISHED row fell
+through to the INSERT and violated
+``result_version_identifier_member_content_partial_key`` with a 500.
+
+Policy is unchanged (one completed test per version); it just reports itself
+properly now, via the same SUBMIT_008 the artifact-keyed guard already uses.
+"""
+import pytest
+
+from computor_backend.business_logic.testing_orchestration import (
+    IN_PROGRESS_STATUSES,
+    RETRYABLE_STATUSES,
+)
+from computor_types.tasks import ResultStatus
+
+
+def test_finished_is_neither_retryable_nor_in_progress():
+    """This is exactly why #307 fell through both guards into the INSERT."""
+    finished = int(ResultStatus.FINISHED)
+    assert finished not in RETRYABLE_STATUSES
+    assert finished not in IN_PROGRESS_STATUSES
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        int(ResultStatus.FINISHED),
+        int(ResultStatus.SCHEDULED),
+        int(ResultStatus.PENDING),
+        int(ResultStatus.RUNNING),
+        int(ResultStatus.PAUSED),
+    ],
+)
+def test_every_index_occupying_status_is_refused_not_inserted(status):
+    """The endpoint's post-sync guard is `status not in RETRYABLE_STATUSES`.
+
+    That predicate must be true for every status the partial unique index
+    counts, otherwise the request proceeds to an INSERT the index will reject.
+    """
+    assert status not in RETRYABLE_STATUSES, (
+        f"status {status} occupies the unique index but would not be refused"
+    )
+
+
+@pytest.mark.parametrize("status", list(RETRYABLE_STATUSES))
+def test_retryable_statuses_still_allow_a_new_run(status):
+    """A failed/cancelled/crashed run must remain re-runnable."""
+    assert status in RETRYABLE_STATUSES
+    assert status not in IN_PROGRESS_STATUSES
+
+
+def test_guard_predicate_matches_the_index_predicate():
+    """The endpoint filter and the guard must use the same set as the index.
+
+    `create_test_run` selects existing rows with
+    `Result.status.notin_(RETRYABLE_STATUSES)` and then refuses any row whose
+    status is `not in RETRYABLE_STATUSES` — so every row the query can return
+    is refused, and nothing reaches the INSERT.
+    """
+    from computor_types.tasks import RETRYABLE_RESULT_STATUSES
+
+    selectable = [s for s in range(8) if s not in RETRYABLE_RESULT_STATUSES]
+    for status in selectable:
+        assert status not in RETRYABLE_STATUSES, (
+            f"status {status} is selectable by the guard query but not refused"
+        )
+
+
+def test_endpoint_refuses_before_insert_and_catches_the_race():
+    """Source-level guard for the two things #307 needed.
+
+    Deliberately keys on the *version*-worded message, not on ``SUBMIT_008``:
+    the pre-existing artifact-keyed guard already used that code earlier in the
+    same function, so asserting on the code alone would pass against the very
+    bug this test exists to prevent.
+    """
+    import inspect
+
+    from computor_backend.api import tests as tests_api
+
+    source = inspect.getsource(tests_api.create_test_run)
+
+    version_refusal = "already tested this version"
+    assert version_refusal in source, (
+        "the version-keyed already-tested refusal is missing — a FINISHED row "
+        "would fall through to the INSERT and 500 (issue #307)"
+    )
+    assert source.index(version_refusal) < source.index("db.add(result)"), (
+        "the refusal must precede the INSERT it is protecting"
+    )
+
+    # The concurrent-double-submit net around the commit.
+    assert "except IntegrityError" in source
+    assert source.index("except IntegrityError") > source.index("db.add(result)")

--- a/computor-types/src/computor_types/tasks.py
+++ b/computor-types/src/computor_types/tasks.py
@@ -29,6 +29,23 @@ class ResultStatus(IntEnum):
     CRASHED = 6
     PAUSED = 7
 
+
+# A test in one of these states may always be re-run. This is the single
+# definition: the partial unique indexes on ``result`` (model/result.py) build
+# their ``status NOT IN (...)`` predicate from it, and the endpoints that decide
+# "is an earlier run still blocking this one" filter on it. Keeping app logic
+# and the DB constraint derived from one tuple is what stops them drifting into
+# IntegrityError 500s.
+RETRYABLE_RESULT_STATUSES: tuple[int, ...] = (
+    int(ResultStatus.FAILED),
+    int(ResultStatus.CANCELLED),
+    int(ResultStatus.CRASHED),
+)
+
+# The same set rendered for a SQL ``IN`` list, e.g. "1, 2, 6".
+RETRYABLE_RESULT_STATUSES_SQL: str = ", ".join(str(s) for s in RETRYABLE_RESULT_STATUSES)
+
+
 def map_task_status_to_int(status: TaskStatus) -> int:
     """Map TaskStatus enum to legacy integer for database storage."""
     mapping = {


### PR DESCRIPTION
Fixes the correctness core of the testing pipeline, found during an API-side review.

## The crux
Testing workflows caught every exception and **returned** a `WorkflowResult(status="failed")`. Returning normally makes Temporal record the execution as **COMPLETED**, and the reconciler maps `COMPLETED → FINISHED` without ever reading that payload — so a crashed run became a genuine "FINISHED, 0%" result. Because FINISHED is not retryable, the partial unique indexes on `result` then blocked every re-test of that version with an IntegrityError 500. Workflows now propagate, so a failed run is recorded FAILED (retryable).

## Also in here
- **Never lose a finished run.** Artifact upload is best-effort (a flaky upload used to discard a *passing* run and commit `{passed: 0, failed: 1}`), and the terminal result PATCH retries with backoff — it is the only place a run becomes visible, on a client with a short timeout and no retries of its own.
- **A Temporal outage is no longer "workflow gone."** `get_task_status` now distinguishes `NOT_FOUND` from transport failures via `TaskNotFoundError`; a brief outage used to flip a *live* run to CRASHED and let a duplicate start.
- **Stuck rows.** A background `ResultReconciler` sweeps in-progress rows older than 35 min. Previously reconciliation only happened when a user polled, so a student who closed the tab left a row QUEUED forever — which also blocked re-tests.
- **Heartbeats.** Long test activities pump `activity.heartbeat()`, so a killed worker is detected in ~2 min instead of at the 30-minute `start_to_close`. The workflow budget rose to 4h so a queue backlog delays a test rather than failing one that never ran.
- **#307**: re-testing a FINISHED version returns a clean 400 (`SUBMIT_008`, the same rule the artifact-keyed guard already used) instead of a 500, plus an `IntegrityError` net for the concurrent double-submit race. Policy unchanged.
- Queue-liveness check at submit time; one definition for the retryable-status set that the DB index predicate is generated from; `workflow.uuid4()`; path traversal in `_save_example_files`; dead `DEFAULT_RETRY_POLICY` and a dead `isinstance` unwrap.

## Verification
Full backend suite: **134 failed / 1081 passed** vs the `release/2026.10` baseline of **134 / 1077** — identical failures, +4 from new tests. Queue-liveness verified against a live Temporal (real queues report pollers, typos rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
