### PR TITLE
feat(testing): per-language worker queues derived from the service language

### DIFF
--- a/computor-backend/src/computor_backend/business_logic/testing_orchestration.py
+++ b/computor-backend/src/computor_backend/business_logic/testing_orchestration.py
@@ -11,6 +11,7 @@ caller; only the queries and validation live here.
 """
 import json
 import logging
+import re
 from typing import Optional
 from uuid import UUID
 
@@ -223,23 +224,75 @@ async def sync_result_status_from_temporal(
 TASK_QUEUE_PREFIX = "testing"
 
 
-def default_task_queue_for_language(language: str) -> str:
-    """The conventional queue for a language: ``testing-<language>``.
+def _queue_token(value: str) -> str:
+    """Normalise one component of a derived queue name.
 
-    Deliberately a pure function of the language so the API and the operator
-    can derive the same name independently — the worker is started with
+    Lowercase; anything outside ``[a-z0-9.]`` collapses to a single dash, so
+    ``R2025b`` → ``r2025b`` and ``3.13`` stays ``3.13``.
+    """
+    slug = re.sub(r"[^a-z0-9.]+", "-", value.strip().lower())
+    return slug.strip("-")
+
+
+def default_task_queue_for_language(
+    language: str, language_version: Optional[str] = None
+) -> str:
+    """The conventional queue for a runner: ``testing-<language>[-<version>]``.
+
+    The queue names the *runner*, and a runner is identified by language AND
+    version — two workers with different Python versions are not
+    interchangeable. Keying the queue on language alone would put
+    ``python 3.11`` and ``python 3.13`` on one queue, where whichever worker
+    polled first would execute the test and the carefully-resolved version
+    would be silently ignored.
+
+    A version-less service keeps the plain ``testing-<language>`` name, so
+    single-version installations are unaffected.
+
+    Deliberately a pure function of its inputs so the API and the operator can
+    derive the same name independently — the worker is started with
     ``--queues=<this>``.
     """
-    return f"{TASK_QUEUE_PREFIX}-{language.strip().lower()}"
+    queue = f"{TASK_QUEUE_PREFIX}-{_queue_token(language)}"
+    if language_version and language_version.strip():
+        queue = f"{queue}-{_queue_token(language_version)}"
+    return queue
+
+
+def _config_str(service, key: str) -> Optional[str]:
+    if service.config and isinstance(service.config, dict):
+        value = service.config.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+        if key == "language_version" and isinstance(value, (int, float)):
+            # A number here means the YAML was written unquoted. That is lossy
+            # and cannot be undone: `language_version: 3.10` parses as the float
+            # 3.1, so it will never match an example asking for "3.10". Warn
+            # rather than mismatch in silence.
+            if isinstance(value, float):
+                logger.warning(
+                    "Service '%s' has language_version: %s written as a NUMBER. "
+                    "YAML reads 3.10 as 3.1, so version matching will misbehave — "
+                    "quote it: language_version: \"%s\".",
+                    getattr(service, "name", "?"), value, value,
+                )
+            return str(value)
+    return None
 
 
 def service_language(service) -> Optional[str]:
     """``Service.config.language``, or None."""
