### PR TITLE
feat(examples): bind examples to a language, with slug as an optional pin

### DIFF
--- a/computor-backend/src/computor_backend/api/examples.py
+++ b/computor-backend/src/computor_backend/api/examples.py
@@ -95,19 +95,21 @@ def _resolve_testing_service_id(db: Session, meta: dict) -> Optional[str]:
     so we never silently ship an untestable *assignment*, but we never block an
     *upload* either.
     """
+    from computor_backend.business_logic.testing_service import (
+        resolve_service_for_execution_backend,
+    )
+
     eb = ExampleVersion.extract_execution_backend(meta)
-    slug = eb.get('slug') if eb else None
-    if not slug:
+    binding = (eb.get('slug') or eb.get('language')) if eb else None
+    if not binding:
         return None
-    service = db.query(Service).filter(
-        Service.slug == slug,
-        Service.enabled == True,  # noqa: E712 — SQLAlchemy column comparison
-        Service.archived_at.is_(None),
-    ).first()
+    # One shared rule for upload / assignment / test time: a pinned slug wins,
+    # otherwise the language (optionally versioned) selects the runner.
+    service = resolve_service_for_execution_backend(db, eb)
     if not service:
         logger.info(
-            "Example upload: executionBackend slug %r has no enabled service yet; "
-            "storing testing_service_id=NULL (resolved at assignment time).", slug
+            "Example upload: executionBackend %r has no enabled service yet; "
+            "storing testing_service_id=NULL (resolved at assignment time).", binding
         )
         return None
     return service.id

--- a/computor-backend/src/computor_backend/business_logic/lecturer_deployment.py
+++ b/computor-backend/src/computor_backend/business_logic/lecturer_deployment.py
@@ -140,8 +140,15 @@ def _link_testing_service(
     # service is only needed at test-execution time; mirroring the upload path
     # ("don't block upload when the execution backend isn't registered"), the
     # lecturer assigns now and the link is filled in once the backend exists.
-    slug = example_version.get_execution_backend_slug()
-    if not slug:
+    from computor_backend.business_logic.testing_service import (
+        resolve_service_for_execution_backend,
+    )
+
+    execution_backend = example_version.execution_backend
+    binding = None
+    if isinstance(execution_backend, dict):
+        binding = execution_backend.get("slug") or execution_backend.get("language")
+    if not binding:
         logger.warning(
             "Example version %s has no testing service link and declares no "
             "executionBackend; assigning without one (link it once the backend "
@@ -150,18 +157,16 @@ def _link_testing_service(
         )
         return
 
-    service = db.query(Service).filter(
-        Service.slug == slug,
-        Service.enabled == True,  # noqa: E712 — SQLAlchemy column comparison
-        Service.archived_at.is_(None),
-    ).first()
+    # Same shared rule as upload and test time: a pinned slug selects one
+    # specific runner; otherwise the language (optionally versioned) does.
+    service = resolve_service_for_execution_backend(db, execution_backend)
 
     if not service:
         logger.warning(
-            "Example version %s declares executionBackend '%s', which matches no "
+            "Example version %s declares executionBackend %r, which matches no "
             "enabled, non-archived service; assigning without a testing service "
-            "(register the service or fix the slug, then re-assign/redeploy).",
-            example_version.id, slug,
+            "(register the service or fix the binding, then re-assign/redeploy).",
+            example_version.id, binding,
         )
         return
 
@@ -172,9 +177,9 @@ def _link_testing_service(
     course_content.updated_by = permissions.user_id
     course_content.updated_at = datetime.now(timezone.utc)
     logger.info(
-        "Backfilled testing service '%s' onto example_version %s "
-        "and course content %s",
-        slug, example_version.id, course_content.path,
+        "Backfilled testing service '%s' (via executionBackend %r) onto "
+        "example_version %s and course content %s",
+        service.slug, binding, example_version.id, course_content.path,
     )
 
 

--- a/computor-backend/src/computor_backend/business_logic/testing_service.py
+++ b/computor-backend/src/computor_backend/business_logic/testing_service.py
@@ -33,20 +33,108 @@ def _usable(service: Optional[Service]) -> bool:
     return bool(service and service.enabled and service.archived_at is None)
 
 
+def _enabled_services(db: Session):
+    return db.query(Service).filter(
+        Service.enabled.is_(True),
+        Service.archived_at.is_(None),
+    )
+
+
+def _config_str(service: Service, key: str) -> Optional[str]:
+    config = service.config
+    if not isinstance(config, dict):
+        return None
+    value = config.get(key)
+    return value.strip().lower() if isinstance(value, str) and value.strip() else None
+
+
+def resolve_service_for_execution_backend(
+    db: Session, execution_backend: Optional[dict]
+) -> Optional[Service]:
+    """Resolve an ``executionBackend`` block to the Service that should run it.
+
+    This is the single definition of the binding, used by the upload path, the
+    assignment path and the test-run path.
+
+    Order:
+
+    1. **A pinned ``slug`` wins outright.** It names one specific runner and is
+       honoured strictly — if that service is missing or disabled the answer is
+       None, never "something else that looks similar". Silently substituting a
+       different test runner is not a favour.
+    2. Otherwise match on ``language`` — what the example actually needs. An
+       exact ``version`` match is preferred; failing that, a runner for that
+       language which declares no version at all (the generic one) is used.
+
+    The language route is what makes examples portable: `language: octave` runs
+    on any installation that has an octave runner, whereas a slug hardcodes one
+    deployment's service name into the content.
+    """
+    if not isinstance(execution_backend, dict):
+        return None
+
+    slug = execution_backend.get("slug")
+    if isinstance(slug, str) and slug.strip():
+        service = _enabled_services(db).filter(Service.slug == slug.strip()).first()
+        if service is None and execution_backend.get("language"):
+            logger.info(
+                "executionBackend pins slug %r which has no enabled service; NOT "
+                "falling back to language %r — a pin selects one specific runner.",
+                slug, execution_backend.get("language"),
+            )
+        return service
+
+    language = execution_backend.get("language")
+    if not isinstance(language, str) or not language.strip():
+        return None
+    language = language.strip().lower()
+
+    candidates = [
+        s for s in _enabled_services(db).all() if _config_str(s, "language") == language
+    ]
+    if not candidates:
+        return None
+
+    version = execution_backend.get("version")
+    if version is not None and str(version).strip():
+        wanted = str(version).strip().lower()
+        exact = [s for s in candidates if _config_str(s, "language_version") == wanted]
+        if exact:
+            return exact[0]
+        # No runner pinned to that version — fall back to a generic one for the
+        # language (no language_version declared) rather than an arbitrary
+        # differently-versioned runner.
+        generic = [s for s in candidates if _config_str(s, "language_version") is None]
+        if generic:
+            logger.info(
+                "No %s runner declares version %r; using the generic %s runner '%s'.",
+                language, version, language, generic[0].slug,
+            )
+            return generic[0]
+        logger.info(
+            "No %s runner matches version %r (available: %s).",
+            language, version,
+            [_config_str(s, "language_version") for s in candidates],
+        )
+        return None
+
+    return candidates[0]
+
+
 def resolve_testing_service(course_content: CourseContent, db: Session) -> Optional[Service]:
     """Resolve the testing service for a content (lazy + self-healing).
 
     Order:
       1. the cached ``testing_service_id`` FK, when it still points at a usable
          (enabled, non-archived) service;
