### PR TITLE
fix(auth): close the service-manager scope escalation and token lifecycle traps

### DIFF
--- a/computor-backend/src/computor_backend/api/api_tokens.py
+++ b/computor-backend/src/computor_backend/api/api_tokens.py
@@ -48,10 +48,16 @@ def create_token_admin_endpoint(
     db: Session = Depends(get_db),
 ):
     """
-    Create an API token with a predefined value (admin-only).
+    Create an API token with a predefined value.
 
-    This endpoint is for initial deployment where tokens need to be known in advance.
-    Requires admin permissions. Regular users should use the standard token creation endpoint.
+    For initial deployment, where a token has to be known in advance (the
+    worker container and the database must agree on the same value).
+
+    **Permissions**: admin, or `_service_manager` when the target is a service
+    account. It is NOT admin-only, despite what this docstring used to claim —
+    a service manager can set an attacker-chosen predefined value on a service
+    token, which is exactly why the scope ceiling in
+    `business_logic.api_tokens.assert_may_grant_scopes` also applies here.
     """
     return create_api_token_admin(token_data, permissions, db)
 
@@ -64,10 +70,13 @@ def update_token_admin_endpoint(
     db: Session = Depends(get_db),
 ):
     """
-    Update an API token (admin-only).
+    Update an API token (name, description, scopes, expiry).
 
-    This endpoint is primarily for updating token scopes after course creation during deployment.
-    Requires admin permissions.
+    Primarily for adjusting token scopes after course creation during deployment.
+
+    **Permissions**: admin, or `_service_manager` for service-owned tokens
+    (`ApiTokenPermissionHandler` narrows the query to those). Re-scoping is
+    gated by the same ceiling as minting.
     """
     return update_api_token_admin(token_id, token_data, permissions, db)
 

--- a/computor-backend/src/computor_backend/api/tutor.py
+++ b/computor-backend/src/computor_backend/api/tutor.py
@@ -1011,6 +1011,37 @@ async def download_tutor_test_input(
     )
 
 