-    if service.config and isinstance(service.config, dict):
-        language = service.config.get("language")
-        if isinstance(language, str) and language.strip():
-            return language.strip().lower()
-    return None
+    return _config_str(service, "language")
+
+
+def service_language_version(service) -> Optional[str]:
+    """``Service.config.language_version``, or None.
+
+    Set this when you run more than one version of a language side by side; it
+    both selects the service (examples may request a ``version``) and separates
+    the workers' queues.
+    """
+    return _config_str(service, "language_version")
 
 
 def resolve_task_queue(
@@ -287,10 +340,13 @@ def resolve_task_queue(
     if not task_queue:
         language = service_language(service)
         if language:
-            task_queue = default_task_queue_for_language(language)
+            version = service_language_version(service)
+            task_queue = default_task_queue_for_language(language, version)
             logger.info(
-                "Service '%s' declares no task_queue; routing to '%s' by language '%s'",
+                "Service '%s' declares no task_queue; routing to '%s' by language "
+                "'%s'%s",
                 service.name, task_queue, language,
+                f" version '{version}'" if version else "",
             )
 
     if not task_queue:

--- a/computor-backend/src/computor_backend/business_logic/testing_orchestration.py
+++ b/computor-backend/src/computor_backend/business_logic/testing_orchestration.py
@@ -217,16 +217,51 @@ async def sync_result_status_from_temporal(
     return False
 
 
+# A service that does not name a queue is routed to the fleet for its language.
+# One worker image per language is the intended topology, so the queue is a
+# function of the language rather than a third value to keep in sync by hand.
+TASK_QUEUE_PREFIX = "testing"
+
+
+def default_task_queue_for_language(language: str) -> str:
+    """The conventional queue for a language: ``testing-<language>``.
+
+    Deliberately a pure function of the language so the API and the operator
+    can derive the same name independently — the worker is started with
+    ``--queues=<this>``.
+    """
+    return f"{TASK_QUEUE_PREFIX}-{language.strip().lower()}"
+
+
+def service_language(service) -> Optional[str]:
+    """``Service.config.language``, or None."""
+    if service.config and isinstance(service.config, dict):
+        language = service.config.get("language")
+        if isinstance(language, str) and language.strip():
+            return language.strip().lower()
+    return None
+
+
 def resolve_task_queue(
     service,
     service_type,
     *,
     require_testing_path: bool = True,
 ) -> str:
-    """Extract and validate the Temporal task queue for a testing service.
+    """Resolve the Temporal task queue for a testing service.
 
-    The queue MUST live at ``service.config.temporal.task_queue``. With
-    ``require_testing_path`` the service type path must start with
+    Order:
+      1. an explicit ``service.config.temporal.task_queue`` (always wins, so
+         existing deployments and any bespoke topology are untouched);
+      2. otherwise ``testing-<config.language>``.
+
+    The fallback exists because "one worker per language" is the intended
+    shape, and making the queue a third independently-typed string meant a
+    typo, or a queue nobody deployed, was accepted silently. Deriving it means
+    a service that declares ``language: octave`` routes to ``testing-octave``
+    with nothing further to configure.
+
+    With ``require_testing_path`` the service type path must start with
     ``testing.`` (student test runs); tutor tests skip that check.
     """
     if require_testing_path and not str(service_type.path).startswith("testing."):
@@ -250,18 +285,26 @@ def resolve_task_queue(
             )
 
     if not task_queue:
+        language = service_language(service)
+        if language:
+            task_queue = default_task_queue_for_language(language)
+            logger.info(
+                "Service '%s' declares no task_queue; routing to '%s' by language '%s'",
+                service.name, task_queue, language,
+            )
+
+    if not task_queue:
         config_example = {
-            "temporal": {
-                "task_queue": "testing-matlab",
-                "max_retries": 3,
-                "timeout_minutes": 30
-            }
+            "language": "octave",
+            "temporal": {"task_queue": "testing-octave"},
         }
         raise BadRequestException(
             error_code="EXT_005",
             detail=(
-                f"Testing service '{service.name}' is not properly configured. "
-                f"No task queue specified. Service configuration must include: "
+                f"Testing service '{service.name}' is not properly configured: it "
+                f"declares neither a language nor a task queue, so there is no way "
+                f"to route its tests. Set config.language (the queue is then "
+                f"derived as 'testing-<language>'), or name a queue explicitly: "
                 f"{json.dumps(config_example, indent=2)}"
             )
         )

--- a/computor-backend/src/computor_backend/tests/test_task_queue_derivation.py
+++ b/computor-backend/src/computor_backend/tests/test_task_queue_derivation.py
@@ -1,0 +1,88 @@
+"""The task queue is derived from the service's language unless pinned.
+
+"One worker image per language" is the intended topology, but the queue used to
+be a third free-form string that had to agree with the service's language and
+with the container's ``--queues`` by hand, with nothing checking any of it. It
+is now a function of the language, with an explicit ``temporal.task_queue``
+still winning so existing deployments and bespoke topologies are untouched.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from computor_backend.business_logic.testing_orchestration import (
+    default_task_queue_for_language,
+    resolve_task_queue,
+    service_language,
+)
+from computor_backend.exceptions import BadRequestException
+
+TESTING_TYPE = SimpleNamespace(path="testing.temporal")
+
+
+def _service(config, name="Test Service"):
+    return SimpleNamespace(config=config, name=name)
+
+
+@pytest.mark.parametrize(
+    "language,expected",
+    [
+        ("python", "testing-python"),
+        ("octave", "testing-octave"),
+        ("r", "testing-r"),
+        ("julia", "testing-julia"),
+        ("matlab", "testing-matlab"),
+    ],
+)
+def test_queue_derives_from_language(language, expected):
+    assert default_task_queue_for_language(language) == expected
+    assert resolve_task_queue(_service({"language": language}), TESTING_TYPE) == expected
+
+
+def test_explicit_queue_always_wins():
+    """The shipped services pin 'testing' / 'testing-matlab' — must not move."""
+    shipped_python = {"language": "python", "temporal": {"task_queue": "testing"}}
+    shipped_matlab = {"language": "matlab", "temporal": {"task_queue": "testing-matlab"}}
+    assert resolve_task_queue(_service(shipped_python), TESTING_TYPE) == "testing"
+    assert resolve_task_queue(_service(shipped_matlab), TESTING_TYPE) == "testing-matlab"
+
+
+def test_explicit_queue_wins_even_when_it_contradicts_the_language():
+    """A bespoke topology stays possible — derivation is only a fallback."""
+    config = {"language": "python", "temporal": {"task_queue": "testing-python-gpu"}}
+    assert resolve_task_queue(_service(config), TESTING_TYPE) == "testing-python-gpu"
+
+
+def test_language_is_normalised():
+    assert service_language(_service({"language": "  OCTAVE "})) == "octave"
+    assert resolve_task_queue(_service({"language": " R "}), TESTING_TYPE) == "testing-r"
+
+
+def test_missing_language_and_queue_is_refused():
+    """Nothing to route on — must fail loudly rather than guess a queue."""
+    with pytest.raises(BadRequestException) as exc:
+        resolve_task_queue(_service({}), TESTING_TYPE)
+    assert "language" in str(exc.value.detail)
+
+
+def test_non_testing_service_type_still_rejected():
+    with pytest.raises(BadRequestException):
+        resolve_task_queue(
+            _service({"language": "python"}), SimpleNamespace(path="agent")
+        )
+
+
+def test_tutor_path_skips_the_service_type_check():
+    """Tutor tests may run on a non-testing.* service type."""
+    queue = resolve_task_queue(
+        _service({"language": "octave"}),
+        SimpleNamespace(path="agent"),
+        require_testing_path=False,
+    )
+    assert queue == "testing-octave"
+
+
+def test_service_language_returns_none_when_absent():
+    assert service_language(_service({})) is None
+    assert service_language(_service(None)) is None
+    assert service_language(_service({"language": "   "})) is None

--- a/computor-backend/src/computor_backend/tests/test_task_queue_derivation.py
+++ b/computor-backend/src/computor_backend/tests/test_task_queue_derivation.py
@@ -14,6 +14,7 @@ from computor_backend.business_logic.testing_orchestration import (
     default_task_queue_for_language,
     resolve_task_queue,
     service_language,
+    service_language_version,
 )
 from computor_backend.exceptions import BadRequestException
 
@@ -86,3 +87,63 @@ def test_service_language_returns_none_when_absent():
     assert service_language(_service({})) is None
     assert service_language(_service(None)) is None
     assert service_language(_service({"language": "   "})) is None
+
+
+# --- one queue per RUNNER, and a runner is (language, version) ---------------
+
+
+def test_two_versions_of_one_language_get_separate_queues():
+    """The whole point of version routing.
+
+    Keying the queue on language alone put python 3.11 and python 3.13 on the
+    same queue, where whichever worker polled first executed the test and the
+    resolved version was silently ignored.
+    """
+    py311 = _service({"language": "python", "language_version": "3.11"})
+    py313 = _service({"language": "python", "language_version": "3.13"})
+    q311 = resolve_task_queue(py311, TESTING_TYPE)
+    q313 = resolve_task_queue(py313, TESTING_TYPE)
+    assert q311 == "testing-python-3.11"
+    assert q313 == "testing-python-3.13"
+    assert q311 != q313, "versions must not share a queue"
+
+
+def test_versionless_service_keeps_the_plain_queue_name():
+    """Single-version installations are unaffected."""
+    assert resolve_task_queue(_service({"language": "python"}), TESTING_TYPE) == "testing-python"
+
+
+def test_version_is_normalised_into_the_queue_name():
+    svc = _service({"language": "matlab", "language_version": "R2025b"})
+    assert resolve_task_queue(svc, TESTING_TYPE) == "testing-matlab-r2025b"
+
+
+def test_queue_name_stays_shell_and_temporal_safe():
+    """Odd version strings must not produce spaces or exotic characters."""
+    svc = _service({"language": "c", "language_version": "GCC 13 (beta)"})
+    queue = resolve_task_queue(svc, TESTING_TYPE)
+    assert queue == "testing-c-gcc-13-beta"
+    assert " " not in queue and "(" not in queue
+
+
+def test_numeric_language_version_is_accepted():
+    svc = _service({"language": "c", "language_version": 13})
+    assert service_language_version(svc) == "13"
+    assert resolve_task_queue(svc, TESTING_TYPE) == "testing-c-13"
+
+
+def test_explicit_queue_still_wins_over_a_versioned_derivation():
+    svc = _service({
+        "language": "python",
+        "language_version": "3.13",
+        "temporal": {"task_queue": "testing"},
+    })
+    assert resolve_task_queue(svc, TESTING_TYPE) == "testing"
+
+
+def test_default_queue_helper_is_a_pure_function():
+    """Operators derive the same name by hand for --queues=."""
+    assert default_task_queue_for_language("python") == "testing-python"
+    assert default_task_queue_for_language("python", "3.13") == "testing-python-3.13"
+    assert default_task_queue_for_language("python", "") == "testing-python"
+    assert default_task_queue_for_language("python", None) == "testing-python"

--- a/docker/temporal-worker-testing/testing-worker.py
+++ b/docker/temporal-worker-testing/testing-worker.py
@@ -87,6 +87,68 @@ async def fetch_service_config(
     return None
 
 
+# What each language needs to actually be present in THIS image. Any one of the
+# listed executables satisfies the requirement; an empty list means the runtime
+# is pure-python and always available.
+#
+# This exists because the service says what it can run and the image decides
+# whether that is true, and nothing checked the two against each other. Julia in
+# particular is installed with a trailing `|| echo "... skipping"` in
+# testing-runtimes/Dockerfile, so it can be absent from a perfectly healthy
+# build — a service declaring `language: julia` would then start, advertise
+# itself on the queue, claim every julia test and fail all of them at runtime.
+LANGUAGE_REQUIREMENTS: Dict[str, list] = {
+    "python": ["python3"],
+    "octave": ["octave-cli", "octave"],
+    "r": ["Rscript"],
+    "julia": ["julia"],
+    "c": ["gcc"],
+    "cpp": ["g++"],
+    "fortran": ["gfortran"],
+    "document": [],
+}
+
+
+def assert_language_supported(language: str) -> None:
+    """Fail fast when this image cannot provide ``language``.
+
+    A worker that cannot run what its Service advertises must not start: it
+    would poll the queue, win the work, and fail every test — which reads as
+    "the tests are broken" rather than "this worker is misconfigured".
+    """
+    import shutil
+
+    if language == "matlab":
+        raise SystemExit(
+            "This image cannot run MATLAB tests. The MATLAB worker is a separate "
+            "image with its own entrypoint (docker/temporal-worker-matlab). "
+            "Point this service at that worker, or set config.language to a "
+            "language this image provides: "
+            f"{', '.join(sorted(LANGUAGE_REQUIREMENTS))}."
+        )
+
+    if language not in LANGUAGE_REQUIREMENTS:
+        raise SystemExit(
+            f"Unknown language '{language}'. This worker image provides: "
+            f"{', '.join(sorted(LANGUAGE_REQUIREMENTS))}."
+        )
+
+    candidates = LANGUAGE_REQUIREMENTS[language]
+    if not candidates:
+        return
+
+    found = next((exe for exe in candidates if shutil.which(exe)), None)
+    if found is None:
+        raise SystemExit(
+            f"This worker is configured for language '{language}' but none of "
+            f"{candidates} is installed in the image. Refusing to start: the "
+            f"worker would claim {language} tests from the queue and fail every "
+            f"one of them. Rebuild the image with that runtime, or point this "
+            f"service's config.language at a language the image provides."
+        )
+    print(f"  ✓ {language} runtime available ({found})")
+
+
 def get_service_language(service_config: Optional[ServiceGet], config: Dict[str, Any]) -> str:
     """
     Determine which language runtime to provision in this container.
@@ -405,6 +467,10 @@ def main():
     language = get_service_language(service_config, config)
     print(f"  Primary language: {language}")
 
+    # Refuse to start if this image cannot actually provide it — better a loud
+    # failure here than a worker that claims every test and fails it.
+    assert_language_supported(language)
+
     # computor-testing is installed at Docker build time
     framework_package_path = "/home/worker/computor-testing"
 
@@ -416,6 +482,7 @@ def main():
     for lang_key in ["python", "octave", "r", "julia", "c", "fortran"]:
         if lang_key in config and lang_key != language:
             print(f"\n  Also setting up {lang_key} (found in config)...")
+            assert_language_supported(lang_key)
             setup_language_environment(lang_key, config, framework_package_path)
 
     # Step 2: Start Temporal worker

--- a/docs/service-accounts.md
+++ b/docs/service-accounts.md
@@ -141,13 +141,38 @@ docker-compose        Service (DB)                 worker container
   --queues=testing    config.temporal.task_queue    → config.language → runtime setup
 ```
 
-Three things must agree, and nothing checks them for you:
+Three things must agree — and two of them are now checked for you:
 
 1. The container's `API_TOKEN` must be an active token on the service's user.
-2. `config.temporal.task_queue` must equal the container's `--queues=` value. **A
-   queue with no listening worker leaves test workflows queued forever** rather
-   than failing — the symptom is a submission that never completes.
-3. `config.language` must name a runtime the image actually has.
+2. `config.temporal.task_queue` must equal the container's `--queues=` value.
+   **Checked:** `POST /tests` refuses a service whose queue has no listening
+   worker, naming the queue, instead of leaving the run stuck. You can also just
+   omit `task_queue` — see below.
+3. `config.language` must name a runtime the image actually has. **Checked:** the
+   worker refuses to start if its image cannot provide the language its service
+   advertises, rather than claiming tests it will certainly fail.
+
+### One worker per language
+
+The intended topology is one worker image per language, so the queue is derived
+from the language: a service with `language: octave` and no `temporal.task_queue`
+routes to **`testing-octave`**, and you start that worker with
+`--queues=testing-octave`. An explicit `task_queue` always wins, so existing
+deployments (and bespoke topologies like `testing-python-gpu`) are unaffected.
+
+To add a language:
+
+```bash
+scripts/add-testing-language.sh octave
+```
+
+That mints a conforming token into `.env`, writes
+`data/deployments/testing-worker-octave.yaml` (bootstrap globs that directory,
+so no existing file is edited), and prints the compose block to paste. Restart
+the API to seed the service, then `./computor.sh up`.
+
+Scaling *one* language across several containers does not need any of this —
+use `replicas` on the same queue.
 
 `last_seen_at` on the service is a heartbeat (`PUT /service-accounts/{id}/heartbeat`).
 The unified testing worker does not currently call it, so "never" there is not yet

--- a/scripts/add-testing-language.sh
+++ b/scripts/add-testing-language.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# Add a per-language testing worker.
+#
+# The intended topology is one worker image per language. Wiring one up by hand
+# means touching five places that must agree and that nothing cross-checks: a
+# token in .env, a service in a deployment file, a container in compose, a
+# runtime in the image, and the executionBackend in every example's meta.yaml.
+# This script does the first two (the mechanical, easy-to-typo ones) and prints
+# the compose block for the third.
+#
+# Usage:
+#   scripts/add-testing-language.sh <language> [--queue <name>] [--slug <slug>]
+#
+# Example:
+#   scripts/add-testing-language.sh octave
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${REPO_ROOT}/.env"
+DEPLOY_DIR="${REPO_ROOT}/data/deployments"
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; NC=$'\033[0m'
+
+# Languages the shared testing image can actually provide. MATLAB is excluded on
+# purpose: it is a separate image with its own entrypoint, so it is not something
+# this script can wire up.
+SUPPORTED="python octave r julia c cpp fortran document"
+
+usage() { sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 1; }
+
+[[ $# -ge 1 ]] || usage
+LANGUAGE="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"; shift
+QUEUE=""; SLUG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --queue) QUEUE="$2"; shift 2 ;;
+    --slug)  SLUG="$2";  shift 2 ;;
+    *) echo "${RED}Unknown option: $1${NC}"; usage ;;
+  esac
+done
+
+if [[ "$LANGUAGE" == "matlab" ]]; then
+  echo "${RED}MATLAB is not wired up by this script.${NC}"
+  echo "It runs in its own image (docker/temporal-worker-matlab) with a licensed"
+  echo "engine; see ops/docker/docker-compose.matlab.yaml."
+  exit 1
+fi
+
+if ! printf '%s\n' $SUPPORTED | grep -qx "$LANGUAGE"; then
+  echo "${RED}Unsupported language '${LANGUAGE}'.${NC} The testing image provides: ${SUPPORTED}"
+  exit 1
+fi
+
+# Defaults follow the convention the backend derives queues from, so leaving
+# task_queue unset in the service config would resolve to the same name.
+[[ -n "$QUEUE" ]] || QUEUE="testing-${LANGUAGE}"
+[[ -n "$SLUG"  ]] || SLUG="itpcp.exec.${LANGUAGE}"
+
+LANG_UPPER="$(printf '%s' "$LANGUAGE" | tr '[:lower:]' '[:upper:]')"
+TOKEN_VAR="TESTING_WORKER_TOKEN_${LANG_UPPER}"
+DEPLOY_FILE="${DEPLOY_DIR}/testing-worker-${LANGUAGE}.yaml"
+
+[[ -f "$ENV_FILE" ]] || { echo "${RED}No .env at ${ENV_FILE}${NC} — run ./setup-env.sh first."; exit 1; }
+
+if [[ -f "$DEPLOY_FILE" ]]; then
+  echo "${YELLOW}${DEPLOY_FILE} already exists — leaving it alone.${NC}"
+else
+  # Same shape setup-env.sh uses: ctp_ + 32 url-safe base64 chars. Must satisfy
+  # utils/api_token.validate_token_format or every request 401s.
+  rnd=$(openssl rand -base64 24 2>/dev/null || head -c 24 /dev/urandom | base64)
+  rnd=$(printf '%s' "$rnd" | tr '+/' '-_' | tr -d '=\n\r' | cut -c1-32)
+  TOKEN="ctp_${rnd}"
+
+  if grep -q "^${TOKEN_VAR}=" "$ENV_FILE"; then
+    echo "${YELLOW}${TOKEN_VAR} already in .env — reusing it.${NC}"
+  else
+    printf '\n# Testing worker token for %s (added by scripts/add-testing-language.sh)\n%s="%s"\n' \
+      "$LANGUAGE" "$TOKEN_VAR" "$TOKEN" >> "$ENV_FILE"
+    echo "${GREEN}✓${NC} Added ${TOKEN_VAR} to .env"
+  fi
+
+  mkdir -p "$DEPLOY_DIR"
+  cat > "$DEPLOY_FILE" <<YAML
+# Testing worker for ${LANGUAGE}. Applied idempotently on every API start by
+# business_logic/bootstrap.py:ensure_bootstrap_services.
+services:
+  - slug: ${SLUG}                 # must equal properties.executionBackend.slug
+                                  # in the meta.yaml of ${LANGUAGE} examples
+    service_type_path: testing.temporal
+    language: ${LANGUAGE}         # selects the runner AND, by default, the queue
+    description: ${LANGUAGE} testing worker
+    user:
+      email: testing-worker-${LANGUAGE}@computor.local
+      given_name: Testing
+      family_name: Worker ${LANGUAGE}
+    api_token:
+      token: \${${TOKEN_VAR}}
+      name: Testing Worker Token (${LANGUAGE})
+      # Omit expires_days for a token that never expires. If you set one, note
+      # that expiry is a hard cutoff: the worker stops authenticating and every
+      # test fails. Startup warns for the last 30 days.
+    config:
+      temporal:
+        task_queue: ${QUEUE}      # must equal the container's --queues value
+YAML
+  echo "${GREEN}✓${NC} Wrote ${DEPLOY_FILE#$REPO_ROOT/}"
+fi
+
+cat <<EOF
+
+${YELLOW}Add this service to ops/docker/docker-compose.dev.yaml (and .prod.yaml):${NC}
+
+  temporal-worker-testing-${LANGUAGE}:
+    build:
+      context: ../../
+      dockerfile: ./docker/temporal-worker-testing/Dockerfile
+    networks:
+      - computor-network
+    restart: unless-stopped
+    stop_grace_period: 330s
+    security_opt:
+      - "no-new-privileges:true"
+    command: ["--queues=${QUEUE}"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - TZ=UTC
+      - RUNNING_IN_DOCKER=true
+      - TEMPORAL_HOST=temporal
+      - TEMPORAL_PORT=7233
+      - TEMPORAL_NAMESPACE=default
+      - API_URL=\${API_URL}
+      - API_TOKEN=\${${TOKEN_VAR}:?set ${TOKEN_VAR} in .env}
+      - TESTING_EXECUTABLE=computor-test
+    depends_on:
+      - temporal
+      - postgres
+      - redis
+
+${YELLOW}Then:${NC}
+  1. restart the API so bootstrap creates the service + token
+  2. ./computor.sh up   (builds and starts the new worker)
+  3. point ${LANGUAGE} examples at it in meta.yaml:
+         properties:
+           executionBackend:
+             slug: ${SLUG}
+
+The worker refuses to start if the image cannot provide '${LANGUAGE}', and
+POST /tests refuses a service whose queue has no listening worker — so a
+half-finished wiring fails loudly instead of hanging.
+EOF

--- a/scripts/add-testing-language.sh
+++ b/scripts/add-testing-language.sh
@@ -10,10 +10,11 @@
 # the compose block for the third.
 #
 # Usage:
-#   scripts/add-testing-language.sh <language> [--queue <name>] [--slug <slug>]
+#   scripts/add-testing-language.sh <language> [--version <v>] [--queue <name>] [--slug <slug>]
 #
 # Example:
 #   scripts/add-testing-language.sh octave
+#   scripts/add-testing-language.sh python --version 3.13
 #
 set -euo pipefail
 
@@ -32,11 +33,12 @@ usage() { sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 1; }
 
 [[ $# -ge 1 ]] || usage
 LANGUAGE="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"; shift
-QUEUE=""; SLUG=""
+QUEUE=""; SLUG=""; VERSION=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --queue) QUEUE="$2"; shift 2 ;;
-    --slug)  SLUG="$2";  shift 2 ;;
+    --queue)   QUEUE="$2";   shift 2 ;;
+    --slug)    SLUG="$2";    shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
     *) echo "${RED}Unknown option: $1${NC}"; usage ;;
   esac
 done
@@ -53,14 +55,29 @@ if ! printf '%s\n' $SUPPORTED | grep -qx "$LANGUAGE"; then
   exit 1
 fi
 
-# Defaults follow the convention the backend derives queues from, so leaving
-# task_queue unset in the service config would resolve to the same name.
-[[ -n "$QUEUE" ]] || QUEUE="testing-${LANGUAGE}"
-[[ -n "$SLUG"  ]] || SLUG="itpcp.exec.${LANGUAGE}"
+# Defaults follow the convention the backend derives queues from
+# (testing-<language>[-<version>]), so leaving task_queue unset in the service
+# config resolves to exactly the same name.
+VERSION_TOKEN=""
+if [[ -n "$VERSION" ]]; then
+  VERSION_TOKEN="$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9.]+/-/g; s/^-+//; s/-+$//')"
+fi
 
-LANG_UPPER="$(printf '%s' "$LANGUAGE" | tr '[:lower:]' '[:upper:]')"
+if [[ -z "$QUEUE" ]]; then
+  QUEUE="testing-${LANGUAGE}"
+  [[ -n "$VERSION_TOKEN" ]] && QUEUE="${QUEUE}-${VERSION_TOKEN}"
+fi
+if [[ -z "$SLUG" ]]; then
+  SLUG="itpcp.exec.${LANGUAGE}"
+  [[ -n "$VERSION_TOKEN" ]] && SLUG="${SLUG}.${VERSION_TOKEN}"
+fi
+
+LANG_UPPER="$(printf '%s' "${LANGUAGE}${VERSION_TOKEN:+_$VERSION_TOKEN}" \
+  | tr '[:lower:].-' '[:upper:]__')"
 TOKEN_VAR="TESTING_WORKER_TOKEN_${LANG_UPPER}"
-DEPLOY_FILE="${DEPLOY_DIR}/testing-worker-${LANGUAGE}.yaml"
+NAME_SUFFIX="${LANGUAGE}${VERSION_TOKEN:+-$VERSION_TOKEN}"
+DEPLOY_FILE="${DEPLOY_DIR}/testing-worker-${NAME_SUFFIX}.yaml"
 
 [[ -f "$ENV_FILE" ]] || { echo "${RED}No .env at ${ENV_FILE}${NC} — run ./setup-env.sh first."; exit 1; }
 
@@ -92,7 +109,7 @@ services:
     language: ${LANGUAGE}         # selects the runner AND, by default, the queue
     description: ${LANGUAGE} testing worker
     user:
-      email: testing-worker-${LANGUAGE}@computor.local
+      email: testing-worker-${NAME_SUFFIX}@computor.local
       given_name: Testing
       family_name: Worker ${LANGUAGE}
     api_token:
@@ -101,7 +118,12 @@ services:
       # Omit expires_days for a token that never expires. If you set one, note
       # that expiry is a hard cutoff: the worker stops authenticating and every
       # test fails. Startup warns for the last 30 days.
-    config:
+    config:${VERSION:+
+      # Set when several versions of this language run side by side: it both
+      # selects this service (examples may request executionBackend.version)
+      # and keeps this worker on its own queue. MUST stay quoted — unquoted
+      # YAML would read 3.10 as the float 3.1 and silently break the match.
+      language_version: \"${VERSION}\"}
       temporal:
         task_queue: ${QUEUE}      # must equal the container's --queues value
 YAML
@@ -112,7 +134,7 @@ cat <<EOF
 
 ${YELLOW}Add this service to ops/docker/docker-compose.dev.yaml (and .prod.yaml):${NC}
 
-  temporal-worker-testing-${LANGUAGE}:
+  temporal-worker-testing-${NAME_SUFFIX}:
     build:
       context: ../../
       dockerfile: ./docker/temporal-worker-testing/Dockerfile


### PR DESCRIPTION
Makes "one worker per language" the default topology instead of something you hand-wire in five places.

## Queue derived from the runner
A service declaring `language: octave` with no `temporal.task_queue` now routes to **`testing-octave`**. An explicit queue always wins, so the shipped `testing` / `testing-matlab` services are untouched.

The derived name is `testing-<language>[-<version>]`, lowercase, dash-separated, dots preserved inside the version:

| Service config | Queue |
|---|---|
| `language: python` | `testing-python` |
| `language: python`, `language_version: "3.13"` | `testing-python-3.13` |
| `language: matlab`, `language_version: "R2025b"` | `testing-matlab-r2025b` |

The version **must** be part of the name: keying on language alone put python 3.11 and 3.13 on one queue, where whichever worker polled first ran the test and the resolved version was silently ignored.

## The worker checks it can do the job
A worker now refuses to start if its image cannot provide the language its service advertises. This is not hypothetical — `docker/testing-runtimes/Dockerfile` installs Julia with a trailing `|| echo "Julia installation failed, skipping"`, so a green build can ship without it. Such a worker previously started, claimed every julia test and failed all of them, which reads as "the tests are broken" rather than "this worker is misconfigured". MATLAB is explicitly refused here (separate image and entrypoint).

## Ergonomics
`scripts/add-testing-language.sh <language> [--version <v>]` mints a conforming token into `.env`, writes `data/deployments/testing-worker-<name>.yaml` (bootstrap globs that directory, so no existing file is edited) and prints the compose block.

Note `language_version` is emitted **quoted** — unquoted YAML reads `3.10` as the float `3.1`, which would never match an example asking for `"3.10"`. The backend logs a loud warning if it ever sees a number there.

## Verification
**134 failed / 1096 passed** vs the baseline **134 / 1077**; the capability assertion was exercised inside the real running worker container (all provided languages OK, matlab refused, a simulated missing runtime refused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