-      2. otherwise the service whose ``slug`` equals the deployed example
-         version's ``executionBackend.slug``;
+      2. otherwise ``resolve_service_for_execution_backend`` on the deployed
+         example version's ``executionBackend`` (pinned slug, else language);
       3. on a fresh resolution, backfill the FK (on the content, and on the
          example version) so later calls take the fast path and the column
          reflects reality.
 
-    Returns None when the content has no example deployment / executionBackend
-    slug, or no enabled service matches that slug yet.
+    Returns None when the content has no example deployment / executionBackend,
+    or nothing enabled matches it yet.
     """
     # 1. Cached FK fast-path.
     if course_content.testing_service_id:
@@ -73,21 +161,14 @@ def resolve_testing_service(course_content: CourseContent, db: Session) -> Optio
         .filter(ExampleVersion.id == deployment.example_version_id)
         .first()
     )
-    slug = example_version.get_execution_backend_slug() if example_version else None
-    if not slug:
-        return None
-
-    service = (
-        db.query(Service)
-        .filter(
-            Service.slug == slug,
-            Service.enabled.is_(True),
-            Service.archived_at.is_(None),
-        )
-        .first()
-    )
+    execution_backend = example_version.execution_backend if example_version else None
+    service = resolve_service_for_execution_backend(db, execution_backend)
     if service is None:
         return None
+    binding = (
+        execution_backend.get("slug")
+        or execution_backend.get("language")
+    )
 
     # 3. Self-heal: cache the resolution. The caller's transaction persists it;
     #    if the caller doesn't commit, correctness still holds (re-resolved next
@@ -96,8 +177,8 @@ def resolve_testing_service(course_content: CourseContent, db: Session) -> Optio
     if example_version is not None and example_version.testing_service_id != service.id:
         example_version.testing_service_id = service.id
     logger.info(
-        "Resolved testing service '%s' for course content %s by executionBackend slug "
+        "Resolved testing service '%s' for course content %s via executionBackend %r "
         "(backfilled testing_service_id)",
-        slug, course_content.id,
+        service.slug, course_content.id, binding,
     )
     return service

--- a/computor-backend/src/computor_backend/tests/test_execution_backend_resolution.py
+++ b/computor-backend/src/computor_backend/tests/test_execution_backend_resolution.py
@@ -1,0 +1,134 @@
+"""Resolving ``executionBackend`` to the Service that runs it.
+
+An example used to be required to name a *service instance* (`slug`), which
+hardcoded one deployment's naming into the content: rename the service, or hand
+the example to another institution, and it stops resolving. It can now declare
+what it actually needs — `language: octave` — with `slug` demoted to an optional
+pin. All three call sites (upload, assignment, test run) share this one rule.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from computor_backend.business_logic import testing_service as ts
+
+
+class _FakeQuery:
+    """Just enough of a SQLAlchemy query for the resolver's two shapes."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, *criteria):
+        rows = self._rows
+        for crit in criteria:
+            # Only `Service.slug == <value>` is used on this path.
+            wanted = crit.right.value
+            rows = [r for r in rows if r.slug == wanted]
+        return _FakeQuery(rows)
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+def _service(slug, language=None, language_version=None):
+    config = {}
+    if language:
+        config["language"] = language
+    if language_version:
+        config["language_version"] = language_version
+    return SimpleNamespace(slug=slug, config=config, id=f"id-{slug}")
+
+
+@pytest.fixture
+def services(monkeypatch):
+    """Install a fleet; returns the mutable list so tests can shape it."""
+    fleet = []
+    monkeypatch.setattr(ts, "_enabled_services", lambda db: _FakeQuery(fleet))
+    return fleet
+
+
+def _resolve(eb):
+    return ts.resolve_service_for_execution_backend(db=None, execution_backend=eb)
+
+
+# --- the existing 166 examples must keep working -----------------------------
+
+def test_pinned_slug_still_resolves(services):
+    services.append(_service("itpcp.exec.py", language="python"))
+    assert _resolve({"slug": "itpcp.exec.py", "version": "3.13"}).slug == "itpcp.exec.py"
+
+
+def test_pinned_slug_that_does_not_exist_returns_none(services):
+    services.append(_service("itpcp.exec.py", language="python"))
+    assert _resolve({"slug": "nope"}) is None
+
+
+def test_a_pin_is_never_silently_substituted(services):
+    """A slug names ONE runner. Missing pin must not fall back to language."""
+    services.append(_service("other.python.runner", language="python"))
+    assert _resolve({"slug": "itpcp.exec.py", "language": "python"}) is None
+
+
+# --- the new, portable form ---------------------------------------------------
+
+def test_language_selects_a_runner(services):
+    services.append(_service("acme.octave", language="octave"))
+    services.append(_service("acme.python", language="python"))
+    assert _resolve({"language": "octave"}).slug == "acme.octave"
+
+
+def test_language_is_case_and_space_tolerant(services):
+    services.append(_service("acme.r", language="R"))
+    assert _resolve({"language": " r "}).slug == "acme.r"
+
+
+def test_unknown_language_resolves_to_nothing(services):
+    services.append(_service("acme.python", language="python"))
+    assert _resolve({"language": "cobol"}) is None
+
+
+def test_empty_block_resolves_to_nothing(services):
+    assert _resolve(None) is None
+    assert _resolve({}) is None
+    assert _resolve({"language": "  "}) is None
+
+
+# --- version routing ----------------------------------------------------------
+
+def test_exact_version_wins(services):
+    services.append(_service("py311", language="python", language_version="3.11"))
+    services.append(_service("py313", language="python", language_version="3.13"))
+    assert _resolve({"language": "python", "version": "3.13"}).slug == "py313"
+    assert _resolve({"language": "python", "version": "3.11"}).slug == "py311"
+
+
+def test_unmatched_version_falls_back_to_the_generic_runner(services):
+    services.append(_service("py311", language="python", language_version="3.11"))
+    services.append(_service("pygeneric", language="python"))
+    assert _resolve({"language": "python", "version": "3.12"}).slug == "pygeneric"
+
+
+def test_unmatched_version_with_no_generic_runner_resolves_to_nothing(services):
+    """Better no runner than an arbitrarily-versioned one."""
+    services.append(_service("py311", language="python", language_version="3.11"))
+    assert _resolve({"language": "python", "version": "3.13"}) is None
+
+
+def test_no_version_requested_takes_any_runner_for_the_language(services):
+    services.append(_service("py311", language="python", language_version="3.11"))
+    assert _resolve({"language": "python"}).slug == "py311"
+
+
+def test_version_is_normalised(services):
+    services.append(_service("mat", language="matlab", language_version="R2025b"))
+    assert _resolve({"language": "matlab", "version": " r2025b "}).slug == "mat"
+
+
+def test_numeric_version_is_accepted(services):
+    """meta.yaml may carry an unquoted number (coerce_numbers_to_str)."""
+    services.append(_service("c13", language="c", language_version="13"))
+    assert _resolve({"language": "c", "version": 13}).slug == "c13"

--- a/computor-backend/src/computor_backend/tests/test_link_testing_service.py
+++ b/computor-backend/src/computor_backend/tests/test_link_testing_service.py
@@ -20,6 +20,10 @@ class _FakeQuery:
     def first(self):
         return self._result
 
+    def all(self):
+        # The language route scans candidates rather than filtering by slug.
+        return [self._result] if self._result is not None else []
+
 
 class _FakeDB:
     def __init__(self, service=None):
@@ -38,10 +42,26 @@ def _content(**kw):
     return SimpleNamespace(**base)
 
 
-def _version(slug=None, testing_service_id=None):
+def _version(slug=None, testing_service_id=None, language=None, version=None):
+    """Stub of ExampleVersion.
+
+    Carries the real ``execution_backend`` JSONB block, which is what the shared
+    resolver reads — the old stub only exposed the slug accessor and so drifted
+    out of shape once slug stopped being the only way to bind.
+    """
+    execution_backend = None
+    if slug or language:
+        execution_backend = {}
+        if slug:
+            execution_backend["slug"] = slug
+        if language:
+            execution_backend["language"] = language
+        if version:
+            execution_backend["version"] = version
     return SimpleNamespace(
         id="ev1",
         testing_service_id=testing_service_id,
+        execution_backend=execution_backend,
         get_execution_backend_slug=lambda: slug,
     )
 
@@ -58,12 +78,21 @@ class TestLinkTestingServiceBestEffort:
         assert content.testing_service_id is None
 
     def test_null_fk_resolves_and_links_when_service_exists(self):
-        svc = SimpleNamespace(id="svc-1")
+        svc = SimpleNamespace(id="svc-1", slug="itpcp.exec.py", config={"language": "python"})
         content = _content()
         version = _version(slug="python")
         _link_testing_service(content, version, _PRINCIPAL, _FakeDB(service=svc))
         assert content.testing_service_id == "svc-1"
         assert version.testing_service_id == "svc-1"  # self-healed back onto the version
+
+    def test_null_fk_resolves_by_language_when_no_slug_is_pinned(self):
+        """The portable binding: the example says what it is, not who runs it."""
+        svc = SimpleNamespace(id="svc-oct", slug="acme.octave", config={"language": "octave"})
+        content = _content()
+        version = _version(language="octave")
+        _link_testing_service(content, version, _PRINCIPAL, _FakeDB(service=svc))
+        assert content.testing_service_id == "svc-oct"
+        assert version.testing_service_id == "svc-oct"
 
     def test_existing_fk_is_propagated_without_lookup(self):
         content = _content()

--- a/computor-types/src/computor_types/codeability_meta.py
+++ b/computor-types/src/computor_types/codeability_meta.py
@@ -10,7 +10,7 @@ the CourseContent model which links examples to specific course contexts.
 """
 
 from typing import List, Optional, Union
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic_yaml import to_yaml_str
 
 # Version regex pattern