+async def _assert_may_report_for_tutor_test(
+    test_id: str,
+    permissions: Principal,
+    redis,
+) -> dict:
+    """Gate the worker-facing write endpoints for a tutor test.
+
+    These report the *outcome* of a run, so only the test runner (a service
+    account) or an admin may call them — not the tutor who started the test,
+    and certainly not an unrelated signed-in user. Both endpoints previously
+    had authentication but no authorization at all: any logged-in user could
+    POST arbitrary results or artifacts for any ``test_id`` they could guess.
+
+    Returns the test metadata so callers can rely on the test existing.
+    """
+    metadata = await get_tutor_test_metadata(redis, test_id)
+    if not metadata:
+        raise NotFoundException(
+            detail="Tutor test not found or expired",
+            context={"test_id": str(test_id)},
+        )
+
+    if not (permissions.is_service or permissions.is_admin):
+        raise ForbiddenException(
+            detail="Only the testing service may report results for a tutor test",
+            context={"test_id": str(test_id)},
+        )
+
+    return metadata
+
+
 @tutor_router.post("/tests/{test_id}/results")
 async def submit_tutor_test_results(
     test_id: str,
@@ -1023,7 +1054,10 @@ async def submit_tutor_test_results(
 
     Used by the testing worker to report results after test execution.
     Stores result.json in MinIO and updates Redis state.
+
+    **Permissions**: service account (the test runner) or admin.
     """
+    await _assert_may_report_for_tutor_test(test_id, permissions, redis)
 
     # Store result.json in MinIO (persistent storage)
     await store_result_minio(test_id, result_data)
@@ -1049,13 +1083,17 @@ async def upload_tutor_test_artifacts(
     test_id: str,
     file: Annotated[bytes, File()],
     permissions: Annotated[Principal, Depends(get_current_principal)],
+    redis=Depends(get_redis_client),
 ):
     """
     Upload test artifacts as a ZIP archive.
 
     Used by the testing worker to upload generated artifacts (plots, figures,
     debug output) after test execution.
+
+    **Permissions**: service account (the test runner) or admin.
     """
+    await _assert_may_report_for_tutor_test(test_id, permissions, redis)
 
     artifacts_stored = await store_tutor_test_artifacts_from_zip(test_id, file)
 

--- a/computor-backend/src/computor_backend/business_logic/api_tokens.py
+++ b/computor-backend/src/computor_backend/business_logic/api_tokens.py
@@ -61,11 +61,17 @@ DEFAULT_SERVICE_SCOPES = {
         "example:download",
     ],
     "worker": [
-        # General workers need broader access for orchestration
+        # General workers read course data for orchestration.
+        #
+        # NOTE: `course:create` and `course:update` used to be granted here by
+        # default, which handed every worker-category service system-wide
+        # course-write authority without anyone asking for it. Since
+        # assert_may_grant_scopes now also treats this table as the ceiling a
+        # non-admin may grant, a broad default is doubly expensive. A worker
+        # that genuinely provisions courses should have those two scopes
+        # granted explicitly by an admin.
         "course:get",
         "course:list",
-        "course:create",
-        "course:update",
         "course_content:get",
         "course_content:list",
         "organization:get",
@@ -132,6 +138,32 @@ def get_default_scopes_for_service(
 
     # Return default scopes based on category
     return DEFAULT_SERVICE_SCOPES.get(service_type.category, [])
+
+
+def _constraint_name(error: IntegrityError) -> str:
+    """Best-effort name of the violated constraint (psycopg2 exposes diag)."""
+    diag = getattr(getattr(error, "orig", None), "diag", None)
+    return getattr(diag, "constraint_name", None) or ""
+
+
+def _is_token_hash_collision(error: IntegrityError) -> bool:
+    """True when the insert failed because the generated token hash exists.
+
+    That is the only failure a retry can fix. Prefer the structured constraint
+    name; fall back to the message for drivers that do not expose diagnostics.
+    """
+    name = _constraint_name(error)
+    if name:
+        return "token_hash" in name
+    return "token_hash" in str(getattr(error, "orig", error))
+
+
+def _constraint_hint(error: IntegrityError) -> str:
+    """Human-readable reason for a non-collision integrity failure."""
+    name = _constraint_name(error)
+    if name == "ck_api_token_expiration":
+        return "expires_at must be later than the token's creation time"
+    return f"database constraint violated{f' ({name})' if name else ''}"
 
 
 def assert_may_grant_scopes(
@@ -298,8 +330,20 @@ def create_api_token(
                 created_at=api_token.created_at,
             )
 
-        except IntegrityError:
+        except IntegrityError as e:
             db.rollback()
+
+            # Retrying only makes sense for a token-hash collision — a fresh
+            # random value fixes that. Any other constraint (e.g. the
+            # expires_at > created_at CHECK) fails identically on all five
+            # attempts and then reported "Failed to generate unique token",
+            # which pointed at the wrong thing entirely.
+            if not _is_token_hash_collision(e):
+                logger.error(f"API token insert violated a constraint: {e}")
+                raise BadRequestException(
+                    detail=f"Could not create API token: {_constraint_hint(e)}"
+                ) from e
+
             if attempt == MAX_TOKEN_GENERATION_RETRIES - 1:
                 logger.error(
                     f"Failed to generate unique API token after {MAX_TOKEN_GENERATION_RETRIES} attempts"
@@ -556,16 +600,27 @@ def create_api_token_admin(
     assert_may_mint_token_for(user, permissions)
     assert_may_grant_scopes(user, token_data.scopes, permissions, db, cache)
 
-    # Validate token format
-    predefined_token = token_data.predefined_token
-    if not predefined_token.startswith("ctp_"):
-        raise BadRequestException(
-            detail="Predefined token must start with 'ctp_' prefix"
-        )
+    # Validate the token with the SAME validator authentication uses.
+    #
+    # This used to accept anything starting with "ctp_" and at least 32 chars
+    # long, but permissions/auth.py rejects a token that is not exactly
+    # len("ctp_") + 32 characters of url-safe base64 *before* it ever hashes
+    # it. A 40-character or oddly-charactered value was therefore stored
+    # happily and then failed every single authentication with "Invalid API
+    # token format" — a token dead on arrival, with nothing flagged at
+    # creation time. Reject it here instead.
+    from computor_backend.utils.api_token import validate_token_format
 
-    if len(predefined_token) < 32:
+    predefined_token = token_data.predefined_token
+    if not validate_token_format(predefined_token):
         raise BadRequestException(
-            detail="Predefined token must be at least 32 characters long"
+            detail=(
+                "Predefined token is not a valid Computor API token. It must be "
+                "'ctp_' followed by exactly 32 url-safe base64 characters "
+                "(A-Z a-z 0-9 - _), e.g. the output of "
+                "`computor token create`. A token that does not match this "
+                "format would be stored but rejected at every authentication."
+            )
         )
 
     # Extract prefix (first 12 characters) and hash the token

--- a/computor-backend/src/computor_backend/business_logic/api_tokens.py
+++ b/computor-backend/src/computor_backend/business_logic/api_tokens.py
@@ -134,6 +134,52 @@ def get_default_scopes_for_service(
     return DEFAULT_SERVICE_SCOPES.get(service_type.category, [])
 
 
+def assert_may_grant_scopes(
+    target_user,
+    requested_scopes: Optional[List[str]],
+    permissions: Principal,
+    db: Session,
+    cache: Optional["Cache"] = None,
+) -> None:
+    """Gate WHICH scopes a caller may put on a token (the scope ceiling).
+
+    ``assert_may_mint_token_for`` only decides *whose* token may be minted. On
+    its own that left a hole: token scopes become ordinary
+    ``("permissions", scope)`` claims that non-admin handlers honour, so a
+    ``_service_manager`` — who holds nothing but ``service:*`` and
+    ``api_token:*`` — could mint a service token carrying ``result:update`` or
+    ``user:create`` and then authenticate as that service to forge grades in
+    any course. Delegating machine identities is supposed to be strictly weaker
+    than admin.
+
+    The rule: an admin may grant anything; anyone else may grant only the
+    scopes the target service's own type category already entitles it to
+    (``DEFAULT_SERVICE_SCOPES``) — exactly the set the backend would have
+    assigned by itself. That keeps the intended workflow working (provision a
+    testing service, mint it its 15 testing scopes) while making it impossible
+    to hand a service authority its type was never meant to have.
+    """
+    if permissions.is_admin or not requested_scopes:
+        return
+
+    allowed = set(get_default_scopes_for_service(str(target_user.id), db, cache))
+    excess = sorted({s for s in requested_scopes if s not in allowed})
+    if not excess:
+        return
+
+    raise ForbiddenException(
+        detail=(
+            "You may not grant these scopes: " + ", ".join(excess) + ". "
+            "Only an administrator can issue a token with scopes beyond the "
+            "service type's defaults."
+        ),
+        context={
+            "target_user_id": str(target_user.id),
+            "rejected_scopes": excess,
+        },
+    )
+
+
 def assert_may_mint_token_for(user, permissions: Principal) -> None:
     """Gate minting a token on behalf of another user.
 
@@ -201,6 +247,7 @@ def create_api_token(
         raise BadRequestException(detail="User not found")
 
     assert_may_mint_token_for(user, permissions)
+    assert_may_grant_scopes(user, token_data.scopes, permissions, db, cache)
 
     # Determine scopes: use provided scopes, or get defaults for service accounts
     scopes = token_data.scopes
@@ -362,6 +409,14 @@ def update_api_token_admin(
     if not token:
         raise NotFoundException(detail="API token not found")
 
+    # Re-scoping is minting by another name — apply the same ceiling, or a
+    # non-admin could simply PATCH the scopes they were refused at create time.
+    if token_data.scopes is not None:
+        token_owner = UserRepository(db, cache).get_by_id_optional(str(token.user_id))
+        if token_owner is None:
+            raise NotFoundException(detail="API token owner not found")
+        assert_may_grant_scopes(token_owner, token_data.scopes, permissions, db, cache)
+
     try:
         # Build updates dict
         updates = {"updated_by": permissions.user_id, "updated_at": datetime.now(timezone.utc)}
@@ -499,6 +554,7 @@ def create_api_token_admin(
     # Same rule as create_api_token: a predefined value doesn't make minting
     # for a human account any less of an escalation.
     assert_may_mint_token_for(user, permissions)
+    assert_may_grant_scopes(user, token_data.scopes, permissions, db, cache)
 
     # Validate token format
     predefined_token = token_data.predefined_token

--- a/computor-backend/src/computor_backend/business_logic/bootstrap.py
+++ b/computor-backend/src/computor_backend/business_logic/bootstrap.py
@@ -179,11 +179,17 @@ def _ensure_service(svc: ServiceConfig, system: Principal, db) -> str:
     if not raw:
         return f"{'created' if created_now else 'present'} WITHOUT a token (no api_token.token in YAML)"
 
+    # Validate with the same function authentication uses — a token that merely
+    # *looks* close enough ("ctp_" + >=32 chars) is stored fine and then fails
+    # every worker request with "Invalid API token format".
+    from computor_backend.utils.api_token import validate_token_format
+
     token = os.path.expandvars(raw)
-    if not token or token.startswith("${") or not token.startswith("ctp_") or len(token) < 32:
+    if not token or token.startswith("${") or not validate_token_format(token):
         return (
             f"{'created' if created_now else 'present'} WITHOUT a token — api_token did not resolve "
-            f"to a valid 'ctp_' token (is TESTING_WORKER_TOKEN set & exported in the API's env?)"
+            f"to a valid token ('ctp_' + exactly 32 url-safe base64 chars). "
+            f"Is TESTING_WORKER_TOKEN set & exported in the API's env?"
         )
 
     expires_at = None

--- a/computor-backend/src/computor_backend/business_logic/bootstrap.py
+++ b/computor-backend/src/computor_backend/business_logic/bootstrap.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import yaml
@@ -43,6 +43,7 @@ from computor_backend.database import get_db_session
 from computor_backend.model.example import ExampleRepository
 from computor_backend.model.service import ApiToken, Service
 from computor_backend.permissions.principal import Principal
+from computor_backend.utils.api_token import hash_api_token, validate_token_format
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,74 @@ def _merged_config(svc: ServiceConfig) -> dict:
     return config
 
 
+# A seeded worker token expiring is a total outage for that worker, so start
+# complaining well before it happens.
+TOKEN_EXPIRY_WARNING_DAYS = 30
+
+
+def _report_token_expiry(token: ApiToken, svc: ServiceConfig, created_now: bool, db) -> str:
+    """Describe an existing token's expiry, self-healing an expired pinned one.
+
+    A bootstrap-pinned token is a shared constant: the same value sits in the
+    API's environment and the worker's ``API_TOKEN``. Letting it lapse buys no
+    security (the secret never changes) but takes the whole testing pipeline
+    down with an error that points at authentication rather than at a calendar.
+
+    So: warn as expiry approaches, and if it has already lapsed while the YAML
+    still pins that very same value, extend it. That is not a rotation — the
+    secret is unchanged, nothing that holds it breaks — it just restores a
+    service the operator plainly still wants.
+    """
+    prefix = "created" if created_now else "present"
+    if token.expires_at is None:
+        return f"{prefix} (token already present, never expires)"
+
+    expires_at = token.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    days_left = (expires_at - now).days
+
+    if days_left > TOKEN_EXPIRY_WARNING_DAYS:
+        return f"{prefix} (token already present, expires in {days_left}d)"
+
+    if days_left >= 0:
+        logger.warning(
+            "Service '%s': API token expires in %d day(s) (%s). When it does, "
+            "this service stops authenticating entirely. Mint a replacement, "
+            "update the worker's API_TOKEN, then revoke the old one.",
+            svc.slug, days_left, expires_at.isoformat(),
+        )
+        return f"{prefix} (token already present, EXPIRES IN {days_left}d — rotate it)"
+
+    # Already expired: the service is dead right now.
+    raw = svc.api_token.token if svc.api_token else None
+    pinned = os.path.expandvars(raw) if raw else None
+    same_secret = False
+    if pinned and validate_token_format(pinned):
+        same_secret = hash_api_token(pinned) == token.token_hash
+
+    if not same_secret:
+        logger.error(
+            "Service '%s': API token expired on %s and the deployment file does "
+            "not pin that same token, so it cannot be revived automatically. "
+            "Mint a new token and update the worker's API_TOKEN.",
+            svc.slug, expires_at.isoformat(),
+        )
+        return f"{prefix} (token EXPIRED on {expires_at.date()} — service cannot authenticate)"
+
+    new_expiry = now + timedelta(days=svc.api_token.expires_days or 365)
+    token.expires_at = new_expiry
+    db.commit()
+    logger.warning(
+        "Service '%s': API token had expired on %s; extended to %s. The secret "
+        "is unchanged (still the value pinned in the deployment file), so no "
+        "worker needs reconfiguring.",
+        svc.slug, expires_at.isoformat(), new_expiry.isoformat(),
+    )
+    return f"{prefix} (token had EXPIRED — expiry extended to {new_expiry.date()})"
+
+
 def _ensure_service(svc: ServiceConfig, system: Principal, db) -> str:
     """Ensure one service + its token exist. Returns a short human status."""
     existing = db.query(Service).filter(Service.slug == svc.slug).first()
@@ -173,7 +242,12 @@ def _ensure_service(svc: ServiceConfig, system: Principal, db) -> str:
         .first()
     )
     if has_token is not None:
-        return "created (token already present)" if created_now else "already present"
+        # ...but "exists and is not revoked" is not the same as "works". This
+        # check ignored expiry, and the seeded tokens carry expires_days: 365 —
+        # so roughly a year after first boot the worker's token quietly expired,
+        # every request started failing AUTH_005, and bootstrap still reported
+        # "already present" on every restart. Nothing surfaced it.
+        return _report_token_expiry(has_token, svc, created_now, db)
 
     raw = svc.api_token.token if svc.api_token else None
     if not raw:
@@ -182,8 +256,6 @@ def _ensure_service(svc: ServiceConfig, system: Principal, db) -> str:
     # Validate with the same function authentication uses — a token that merely
     # *looks* close enough ("ctp_" + >=32 chars) is stored fine and then fails
     # every worker request with "Invalid API token format".
-    from computor_backend.utils.api_token import validate_token_format
-
     token = os.path.expandvars(raw)
     if not token or token.startswith("${") or not validate_token_format(token):
         return (

--- a/computor-backend/src/computor_backend/business_logic/service_accounts.py
+++ b/computor-backend/src/computor_backend/business_logic/service_accounts.py
@@ -237,10 +237,18 @@ def get_service_account(
     permissions: Principal,
     db: Session,
 ) -> ServiceGet:
-    """Get service account by ID."""
+    """Get service account by ID.
+
+    Archived services are excluded, exactly as in ``list_service_accounts``.
+    Without this filter a soft-deleted service was invisible in the list yet
+    fully readable — and writable — by id.
+    """
     query = check_permissions(permissions, Service, "get", db)
 
-    service = query.filter(Service.id == service_id).first()
+    service = query.filter(
+        Service.id == service_id,
+        Service.archived_at.is_(None),
+    ).first()
     if not service:
         raise NotFoundException(detail="Service not found")
 
@@ -332,7 +340,13 @@ def update_service_account(
     """
     query = check_permissions(permissions, Service, "update", db)
 
-    service = query.filter(Service.id == service_id).first()
+    # An archived service is deleted as far as the API is concerned; it must
+    # not be silently resurrected (e.g. by PATCHing enabled=true) through a
+    # direct id reference that the list endpoint would never have surfaced.
+    service = query.filter(
+        Service.id == service_id,
+        Service.archived_at.is_(None),
+    ).first()
     if not service:
         raise NotFoundException(detail="Service not found")
 
@@ -411,8 +425,12 @@ def update_service_heartbeat(
     db: Session,
 ) -> None:
     """Update service last_seen_at timestamp (heartbeat)."""
-    # Service can update its own heartbeat
-    service = db.query(Service).filter(Service.id == service_id).first()
+    # Service can update its own heartbeat. Archived services are gone as far
+    # as the API is concerned and must not report liveness.
+    service = db.query(Service).filter(
+        Service.id == service_id,
+        Service.archived_at.is_(None),
+    ).first()
     if not service:
         raise NotFoundException(detail="Service not found")
 

--- a/computor-backend/src/computor_backend/tests/test_token_scope_ceiling.py
+++ b/computor-backend/src/computor_backend/tests/test_token_scope_ceiling.py
@@ -1,0 +1,103 @@
+"""A token minter may not grant scopes beyond the target service type's defaults.
+
+Token scopes become ordinary ``("permissions", scope)`` claims that non-admin
+permission handlers honour. Without a ceiling, a ``_service_manager`` — whose
+own claims are only ``service:*`` and ``api_token:*`` — could mint a service
+token carrying ``result:update`` or ``user:create``, authenticate as that
+service, and forge grades in any course. These tests pin the ceiling.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from computor_backend.business_logic.api_tokens import (
+    DEFAULT_SERVICE_SCOPES,
+    assert_may_grant_scopes,
+)
+from computor_backend.exceptions import ForbiddenException
+
+
+class _Principal(SimpleNamespace):
+    """Minimal stand-in for permissions.Principal."""
+
+
+def _service_manager():
+    return _Principal(is_admin=False, user_id="mgr-1")
+
+
+def _admin():
+    return _Principal(is_admin=True, user_id="admin-1")
+
+
+@pytest.fixture
+def testing_service(monkeypatch):
+    """A service whose type category is 'testing'."""
+    monkeypatch.setattr(
+        "computor_backend.business_logic.api_tokens.get_default_scopes_for_service",
+        lambda *a, **k: list(DEFAULT_SERVICE_SCOPES["testing"]),
+    )
+    return SimpleNamespace(id="svc-user-1", is_service=True)
+
+
+@pytest.fixture
+def agent_service(monkeypatch):
+    """An 'agent' service — no default scopes at all."""
+    monkeypatch.setattr(
+        "computor_backend.business_logic.api_tokens.get_default_scopes_for_service",
+        lambda *a, **k: [],
+    )
+    return SimpleNamespace(id="svc-user-2", is_service=True)
+
+
+def test_service_manager_may_grant_the_types_own_scopes(testing_service):
+    """The intended workflow must keep working: provision a testing worker."""
+    assert_may_grant_scopes(
+        testing_service,
+        ["result:create", "result:update", "example:download"],
+        _service_manager(),
+        db=None,
+    )
+
+
+def test_service_manager_cannot_grant_user_create(testing_service):
+    with pytest.raises(ForbiddenException) as exc:
+        assert_may_grant_scopes(
+            testing_service,
+            ["result:create", "user:create"],
+            _service_manager(),
+            db=None,
+        )
+    assert "user:create" in str(exc.value.detail)
+
+
+def test_service_manager_cannot_grant_result_write_to_an_agent(agent_service):
+    """An agent type has no defaults, so nothing may be granted by a non-admin."""
+    with pytest.raises(ForbiddenException) as exc:
+        assert_may_grant_scopes(
+            agent_service, ["result:update"], _service_manager(), db=None
+        )
+    assert "result:update" in str(exc.value.detail)
+
+
+def test_admin_may_grant_anything(agent_service):
+    assert_may_grant_scopes(
+        agent_service, ["user:create", "result:update"], _admin(), db=None
+    )
+
+
+def test_empty_scopes_are_always_allowed(agent_service):
+    """Empty means 'fill in the type defaults', which is not an escalation."""
+    assert_may_grant_scopes(agent_service, [], _service_manager(), db=None)
+    assert_may_grant_scopes(agent_service, None, _service_manager(), db=None)
+
+
+def test_every_default_scope_set_is_grantable_by_a_service_manager(monkeypatch):
+    """No category may define a default its own manager would be refused."""
+    for category, scopes in DEFAULT_SERVICE_SCOPES.items():
+        monkeypatch.setattr(
+            "computor_backend.business_logic.api_tokens.get_default_scopes_for_service",
+            lambda *a, _s=scopes, **k: list(_s),
+        )
+        assert_may_grant_scopes(
+            SimpleNamespace(id=f"svc-{category}"), list(scopes), _service_manager(), db=None
+        )

--- a/computor-backend/src/computor_backend/tests/test_tutor_test_report_auth.py
+++ b/computor-backend/src/computor_backend/tests/test_tutor_test_report_auth.py
@@ -1,0 +1,92 @@
+"""The tutor-test *write* endpoints must be service-account only.
+
+``POST /tutors/tests/{id}/results`` and ``.../artifacts/upload`` are how the
+testing worker reports a run's outcome. Both had authentication (the router
+requires a principal) but no authorization whatsoever — no owner check, no
+service check — while their sibling ``input/download`` carefully gated on
+owner/admin/service. Any signed-in user could therefore overwrite the result
+JSON and artifacts of any tutor test whose id they could guess (the path
+parameter is a plain ``str``, not even a UUID).
+
+The only callers are the two worker activities in ``temporal_tutor_testing``,
+so the endpoints are now restricted to service accounts and admins.
+"""
+import pytest
+
+from computor_backend.api.tutor import _assert_may_report_for_tutor_test
+from computor_backend.exceptions import ForbiddenException, NotFoundException
+from computor_backend.permissions.principal import Principal
+
+TEST_ID = "11111111-2222-3333-4444-555555555555"
+OWNER_ID = "owner-user-id"
+
+
+class _Redis:
+    """Stands in for the Redis client; only metadata lookup is exercised."""
+
+    def __init__(self, metadata):
+        self._metadata = metadata
+
+
+@pytest.fixture
+def redis_with_test(monkeypatch):
+    async def _get_metadata(redis, test_id):
+        return redis._metadata
+
+    monkeypatch.setattr(
+        "computor_backend.api.tutor.get_tutor_test_metadata", _get_metadata
+    )
+    return _Redis({"test_id": TEST_ID, "user_id": OWNER_ID})
+
+
+@pytest.fixture
+def redis_without_test(monkeypatch):
+    async def _get_metadata(redis, test_id):
+        return None
+
+    monkeypatch.setattr(
+        "computor_backend.api.tutor.get_tutor_test_metadata", _get_metadata
+    )
+    return _Redis(None)
+
+
+@pytest.mark.asyncio
+async def test_service_account_may_report(redis_with_test):
+    """The testing worker must keep working — it authenticates as a service."""
+    principal = Principal(user_id="worker-user", is_service=True)
+    metadata = await _assert_may_report_for_tutor_test(
+        TEST_ID, principal, redis_with_test
+    )
+    assert metadata["test_id"] == TEST_ID
+
+
+@pytest.mark.asyncio
+async def test_admin_may_report(redis_with_test):
+    principal = Principal(user_id="admin-user", is_admin=True)
+    await _assert_may_report_for_tutor_test(TEST_ID, principal, redis_with_test)
+
+
+@pytest.mark.asyncio
+async def test_unrelated_user_is_rejected(redis_with_test):
+    """The actual hole: any logged-in user could poison any tutor test."""
+    principal = Principal(user_id="some-other-user")
+    with pytest.raises(ForbiddenException):
+        await _assert_may_report_for_tutor_test(TEST_ID, principal, redis_with_test)
+
+
+@pytest.mark.asyncio
+async def test_even_the_owning_tutor_cannot_report(redis_with_test):
+    """Results are reported by the runner, never self-asserted by the tutor."""
+    principal = Principal(user_id=OWNER_ID)
+    with pytest.raises(ForbiddenException):
+        await _assert_may_report_for_tutor_test(TEST_ID, principal, redis_with_test)
+
+
+@pytest.mark.asyncio
+async def test_unknown_test_is_not_found(redis_without_test):
+    """A guessed/expired id must 404 before any storage write happens."""
+    principal = Principal(user_id="worker-user", is_service=True)
+    with pytest.raises(NotFoundException):
+        await _assert_may_report_for_tutor_test(
+            TEST_ID, principal, redis_without_test
+        )

--- a/computor-types/src/computor_types/api_tokens.py
+++ b/computor-types/src/computor_types/api_tokens.py
@@ -3,11 +3,29 @@ API Token DTOs for token-based authentication.
 """
 
 from __future__ import annotations
-from datetime import datetime
-from pydantic import BaseModel, Field, ConfigDict
+from datetime import datetime, timezone
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 from typing import Optional, List, Dict, Any
 
 from computor_types.base import BaseEntityGet, BaseEntityList, EntityInterface, ListQuery
+
+
+def _reject_past_expiry(value: Optional[datetime]) -> Optional[datetime]:
+    """Reject an expiry that is already in the past.
+
+    ``api_token`` carries a CHECK constraint (``expires_at > created_at``), so
+    a past date fails at INSERT — but the create path treats *any* IntegrityError
+    as a token-hash collision and retries five times before reporting
+    "Failed to generate unique token", which says nothing about the real
+    problem. Catch it here, where the message can name the actual field.
+    """
+    if value is None:
+        return value
+    # Naive datetimes are treated as UTC (bootstrap builds them with utcnow()).
+    reference = datetime.now(timezone.utc) if value.tzinfo else datetime.utcnow()
+    if value <= reference:
+        raise ValueError("expires_at must be in the future")
+    return value
 
 
 class ApiTokenCreate(BaseModel):
@@ -22,6 +40,8 @@ class ApiTokenCreate(BaseModel):
     user_id: Optional[str] = Field(None, description="User ID that owns this token (defaults to the authenticated user)")
     scopes: List[str] = Field(default_factory=list, description="Token scopes (e.g., ['read:courses', 'write:results'])")
     expires_at: Optional[datetime] = Field(None, description="Token expiration date (null = never expires)")
+
+    _validate_expires_at = field_validator("expires_at")(_reject_past_expiry)
     properties: Optional[Dict[str, Any]] = Field(None, description="Additional properties")
 
 
@@ -38,6 +58,8 @@ class ApiTokenAdminCreate(BaseModel):
     predefined_token: str = Field(..., min_length=32, description="Predefined token value (must start with 'ctp_')")
     scopes: List[str] = Field(default_factory=list, description="Token scopes (e.g., ['read:courses', 'write:results'])")
     expires_at: Optional[datetime] = Field(None, description="Token expiration date (null = never expires)")
+
+    _validate_expires_at = field_validator("expires_at")(_reject_past_expiry)
     properties: Optional[Dict[str, Any]] = Field(None, description="Additional properties")
 
 

--- a/data/deployments/testing-worker.example.yaml
+++ b/data/deployments/testing-worker.example.yaml
@@ -34,6 +34,11 @@ services:
     api_token:
       token: ${TESTING_WORKER_TOKEN}     # expanded from the environment at apply time
       name: Testing Worker Token
+      # Expiry is a hard cutoff: when it passes, this service stops
+      # authenticating and every test fails. Bootstrap warns for the last
+      # 30 days, and if the token lapses while this file still pins the
+      # same value it extends it rather than leaving the pipeline dead.
+      # Omit the field entirely for a token that never expires.
       expires_days: 365
     config:
       temporal:

--- a/docs/service-accounts.md
+++ b/docs/service-accounts.md
@@ -133,6 +133,18 @@ does not re-issue anything — that would silently break a running worker. Rotat
 purpose: mint the new token, update the container's `API_TOKEN`, restart it, then
 revoke the old one.
 
+The token value is also validated with the same checker authentication uses
+(`ctp_` + exactly 32 url-safe base64 characters). A near-miss used to be stored
+happily and then rejected on every request as "Invalid API token format".
+
+**Expiry is a cutoff, not a nudge.** `expires_days: 365` means that a year after
+first boot the worker stops authenticating and every test fails — and because
+the seeding check only asked "is there an unrevoked token", it kept reporting
+*already present* while the pipeline was dead. Startup now warns for the last 30
+days, and if the token has already lapsed while the deployment file still pins
+that same value, it extends the expiry (same secret, so nothing needs
+reconfiguring). Omit `expires_days` for a token that never expires.
+
 ## Wiring a testing worker
 
 ```
@@ -174,6 +186,28 @@ Consequences:
 
 That asymmetry is why only admins may mint a token for another human, and why a
 `_service_manager` is confined to service accounts (below).
+
+### …but there is a ceiling on what you may grant
+
+Because scopes only ever add authority, "who may mint" is not by itself enough:
+a `_service_manager` holds nothing but `service:*` and `api_token:*`, yet could
+once mint a service token carrying `result:update` or `user:create` and then
+authenticate as that service — forging grades in any course.
+
+`assert_may_grant_scopes` (`business_logic/api_tokens.py`) closes that:
+
+| Caller | May grant |
+|---|---|
+| `_admin` | any scope |
+| anyone else (e.g. `_service_manager`) | only the scopes in `DEFAULT_SERVICE_SCOPES` for the target service type's **category** |
+
+So provisioning a testing worker still works — `testing` category ⇒ its 15
+scopes — while a service manager cannot invent authority the type was never
+meant to have. The ceiling applies at every write: `POST /api-tokens`,
+`POST /api-tokens/admin/create`, and `PATCH /api-tokens/admin/{id}` (re-scoping
+is minting by another name). Because the same table is now also the allow-list,
+keep the defaults tight — `worker` deliberately no longer includes
+`course:create`/`course:update`.
 
 ## Governance
 


### PR DESCRIPTION
Closes an authorization hole and several token-lifecycle traps in the service-account surface.

- **Privilege escalation (the main one).** `assert_may_mint_token_for` gated on *who* the target user is but never on *which scopes* were requested, and scopes become ordinary `("permissions", scope)` claims that non-admin handlers honour. A `_service_manager` — whose own claims are only `service:*` and `api_token:*` — could mint a service token carrying `result:update` or `user:create`, authenticate as that service, and forge grades in any course. New `assert_may_grant_scopes` caps a non-admin at the target service type's own `DEFAULT_SERVICE_SCOPES`, applied at create, admin-create **and** re-scope (re-scoping is minting by another name).
- **Unauthenticated tutor ingestion.** `POST /tutors/tests/{id}/results` and `.../artifacts/upload` had authentication but *no* authorization — any signed-in user could overwrite any tutor test's results and artifacts (`test_id` is a plain `str`). Their sibling `input/download` already gated on owner/admin/service. Now restricted to service accounts and admins; the only callers are the two worker activities.
- **Dead-on-arrival tokens.** Admin-create and bootstrap accepted `ctp_` + ≥32 chars, while authentication requires *exactly* 36 chars of url-safe base64. A near-miss stored fine and then failed every request. Both paths now use `validate_token_format`.
- **Token expiry was a silent time bomb.** The seeding check only asked "is there an unrevoked token", so once `expires_days: 365` elapsed the worker stopped authenticating, every test failed, and bootstrap kept reporting *already present*. Now warns for the last 30 days and, if a lapsed token is still pinned in the deployment file, extends it (same secret, nothing to reconfigure).
- Archived services are no longer readable/editable/resurrectable by id; token-create no longer misreports a past `expires_at` as a hash collision; `worker` default scopes lose `course:create`/`course:update`; the false "admin-only" docstrings are corrected.

## Verification
**134 failed / 1088 passed** vs the baseline **134 / 1077** — identical failures, +11 from new tests covering the ceiling and the tutor guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
