### PR TITLE
feat(courses): public course discovery and self-subscription

### DIFF
--- a/computor-backend/src/computor_backend/alembic/versions/c4d5e6f7a8b9_add_public_course_flag.py
+++ b/computor-backend/src/computor_backend/alembic/versions/c4d5e6f7a8b9_add_public_course_flag.py
@@ -1,0 +1,26 @@
+"""Add the explicit public-course visibility flag.
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3d4e5f6a7b8
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c4d5e6f7a8b9"
+down_revision: Union[str, None] = "b3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "course",
+        sa.Column("is_public", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("course", "is_public")

--- a/computor-backend/src/computor_backend/api/public_courses.py
+++ b/computor-backend/src/computor_backend/api/public_courses.py
@@ -1,0 +1,120 @@
+"""Public course discovery and safe self-subscription endpoints."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from computor_backend.business_logic.course_member_post_create import (
+    course_member_post_create,
+)
+from computor_backend.database import get_db
+from computor_backend.exceptions import NotFoundException
+from computor_backend.model.course import Course, CourseGroup, CourseMember
+from computor_backend.permissions.auth import get_current_principal
+from computor_backend.permissions.principal import Principal
+from computor_types.courses import CourseList
+from computor_types.course_members import CourseMemberGet
+
+
+public_courses_router = APIRouter(tags=["public-courses"])
+
+
+@public_courses_router.get("/public/courses", response_model=list[CourseList])
+def list_public_courses(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=100),
+    db: Session = Depends(get_db),
+) -> list[CourseList]:
+    """List only courses explicitly made public by a course manager.
+
+    This endpoint intentionally does not expose course content, members, git
+    configuration, or organization internals. A user must authenticate and
+    subscribe before the normal course permissions grant access to course
+    resources.
+    """
+    courses = (
+        db.query(Course)
+        .filter(Course.is_public.is_(True))
+        .order_by(Course.title.asc(), Course.id.asc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    return [CourseList.model_validate(course, from_attributes=True) for course in courses]
+
+
+def _get_or_create_public_group(course: Course, db: Session) -> CourseGroup:
+    """Return the stable default group required by the student FK invariant."""
+    group = (
+        db.query(CourseGroup)
+        .filter(CourseGroup.course_id == course.id)
+        .order_by(CourseGroup.title.asc(), CourseGroup.id.asc())
+        .first()
+    )
+    if group is not None:
+        return group
+
+    group = CourseGroup(
+        course_id=course.id,
+        title="Public students",
+        description="Students who self-subscribed to this public course.",
+    )
+    db.add(group)
+    db.flush()
+    return group
+
+
+@public_courses_router.post(
+    "/courses/{course_id}/subscribe",
+    response_model=CourseMemberGet,
+    summary="Subscribe the current user to a public course",
+)
+async def subscribe_to_public_course(
+    course_id: UUID,
+    permissions: Annotated[Principal, Depends(get_current_principal)],
+    db: Session = Depends(get_db),
+) -> CourseMemberGet:
+    """Idempotently create exactly a ``_student`` membership.
+
+    The request contains no role or group fields. This is deliberate: social
+    registration and self-subscription can never grant lecturer, maintainer,
+    owner, administrator, or organization roles.
+    """
+    course = (
+        db.query(Course)
+        .filter(Course.id == str(course_id), Course.is_public.is_(True))
+        .first()
+    )
+    if course is None:
+        # Do not reveal whether a private course exists.
+        raise NotFoundException(detail="Public course not found")
+
+    existing = (
+        db.query(CourseMember)
+        .filter(
+            CourseMember.course_id == course.id,
+            CourseMember.user_id == permissions.get_user_id_or_throw(),
+        )
+        .first()
+    )
+    if existing is not None:
+        return CourseMemberGet.model_validate(existing, from_attributes=True)
+
+    group = _get_or_create_public_group(course, db)
+    member = CourseMember(
+        user_id=permissions.get_user_id_or_throw(),
+        course_id=course.id,
+        course_group_id=group.id,
+        course_role_id="_student",
+        properties={"self_subscribed": True},
+    )
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+
+    # Preserve the existing membership lifecycle: student profile,
+    # submission-group provisioning, and any configured repository workflow.
+    await course_member_post_create(member, db)
+    return CourseMemberGet.model_validate(member, from_attributes=True)

--- a/computor-backend/src/computor_backend/model/course.py
+++ b/computor-backend/src/computor_backend/model/course.py
@@ -151,6 +151,7 @@ class Course(UUIDPkMixin, VersionedMixin, AuditMixin, Base):
     course_family_id = Column(ForeignKey('course_family.id', ondelete='CASCADE', onupdate='RESTRICT'), nullable=False)
     organization_id = Column(ForeignKey('organization.id', ondelete='CASCADE', onupdate='RESTRICT'), nullable=False)
     language_code = Column(String(2), ForeignKey('language.code', ondelete='SET NULL', onupdate='CASCADE'))
+    is_public = Column(Boolean, nullable=False, server_default=text("false"))
 
     # Course-wide defaults for the per-assignment budgets. NULL means "no
     # default"; a CourseContent value overrides these, and a SubmissionGroup

--- a/computor-backend/src/computor_backend/server.py
+++ b/computor-backend/src/computor_backend/server.py
@@ -57,6 +57,7 @@ from computor_backend.api.tutor import tutor_router
 from computor_backend.api.lecturer import lecturer_router
 from computor_backend.api.organizations import organization_router
 from computor_backend.api.courses import course_router
+from computor_backend.api.public_courses import public_courses_router
 from computor_backend.api.course_families import course_family_router
 from computor_backend.api.user_roles import user_roles_router
 from computor_backend.api.role_claims import role_claim_router
@@ -442,6 +443,11 @@ CrudRouter(GroupInterface).register_routes(app)
 # GET /sessions/me is matched before the generic GET /sessions/{id} route.
 app.include_router(session_router, tags=["sessions"])
 CrudRouter(SessionInterface).register_routes(app)
+# Public course discovery must be registered before the authenticated CRUD
+# collection routes. The subscribe route has a distinct suffix and is safe to
+# register alongside the normal course resource routes.
+app.include_router(public_courses_router)
+
 # These three hand-declare a cascade-aware DELETE (see api/{courses,organizations,
 # course_families}.py), which shadows the generic one — skip it rather than
 # registering a second, unreachable route.

--- a/computor-backend/src/computor_backend/tests/test_public_courses.py
+++ b/computor-backend/src/computor_backend/tests/test_public_courses.py
@@ -1,0 +1,154 @@
+"""Behavioral tests for public-course discovery and self-subscription."""
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+from computor_backend.api import public_courses
+from computor_backend.model.course import Course, CourseGroup, CourseMember
+from computor_backend.permissions.principal import Principal
+
+
+class _Query:
+    def __init__(self, db, model):
+        self.db = db
+        self.model = model
+
+    def filter(self, *conditions):
+        return self
+
+    def order_by(self, *columns):
+        return self
+
+    def offset(self, value):
+        return self
+
+    def limit(self, value):
+        return self
+
+    def all(self):
+        if self.model is Course:
+            return [course for course in self.db.courses if course.is_public]
+        if self.model is CourseGroup:
+            return self.db.groups
+        return self.db.members
+
+    def first(self):
+        if self.model is Course:
+            return next((course for course in self.db.courses if course.is_public), None)
+        if self.model is CourseGroup:
+            return self.db.groups[0] if self.db.groups else None
+        return self.db.members[0] if self.db.members else None
+
+
+class _Session:
+    def __init__(self, courses, groups=None, members=None):
+        self.courses = courses
+        self.groups = groups or []
+        self.members = members or []
+        self.added = []
+        self.commits = 0
+
+    def query(self, model):
+        return _Query(self, model)
+
+    def add(self, entity):
+        self.added.append(entity)
+        if isinstance(entity, CourseGroup):
+            entity.id = entity.id or str(uuid4())
+            self.groups.append(entity)
+        elif isinstance(entity, CourseMember):
+            entity.id = entity.id or str(uuid4())
+            self.members.append(entity)
+
+    def flush(self):
+        return None
+
+    def commit(self):
+        self.commits += 1
+
+    def refresh(self, entity):
+        return None
+
+
+def _course(*, public: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=str(uuid4()),
+        title="Intro to Python",
+        description="A public course",
+        course_family_id=str(uuid4()),
+        organization_id=str(uuid4()),
+        path="intro.python",
+        language_code="en",
+        properties=None,
+        is_public=public,
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_catalog_contains_only_explicitly_public_courses():
+    public_course = _course(public=True)
+    private_course = _course(public=False)
+    response = public_courses.list_public_courses(
+        skip=0,
+        limit=100,
+        db=_Session([public_course, private_course]),
+    )
+
+    assert [course.id for course in response] == [public_course.id]
+    assert response[0].is_public is True
+
+
+@pytest.mark.asyncio
+async def test_self_subscription_creates_student_membership_and_runs_lifecycle(monkeypatch):
+    course = _course(public=True)
+    session = _Session([course])
+    principal = Principal(user_id=str(uuid4()))
+    lifecycle_calls = []
+
+    async def fake_lifecycle(member, db):
+        lifecycle_calls.append((member, db))
+
+    monkeypatch.setattr(public_courses, "course_member_post_create", fake_lifecycle)
+
+    member = await public_courses.subscribe_to_public_course(
+        course_id=UUID(course.id),
+        permissions=principal,
+        db=session,
+    )
+
+    created = session.members[0]
+    assert member.course_id == course.id
+    assert created.user_id == principal.user_id
+    assert created.course_role_id == "_student"
+    assert created.course_group_id is not None
+    assert created.properties == {"self_subscribed": True}
+    assert len(lifecycle_calls) == 1
+    assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_self_subscription_is_idempotent_and_never_changes_existing_role(monkeypatch):
+    course = _course(public=True)
+    user_id = str(uuid4())
+    existing = CourseMember(
+        id=str(uuid4()),
+        user_id=user_id,
+        course_id=course.id,
+        course_group_id=str(uuid4()),
+        course_role_id="_student",
+    )
+    session = _Session([course], members=[existing])
+    monkeypatch.setattr(public_courses, "course_member_post_create", lambda *_: None)
+
+    response = await public_courses.subscribe_to_public_course(
+        course_id=UUID(course.id),
+        permissions=Principal(user_id=user_id),
+        db=session,
+    )
+
+    assert response.id == existing.id
+    assert len(session.members) == 1
+    assert existing.course_role_id == "_student"
+    assert session.commits == 0

--- a/computor-types/src/computor_types/courses.py
+++ b/computor-types/src/computor_types/courses.py
@@ -31,6 +31,7 @@ class CourseCreate(BaseModel):
     course_family_id: str
     language_code: Optional[str] = None
     properties: Optional[CourseProperties] = None
+    is_public: bool = False
     # Course-wide defaults for the per-assignment test/submission budgets.
     # None means "no default"; a course content value overrides these, and a
     # submission group value overrides both.
@@ -70,6 +71,7 @@ class CourseList(BaseModel):
     path: str
     language_code: Optional[str] = None
     properties: Optional[CoursePropertiesGet] = None
+    is_public: bool = False
     # Course-wide defaults for the per-assignment test/submission budgets.
     # None means "no default"; a course content value overrides these, and a
     # submission group value overrides both.
@@ -87,6 +89,7 @@ class CourseUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
     language_code: Optional[str] = None
+    is_public: Optional[bool] = None
     # Course-wide defaults for the per-assignment test/submission budgets.
     # None means "no default"; a course content value overrides these, and a
     # submission group value overrides both.

--- a/computor-web/app/courses/[id]/edit/page.tsx
+++ b/computor-web/app/courses/[id]/edit/page.tsx
@@ -50,6 +50,7 @@ export default function CourseEditPage() {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [language, setLanguage] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
   // Course-wide budget defaults. Held as strings so an empty field can mean
   // "unlimited" rather than collapsing to 0.
   const [maxTestRuns, setMaxTestRuns] = useState('');
@@ -79,6 +80,7 @@ export default function CourseEditPage() {
       setTitle(c.title || '');
       setDescription(c.description || '');
       setLanguage(c.language_code || '');
+      setIsPublic(c.is_public ?? false);
       setMaxTestRuns(c.max_test_runs != null ? String(c.max_test_runs) : '');
       setMaxSubmissions(c.max_submissions != null ? String(c.max_submissions) : '');
       const srv = await gitServersClient.listGitServersEndpointGitServersGet({}).catch(() => [] as GitServerGet[]);
@@ -123,6 +125,7 @@ export default function CourseEditPage() {
           title: title.trim() || null,
           description: description.trim() || null,
           language_code: language.trim() || null,
+          is_public: isPublic,
           max_test_runs: parseLimit(maxTestRuns),
           max_submissions: parseLimit(maxSubmissions),
         },
@@ -241,6 +244,20 @@ export default function CourseEditPage() {
                     />
                   </Field>
                 </div>
+                <label className="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={isPublic}
+                    onChange={(e) => setIsPublic(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  <span>
+                    <span className="block font-medium text-gray-900">Make this course public</span>
+                    <span className="block text-xs text-gray-600">
+                      Anyone can discover it and authenticated users can self-subscribe as students. Course content remains protected until they join.
+                    </span>
+                  </span>
+                </label>
                 <div className="flex items-center gap-3">
                   <button onClick={saveGeneral} disabled={savingGeneral} className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50">
                     {savingGeneral ? 'Saving…' : 'Save'}

--- a/computor-web/app/page.tsx
+++ b/computor-web/app/page.tsx
@@ -96,6 +96,12 @@ export default function Home() {
           ) : (
             <div className="flex items-center space-x-3">
               <Link
+                href="/public-courses"
+                className="px-4 py-2 text-gray-700 hover:text-gray-900 transition-colors font-medium"
+              >
+                Public Courses
+              </Link>
+              <Link
                 href="/login"
                 className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
               >

--- a/computor-web/app/public-courses/page.tsx
+++ b/computor-web/app/public-courses/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { CourseList } from 'types/generated';
+import { useAuth } from '@/src/contexts/AuthContext';
+import { API_BASE_URL, apiGet, apiPost } from '@/src/utils/apiClient';
+
+export default function PublicCoursesPage() {
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+  const [courses, setCourses] = useState<CourseList[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [joining, setJoining] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiGet(`${API_BASE_URL}/public/courses`)
+      .then(async (response) => {
+        if (!response.ok) throw new Error('Could not load public courses.');
+        setCourses(await response.json());
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : 'Could not load public courses.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function join(courseId: string) {
+    if (!isAuthenticated) {
+      router.push(`/login?next=${encodeURIComponent('/public-courses')}`);
+      return;
+    }
+
+    setJoining(courseId);
+    setError(null);
+    try {
+      const response = await apiPost(`${API_BASE_URL}/courses/${courseId}/subscribe`);
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Could not join this course.');
+      }
+      router.push(`/courses/${courseId}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not join this course.');
+    } finally {
+      setJoining(null);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <header className="border-b bg-white">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <Link href="/" className="flex items-center gap-3">
+            <Image src="/computor_logo.png" alt="Computor" width={36} height={36} className="h-9 w-9" />
+            <span className="text-xl font-semibold text-gray-900">Computor</span>
+          </Link>
+          <Link href={isAuthenticated ? '/dashboard' : '/login'} className="text-sm font-medium text-blue-600 hover:text-blue-700">
+            {isAuthenticated ? 'Dashboard' : 'Sign in'}
+          </Link>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-6xl px-6 py-12">
+        <div className="mb-8 max-w-2xl">
+          <h1 className="text-3xl font-bold text-gray-900">Public courses</h1>
+          <p className="mt-2 text-gray-600">Discover courses that allow students to join themselves.</p>
+        </div>
+
+        {error && <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">{error}</div>}
+        {loading && <p className="text-gray-600">Loading courses…</p>}
+        {!loading && !error && courses.length === 0 && (
+          <div className="rounded-xl border-2 border-dashed border-gray-300 bg-white p-12 text-center text-gray-600">
+            No public courses are available yet.
+          </div>
+        )}
+        {!loading && courses.length > 0 && (
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {courses.map((course) => (
+              <article key={course.id} className="flex flex-col rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+                <h2 className="text-lg font-semibold text-gray-900">{course.title || 'Untitled course'}</h2>
+                {course.description && <p className="mt-3 flex-1 text-sm leading-6 text-gray-600">{course.description}</p>}
+                <div className="mt-6 flex items-center justify-between border-t border-gray-100 pt-4">
+                  {course.language_code && <span className="text-xs uppercase text-gray-500">{course.language_code}</span>}
+                  <button
+                    type="button"
+                    onClick={() => join(course.id)}
+                    disabled={joining === course.id}
+                    className="ml-auto rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {joining === course.id ? 'Joining…' : 'Join course'}
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/computor-web/src/generated/types/courses.ts
+++ b/computor-web/src/generated/types/courses.ts
@@ -1269,6 +1269,7 @@ export interface CourseCreate {
   course_family_id: string;
   language_code?: string | null;
   properties?: CourseProperties | null;
+  is_public?: boolean;
   max_test_runs?: number | null;
   max_submissions?: number | null;
 }
@@ -1281,6 +1282,7 @@ export interface CourseGet {
   course_family_id: string;
   language_code?: string | null;
   properties?: CoursePropertiesGet | null;
+  is_public?: boolean;
   max_test_runs?: number | null;
   max_submissions?: number | null;
   /** Creation timestamp */
@@ -1302,6 +1304,7 @@ export interface CourseList {
   path: string;
   language_code?: string | null;
   properties?: CoursePropertiesGet | null;
+  is_public?: boolean;
   max_test_runs?: number | null;
   max_submissions?: number | null;
 }
@@ -1310,6 +1313,7 @@ export interface CourseUpdate {
   title?: string | null;
   description?: string | null;
   language_code?: string | null;
+  is_public?: boolean | null;
   max_test_runs?: number | null;
   max_submissions?: number | null;
 }


### PR DESCRIPTION
## Summary

- add an explicit `course.is_public` flag and migration
- add a public metadata-only catalog at `GET /public/courses`
- add idempotent `POST /courses/{course_id}/subscribe`
- self-subscription can create only the `_student` course role and uses the existing membership lifecycle
- add a public course catalog page and a lecturer checkbox for visibility

## Verification

- `PYTHONPATH="$PWD/computor-backend/src:$PWD/computor-types/src:$PWD/computor-client/src" computor-backend/.venv/bin/pytest -q computor-backend/src/computor_backend/tests/test_public_courses.py`
- `cd computor-web && npm run lint` (no errors; existing warnings remain)

## Security boundary

The public endpoint returns course metadata only. Course contents and normal course APIs remain permission-protected; joining never accepts a caller-supplied role or group.