@@ -99,10 +99,37 @@ class CodeAbilityPerson(CodeAbilityBase):
     affiliation: Optional[str] = Field(None, min_length=1, description="Institutional affiliation")
 
 class CourseExecutionBackendConfig(CodeAbilityBase):
-    """Configuration for course execution backend."""
-    slug: str = Field(description="Unique identifier for the execution backend")
-    version: str = Field(description="Version of the execution backend (e.g., 'r2024b', 'v1.0')")
+    """Configuration for course execution backend.
+
+    Declare EITHER ``language`` (portable: "this is octave code", matched
+    against any runner providing it) OR ``slug`` (a pin: "run it on exactly
+    this registered service"). ``slug`` was once required, which hardcoded one
+    deployment's service name into every example and made content
+    non-transferable between installations; it is now optional.
+    """
+    slug: Optional[str] = Field(
+        None,
+        description="Pin a specific registered execution backend by Service.slug",
+    )
+    language: Optional[str] = Field(
+        None,
+        description="Language this example needs (python, octave, r, julia, c, "
+                    "cpp, fortran, document, matlab) — matched against a runner",
+    )
+    version: Optional[str] = Field(
+        None,
+        description="Language/backend version requirement (e.g. '3.13', 'r2024b')",
+    )
     settings: Optional[dict] = Field(None, description="Backend-specific settings")
