### PR TITLE
fix(time): make worker-produced timestamps timezone-aware

### DIFF
--- a/computor-backend/src/computor_backend/business_logic/bootstrap.py
+++ b/computor-backend/src/computor_backend/business_logic/bootstrap.py
@@ -266,7 +266,7 @@ def _ensure_service(svc: ServiceConfig, system: Principal, db) -> str:
 
     expires_at = None
     if svc.api_token.expires_days:
-        expires_at = datetime.utcnow() + timedelta(days=svc.api_token.expires_days)
+        expires_at = datetime.now(timezone.utc) + timedelta(days=svc.api_token.expires_days)
 
     create_api_token_admin(
         ApiTokenAdminCreate(

--- a/computor-backend/src/computor_backend/business_logic/submissions.py
+++ b/computor-backend/src/computor_backend/business_logic/submissions.py
@@ -486,7 +486,12 @@ async def upload_submission_artifact(
         uploaded_by_course_member_id=submitting_member.id,
         total_size=total_filtered_size,
         files_count=len(files_included),
-        uploaded_at=datetime.utcnow(),
+        # The value actually stored (timestamptz, server_default now()), not a
+        # second clock reading: utcnow() produced a naive stamp that both drifted
+        # from the row by the duration of the upload and, having no offset, was
+        # read as local time by clients — so this response and a later artifact
+        # listing disagreed by the UTC offset.
+        uploaded_at=created_artifact.uploaded_at,
         version_identifier=manual_version_identifier,
     )
 

--- a/computor-backend/src/computor_backend/interfaces/api_token.py
+++ b/computor-backend/src/computor_backend/interfaces/api_token.py
@@ -46,11 +46,16 @@ class ApiTokenInterface(ApiTokenInterfaceBase, BackendEntityInterface):
 
         # Active tokens only (not revoked and not expired)
         if hasattr(params, 'active') and params.active is not None:
-            from datetime import datetime
+            from datetime import datetime, timezone
             if params.active:
+                # Aware, not utcnow(): expires_at is timestamptz, so a naive
+                # bound would be resolved against the database session's time
+                # zone. That is UTC today, which is the only reason the naive
+                # form worked — it would silently skew the active/expired
+                # boundary the moment that setting changed.
                 query = query.filter(
                     ApiToken.revoked == False,
-                    (ApiToken.expires_at == None) | (ApiToken.expires_at > datetime.utcnow())
+                    (ApiToken.expires_at == None) | (ApiToken.expires_at > datetime.now(timezone.utc))
                 )
 
         return query

--- a/computor-backend/src/computor_backend/scripts/generate_typescript_clients.py
+++ b/computor-backend/src/computor_backend/scripts/generate_typescript_clients.py
@@ -10,7 +10,7 @@ import os
 import pkgutil
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type
 
@@ -140,7 +140,7 @@ class TypeScriptClientGenerator:
         if not self.include_timestamp:
             raise RuntimeError("Timestamp requested but include_timestamp is False")
         if self._timestamp_value is None:
-            self._timestamp_value = datetime.utcnow().isoformat()
+            self._timestamp_value = datetime.now(timezone.utc).isoformat()
         return self._timestamp_value
 
     # ------------------------------------------------------------------

--- a/computor-backend/src/computor_backend/tasks/temporal_examples.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_examples.py
@@ -3,7 +3,7 @@ Example Temporal workflow and activity implementations.
 """
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
 from temporalio import workflow, activity
 from temporalio.common import RetryPolicy
@@ -16,12 +16,12 @@ from .registry import register_task
 @activity.defn(name="simulate_processing")
 async def simulate_processing_activity(duration: int, message: str) -> Dict[str, Any]:
     """Simulate processing work."""
-    start_time = datetime.utcnow()
-    
+    start_time = datetime.now(timezone.utc)
+
     # Simulate work
     await asyncio.sleep(duration)
-    
-    end_time = datetime.utcnow()
+
+    end_time = datetime.now(timezone.utc)
     
     return {
         "message": message,

--- a/computor-backend/src/computor_backend/tasks/temporal_student_testing.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_student_testing.py
@@ -16,7 +16,7 @@ import subprocess
 import asyncio
 import shutil
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Dict, Any, Optional, List
 from temporalio import workflow, activity
 from temporalio.common import RetryPolicy
@@ -852,7 +852,14 @@ class StudentTestingWorkflow(BaseWorkflow):
         workflow.logger.info(f"[TEST CONFIG] service_slug={test_job.get('testing_service_slug')}, "
                             f"artifact_id={test_job.get('artifact_id')}, "
                             f"example_version_id={test_job.get('example_version_id')}")
-        started_at = datetime.utcnow()
+        # workflow.now(), not datetime.utcnow(): this is workflow code, so the
+        # clock has to come from Temporal. utcnow() is both naive (its
+        # isoformat() below carried no offset, so consumers read UTC as local)
+        # and non-deterministic — on a replay it re-stamps with the replay
+        # time instead of the original start, silently corrupting the reported
+        # duration. It only ran at all because these workflows are declared
+        # sandboxed=False; the sandbox rejects datetime.utcnow() outright.
+        started_at = workflow.now()
 
         try:
             # API configuration - activities read from their own os.environ
@@ -875,7 +882,7 @@ class StudentTestingWorkflow(BaseWorkflow):
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
 
-            completed_at = datetime.utcnow()
+            completed_at = workflow.now()
             duration = (completed_at - started_at).total_seconds()
 
             # Extract results

--- a/computor-backend/src/computor_backend/tasks/temporal_tutor_testing.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_tutor_testing.py
@@ -20,7 +20,7 @@ import zipfile
 import tempfile
 import logging
 from io import BytesIO
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Dict, Any
 
 from temporalio import workflow, activity
@@ -384,7 +384,10 @@ class TutorTestingWorkflow(BaseWorkflow):
             f"[TUTOR TEST CONFIG] service_slug={test_config.get('testing_service_slug')}, "
             f"example_version_id={example_version_id}"
         )
-        started_at = datetime.utcnow()
+        # workflow.now(), not datetime.utcnow() — see StudentTestingWorkflow:
+        # workflow code needs Temporal's clock, which is both tz-aware and
+        # stable across replays.
+        started_at = workflow.now()
 
         try:
             # API configuration - activities read from their own os.environ
@@ -411,7 +414,7 @@ class TutorTestingWorkflow(BaseWorkflow):
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
 
-            completed_at = datetime.utcnow()
+            completed_at = workflow.now()
             duration = (completed_at - started_at).total_seconds()
 
             # Extract results

--- a/computor-backend/src/computor_backend/tasks/temporal_worker.py
+++ b/computor-backend/src/computor_backend/tasks/temporal_worker.py
@@ -7,7 +7,7 @@ import logging
 import signal
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 from temporalio.worker import Worker
 from temporalio.client import Client
@@ -78,7 +78,7 @@ class TemporalWorker:
             except asyncio.TimeoutError:
                 pass  # normal interval elapsed
             if not self._shutdown:
-                uptime = datetime.utcnow() - self._start_time if self._start_time else "unknown"
+                uptime = datetime.now(timezone.utc) - self._start_time if self._start_time else "unknown"
                 logger.info(
                     f"[HEARTBEAT] Worker alive - queues: {self.task_queues}, "
                     f"uptime: {uptime}"
@@ -86,7 +86,11 @@ class TemporalWorker:
 
     async def start(self):
         """Start the worker and begin processing workflows."""
-        self._start_time = datetime.utcnow()
+        # Aware UTC. The worker container runs on UTC by design, but a naive
+        # stamp logged its isoformat() with no offset ("2026-08-10T11:03:52"),
+        # which reads as local time to anyone correlating it against a wall
+        # clock or feeding it to a parser.
+        self._start_time = datetime.now(timezone.utc)
         logger.info(f"Starting Temporal worker for queues: {', '.join(self.task_queues)}")
         logger.info(f"Worker start time: {self._start_time.isoformat()}")
 
@@ -230,7 +234,7 @@ class TemporalWorker:
         for executor in self._activity_executors:
             executor.shutdown(wait=False)
 
-        uptime = datetime.utcnow() - self._start_time if self._start_time else "unknown"
+        uptime = datetime.now(timezone.utc) - self._start_time if self._start_time else "unknown"
         logger.info(f"Workers shut down - uptime: {uptime}")
 
 

--- a/computor-types/src/computor_types/api_tokens.py
+++ b/computor-types/src/computor_types/api_tokens.py
@@ -21,9 +21,14 @@ def _reject_past_expiry(value: Optional[datetime]) -> Optional[datetime]:
     """
     if value is None:
         return value
-    # Naive datetimes are treated as UTC (bootstrap builds them with utcnow()).
-    reference = datetime.now(timezone.utc) if value.tzinfo else datetime.utcnow()
-    if value <= reference:
+    # A caller may still send an offset-less datetime ("2027-01-01T00:00:00"),
+    # which pydantic parses as naive. Interpret it as UTC and return it that
+    # way, rather than comparing it against a naive "now": every column here is
+    # timestamptz, so a naive value would otherwise be resolved against the
+    # database session's time zone instead of the one the caller meant.
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    if value <= datetime.now(timezone.utc):
         raise ValueError("expires_at must be in the future")
     return value
 


### PR DESCRIPTION
Follow-up to the MATLAB result-timestamp fix. Same class of bug, different sites — none of these feed the results tree, so they were split out.

## Problem

Every container runs on UTC by design and every `DateTime` column is `timestamptz`, but 15 sites still built naive datetimes with `datetime.utcnow()`. A naive value serialises with **no offset**:

```
utcnow()          -> "2026-08-10T15:15:06.027313"    <- no marker
now(timezone.utc) -> "2026-08-10T15:15:06.027319Z"
```

JavaScript parses the offset-less form as *local* time, and Postgres resolves it against the **session** time zone. Either way the value silently shifts by the local offset.

## Changes

**Workflows → `workflow.now()`** (`temporal_student_testing`, `temporal_tutor_testing`)

This fixes a second, independent defect: `utcnow()` is non-deterministic, so a replay re-stamped `started_at` with the *replay* time and corrupted the reported duration. It only ran at all because these workflows are declared `sandboxed=False` — the Temporal sandbox rejects it outright:

```
RestrictedWorkflowAccessError: Cannot access datetime.datetime.utcnow.__call__ from inside a workflow.
```

`temporal_coder_setup` already used `workflow.now()`; this brings the rest in line.

**Everything else → `datetime.now(timezone.utc)`**

- `temporal_worker` — start time and uptime. The start time was logged via `isoformat()` with no offset.
- `temporal_examples` — activity start/end (activity code, so the plain aware clock is correct, not `workflow.now()`).
- `bootstrap` / `interfaces.api_token` — token expiry written to, and compared against, a `timestamptz` column. These worked **only** because the database session happens to run UTC.
- `generate_typescript_clients` — codegen banner timestamp.

## Two behavioural changes worth review

- `upload_submission_artifact` now reports the artifact's **stored** `uploaded_at` rather than a second clock reading. The repository's `create()` flushes and refreshes so server defaults are populated, so the real value is available — the upload response can no longer disagree with a later artifact listing.
- `_reject_past_expiry` now interprets a naive `expires_at` as UTC and returns it **aware**, instead of comparing it against a naive `now()`. Callers may still send an offset-less datetime; it is simply no longer resolved against the database session's zone.

## Verification

- No naive `utcnow()` remains outside tests.
- Ruff: **18 errors vs 19 at base** — one fewer (removed a pre-existing unused `timezone` import on a line being rewritten anyway), zero new.
- All 9 changed modules import; `workflow.now()` confirmed present in the SDK.
- Validator behaviour checked directly: naive future → normalised to UTC, aware → preserved, past → rejected, `None` → allowed.
- Backend suite run against a `release/2026.10` worktree: **143 failed / 1103 passed / 44 skipped / 25 errors on both trees**, with byte-identical failure sets across all 149 `FAILED`+`ERROR` lines. Those failures are the branch's pre-existing state, not damage from this change.