+
+    @model_validator(mode="after")
+    def require_slug_or_language(self):
+        if not (self.slug or self.language):
+            raise ValueError(
+                "executionBackend needs either 'language' (portable) or 'slug' "
+                "(pin a specific runner)"
+            )
+        return self
 
 # TypeConfig removed - content types are managed at CourseContent level, not in examples
 
@@ -328,18 +355,36 @@ class ExecutionBackend(CodeAbilityBase):
         coerce_numbers_to_str=True,
     )
 
-    slug: str = Field(
+    slug: Optional[str] = Field(
+        default=None,
         min_length=1,
-        description="Backend identifier (e.g., 'itpcp.exec.mat', 'itpcp.exec.c')"
+        description="Pin a specific runner by Service.slug (e.g. 'itpcp.exec.mat'). "
+                    "Prefer 'language' unless you really need one exact service."
+    )
+    language: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="Language this example needs (python, octave, r, julia, c, "
+                    "cpp, fortran, document, matlab). Portable across installations."
     )
     version: Optional[str] = Field(
         default=None,
-        description="Backend/language version requirement"
+        description="Backend/language version requirement, matched against a "
+                    "runner's config.language_version"
     )
     settings: Optional[ExecutionBackendSettings] = Field(
         default=None,
         description="Backend-specific settings (timeout, memory, etc.)"
     )
+
+    @model_validator(mode="after")
+    def require_slug_or_language(self):
+        if not (self.slug or self.language):
+            raise ValueError(
+                "executionBackend needs either 'language' (portable) or 'slug' "
+                "(pin a specific runner)"
+            )
+        return self
 
 
 class ContentMetadata(CodeAbilityBase):

--- a/docs/service-accounts.md
+++ b/docs/service-accounts.md
@@ -25,16 +25,46 @@ precedence over `Authorization` (`permissions/auth.py:parse_authorization_header
 
 ## Two contracts worth getting right
 
-### 1. The slug binds examples to services — and nothing else
+### 1. An example declares what it needs; the slug is an optional pin
 
-An example's `meta.yaml` declares which testing system may run it:
+An example's `meta.yaml` declares how it must be executed. Prefer **language** —
+it says what the example actually is, and resolves on any installation that has
+a runner for it:
 
 ```yaml
 properties:
   executionBackend:
-    slug: acme.exec.py     # ← must equal Service.slug
+    language: python        # ← what this example needs (portable)
+    version: "3.13"         # ← optional; matched against Service.config.language_version
     settings: { timeout: 60 }
 ```
+
+Use **slug** only when you genuinely need one specific registered service:
+
+```yaml
+properties:
+  executionBackend:
+    slug: acme.exec.py      # ← must equal Service.slug (a pin)
+```
+
+Exactly one of the two is required. A pin is honoured **strictly**: if that
+service is missing or disabled, resolution returns nothing rather than
+substituting a different runner — silently running a student's code on a
+backend the author didn't choose is not a favour. Language binding is what makes
+examples transferable; a slug hardcodes one deployment's service naming into the
+content, so sharing those examples between installations requires editing every
+`meta.yaml`.
+
+Resolution (one rule, shared by upload, assignment and test time —
+`business_logic/testing_service.py:resolve_service_for_execution_backend`):
+
+1. a pinned `slug` → that enabled service, or nothing;
+2. else `language` → a runner whose `config.language` matches, preferring an
+   exact `config.language_version` match, then a runner that declares no version.
+
+That last step is how you run e.g. python 3.11 and 3.13 as separate workers:
+give each service a `config.language_version`, and examples that don't care
+still land on whichever runner declares no version.
 
 That string is matched to `Service.slug` at upload
 (`api/examples.py:_resolve_testing_service_id`), at assignment
@@ -47,7 +77,9 @@ example can be uploaded and assigned before its service exists — testing start
 working the moment a matching slug appears.
 
 The slug is an **identifier you choose**. It does not select the test runner and
-carries no meaning to the code. Any name works.
+carries no meaning to the code — `config.language` does that. Any name works,
+which is exactly why binding content to it is a liability: the name is arbitrary
+and local to one deployment.
 
 ### 2. `config.language` selects the runner
 

--- a/docs/service-accounts.md
+++ b/docs/service-accounts.md
@@ -66,15 +66,15 @@ That last step is how you run e.g. python 3.11 and 3.13 as separate workers:
 give each service a `config.language_version`, and examples that don't care
 still land on whichever runner declares no version.
 
-That string is matched to `Service.slug` at upload
-(`api/examples.py:_resolve_testing_service_id`), at assignment
-(`lecturer_deployment:_link_testing_service`) and again at test time
-(`business_logic/testing_service.py:resolve_testing_service`).
+The binding is resolved at upload (`api/examples.py:_resolve_testing_service_id`),
+at assignment (`lecturer_deployment:_link_testing_service`) and again at test time
+(`business_logic/testing_service.py:resolve_testing_service`) — all three now
+delegate to the single rule above.
 
 `CourseContent.testing_service_id`, `ExampleVersion.testing_service_id` and
 `Result.testing_service_id` are **caches** of that resolution, self-healing. So an
 example can be uploaded and assigned before its service exists — testing starts
-working the moment a matching slug appears.
+working the moment a matching runner appears.
 
 The slug is an **identifier you choose**. It does not select the test runner and
 carries no meaning to the code — `config.language` does that. Any name works,


### PR DESCRIPTION
Lets an example say **what it is** instead of naming one deployment's service instance.

## The problem
`Service.slug` was doing two jobs: the identity of a service instance, *and* the key examples bind to in `meta.yaml`. `slug` was required, so every example hardcoded a name like `itpcp.exec.py` — arbitrary and local to one installation. Rename the service, or hand the example to another institution, and it stops resolving.

## The change
```yaml
properties:
  executionBackend:
    language: python      # what this example needs (portable)
    version: "3.13"       # optional; matched against Service.config.language_version
```

`slug` stays supported and becomes an optional **pin**. Exactly one of the two is required.

A pin is honoured **strictly**: if the pinned service is missing or disabled, resolution returns nothing rather than substituting a different runner — silently executing a student's code on a backend the author didn't choose is not a favour.

Resolution is now one shared rule (`resolve_service_for_execution_backend`) used by all three former call sites — upload, assignment and test time:
1. a pinned `slug` → that enabled service, or nothing;
2. else `language` → exact `config.language_version` match → a runner declaring no version → nothing.

That second step is how python 3.11 and 3.13 run as separate workers while examples that don't care still land on the generic runner.

## Compatibility
No migration: `extract_execution_backend` already stored the meta block verbatim into the `execution_backend` JSONB column. **All 168 example versions in the dev database resolve identically** (98 `itpcp.exec.mat`, 68 `itpcp.exec.py`, 2 with no backend → none).

## Verification
**134 failed / 1091 passed** vs the baseline **134 / 1077**, +14 from new tests. Three tests in `test_link_testing_service.py` needed updating: their `example_version` stub exposed only `get_execution_backend_slug()` while the real model always carries `execution_backend` — the stub had drifted, so the stub was fixed rather than adding a fallback in production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
