### PR TITLE
feat(auth): add social self-registration via Keycloak broker

### DIFF
--- a/computor-backend/src/computor_backend/api/auth.py
+++ b/computor-backend/src/computor_backend/api/auth.py
@@ -20,6 +20,11 @@ from sqlalchemy.orm import Session
 
 from computor_backend.coder.keepalive import bump_workspace_activity
 from computor_backend.coder.naming import coder_username_matches_user
+from computor_backend.auth.social import (
+    add_keycloak_identity_provider_hint,
+    enabled_social_providers,
+    social_provider,
+)
 from computor_backend.database import get_db
 from computor_backend.permissions.auth import get_current_principal
 from computor_backend.exceptions import (
@@ -71,6 +76,22 @@ async def list_providers() -> List[ProviderInfo]:
                 enabled=True,
                 login_url=f"/auth/{plugin_name}/login"
             ))
+
+    # Google, GitHub, and GitLab are brokered through the enabled Keycloak
+    # plugin. Secrets stay in Keycloak/server configuration; the browser only
+    # receives a redirect URL and never sees an upstream client secret.
+    if "keycloak" in registry.get_enabled_plugins():
+        for social in enabled_social_providers():
+            providers.append(ProviderInfo(
+                name=social["name"],
+                display_name=social["display_name"],
+                type="oidc",
+                enabled=True,
+                login_url=(
+                    "/auth/keycloak/login?"
+                    + urlencode({"provider_hint": social["name"]})
+                ),
+            ))
     
     return providers
 
@@ -78,6 +99,8 @@ async def list_providers() -> List[ProviderInfo]:
 async def initiate_login(
     provider: str,
     redirect_uri: Optional[str] = Query(None, description="Redirect URI after authentication"),
+    provider_hint: Optional[str] = Query(None, description="Configured Keycloak broker provider"),
+    registration: bool = Query(False, description="Use the student-only self-registration flow"),
     request: Request = None
 ) -> RedirectResponse:
     """
@@ -90,6 +113,18 @@ async def initiate_login(
     # Check if provider exists and is enabled
     if provider not in registry.get_enabled_plugins():
         raise NotFoundException(detail=f"Authentication provider not found or not enabled: {provider}")
+
+    social = None
+    if provider_hint:
+        if provider != "keycloak":
+            raise NotFoundException(detail="Social providers must use Keycloak brokering")
+        social = social_provider(provider_hint)
+        if social is None:
+            raise NotFoundException(detail="Authentication provider not configured")
+    if registration and social is None:
+        raise BadRequestException(
+            detail="Self-registration is available only through a configured social provider"
+        )
 
     # If the plugin is enabled but not yet loaded (e.g. Keycloak wasn't ready at startup), try now
     if registry.get_plugin(provider) is None:
@@ -110,6 +145,9 @@ async def initiate_login(
         "redirect_uri": redirect_uri or str(request.url_for("sso_success")),
         "timestamp": str(request.headers.get("date", ""))
     }
+    if social:
+        state_data["social_provider"] = social["name"]
+        state_data["registration"] = registration
     await redis_client.set(
         f"sso_state:{state}",
         json.dumps(state_data),
@@ -131,6 +169,9 @@ async def initiate_login(
     try:
         # Get login URL from provider
         login_url = registry.get_login_url(provider, callback_url, state)
+
+        if social:
+            login_url = add_keycloak_identity_provider_hint(login_url, social["alias"])
         
         # Redirect to provider login
         return RedirectResponse(url=login_url, status_code=302)

--- a/computor-backend/src/computor_backend/auth/social.py
+++ b/computor-backend/src/computor_backend/auth/social.py
@@ -1,0 +1,67 @@
+"""Configuration for brokered social sign-in providers.
+
+Computor does not put provider secrets in the browser or implement separate
+token exchanges for each provider. Keycloak brokers the upstream accounts and
+the backend receives the normal Keycloak OIDC session. Operators enable the
+providers that are actually configured in Keycloak with
+``COMPUTOR_SOCIAL_LOGIN_PROVIDERS``.
+"""
+
+import os
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+SOCIAL_PROVIDER_NAMES = ("google", "github", "gitlab")
+_DISPLAY_NAMES = {
+    "google": "Google",
+    "github": "GitHub",
+    "gitlab": "GitLab",
+}
+
+
+def enabled_social_providers() -> list[dict[str, str]]:
+    """Return the configured providers in stable UI order."""
+    configured = {
+        name.strip().lower()
+        for name in os.environ.get("COMPUTOR_SOCIAL_LOGIN_PROVIDERS", "").split(",")
+        if name.strip()
+    }
+    return [
+        {
+            "name": name,
+            "display_name": _DISPLAY_NAMES[name],
+            "alias": os.environ.get(
+                f"KEYCLOAK_IDP_{name.upper()}_ALIAS", name
+            ),
+        }
+        for name in SOCIAL_PROVIDER_NAMES
+        if name in configured
+    ]
+
+
+def social_provider(name: str) -> dict[str, str] | None:
+    """Resolve a user-facing provider name to its configured broker alias."""
+    return next(
+        (provider for provider in enabled_social_providers() if provider["name"] == name.lower()),
+        None,
+    )
+
+
+def add_keycloak_identity_provider_hint(login_url: str, alias: str) -> str:
+    """Add the Keycloak broker hint without disturbing existing query values."""
+    parts = urlsplit(login_url)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query["kc_idp_hint"] = alias
+    return urlunsplit(parts._replace(query=urlencode(query)))
+
+
+def should_bootstrap_admin(*, groups: list[str] | None, registration: bool) -> bool:
+    """Only an ordinary trusted Keycloak login may bootstrap ``_admin``.
+
+    Social self-registration must never turn upstream claims into a global
+    administrator role. Existing database roles remain authoritative and are
+    not revoked here.
+    """
+    if registration:
+        return False
+    return any(group.strip("/").split("/")[-1] == "administrators" for group in (groups or []))

--- a/computor-backend/src/computor_backend/business_logic/auth.py
+++ b/computor-backend/src/computor_backend/business_logic/auth.py
@@ -24,6 +24,7 @@ from computor_backend.redis_cache import get_redis_client
 from computor_backend.plugins.registry import get_plugin_registry
 from computor_backend.plugins import AuthStatus
 from computor_backend.auth.keycloak_admin import KeycloakAdminClient, KeycloakUser
+from computor_backend.auth.social import should_bootstrap_admin
 from computor_types.auth import (
     LocalTokenRefreshRequest,
     LocalTokenRefreshResponse,
@@ -411,6 +412,7 @@ async def handle_sso_callback(
     # Find or create user account (wrap blocking DB operations)
     def _find_or_create_account():
         nonlocal user_info, provider, registry
+        is_registration = bool(state_data.get("registration"))
 
         account = (
             db.query(Account)
@@ -425,6 +427,11 @@ async def handle_sso_callback(
         is_new_user = False
 
         if account:
+            if is_registration:
+                raise ForbiddenException(
+                    detail="An account already exists; use the sign-in flow instead"
+                )
+
             # Existing account - get user
             user = account.user
 
@@ -500,6 +507,10 @@ async def handle_sso_callback(
                 )
                 db.add(user)
                 db.flush()
+            elif is_registration:
+                raise ForbiddenException(
+                    detail="An account already exists for this email; use the sign-in flow instead"
+                )
 
             # Create account
             account = Account(
@@ -525,8 +536,10 @@ async def handle_sso_callback(
         # Additive only: membership grants _admin, but we never revoke — admin
         # can also be granted manually in the computor DB, which stays authoritative.
         groups = user_info.groups or []
-        is_kc_admin = any(g.strip("/").split("/")[-1] == "administrators" for g in groups)
-        if is_kc_admin:
+        if should_bootstrap_admin(
+            groups=groups,
+            registration=bool(state_data.get("registration")),
+        ):
             from computor_backend.model.role import UserRole
             existing_admin = (
                 db.query(UserRole)

--- a/computor-backend/src/computor_backend/tests/test_social_auth.py
+++ b/computor-backend/src/computor_backend/tests/test_social_auth.py
@@ -1,0 +1,120 @@
+"""Behavioral tests for brokered social-provider registration."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from computor_backend.api import auth
+from computor_backend.auth import social
+from computor_backend import redis_cache
+from computor_backend.exceptions import BadRequestException
+from computor_backend.plugins.base import AuthenticationType, PluginMetadata
+
+
+def test_social_provider_allowlist_and_keycloak_hint(monkeypatch):
+    monkeypatch.setenv("COMPUTOR_SOCIAL_LOGIN_PROVIDERS", "gitlab,google")
+    monkeypatch.setenv("KEYCLOAK_IDP_GOOGLE_ALIAS", "google-prod")
+
+    providers = social.enabled_social_providers()
+    assert [provider["name"] for provider in providers] == ["google", "gitlab"]
+    assert providers[0]["alias"] == "google-prod"
+    assert social.add_keycloak_identity_provider_hint(
+        "https://idp.example/authorize?client_id=computor", "google-prod"
+    ).endswith("client_id=computor&kc_idp_hint=google-prod")
+
+
+def test_student_registration_cannot_bootstrap_admin_from_upstream_groups():
+    assert social.should_bootstrap_admin(
+        groups=["/administrators"], registration=True
+    ) is False
+    assert social.should_bootstrap_admin(
+        groups=["/administrators"], registration=False
+    ) is True
+
+
+@pytest.mark.asyncio
+async def test_provider_listing_exposes_only_configured_social_buttons(monkeypatch):
+    metadata = PluginMetadata(
+        name="keycloak",
+        version="1",
+        description="test",
+        provider_name="Keycloak",
+        provider_type=AuthenticationType.OIDC,
+    )
+
+    class Registry:
+        def get_enabled_plugins(self):
+            return ["keycloak"]
+
+        def get_plugin_metadata(self, name):
+            return metadata
+
+    monkeypatch.setattr(auth, "get_plugin_registry", lambda: Registry())
+    monkeypatch.setenv("COMPUTOR_SOCIAL_LOGIN_PROVIDERS", "google,gitlab")
+
+    providers = await auth.list_providers()
+    assert [provider.name for provider in providers] == ["keycloak", "google", "gitlab"]
+    assert providers[1].login_url.endswith("provider_hint=google")
+
+
+@pytest.mark.asyncio
+async def test_social_login_redirect_contains_hint_and_student_registration_state(monkeypatch):
+    stored = {}
+
+    class Redis:
+        async def set(self, key, value, ex):
+            stored[key] = (value, ex)
+
+    class Registry:
+        def get_enabled_plugins(self):
+            return ["keycloak"]
+
+        def get_plugin(self, name):
+            return object()
+
+        def get_login_url(self, provider, redirect_uri, state):
+            return "https://idp.example/authorize?state=" + state
+
+    monkeypatch.setattr(auth, "get_plugin_registry", lambda: Registry())
+    async def fake_get_redis_client():
+        return Redis()
+
+    monkeypatch.setattr(redis_cache, "get_redis_client", fake_get_redis_client)
+    monkeypatch.setenv("COMPUTOR_SOCIAL_LOGIN_PROVIDERS", "google")
+    monkeypatch.setenv("NEXT_PUBLIC_API_URL", "https://api.example")
+
+    request = SimpleNamespace(
+        headers={},
+        url_for=lambda name, **kwargs: "http://localhost/unused",
+    )
+    response = await auth.initiate_login(
+        provider="keycloak",
+        redirect_uri="https://app.example/auth/success",
+        provider_hint="google",
+        registration=True,
+        request=request,
+    )
+
+    assert "kc_idp_hint=google" in response.headers["location"]
+    state_key, (raw_state, ttl) = next(iter(stored.items()))
+    assert state_key.startswith("sso_state:")
+    assert ttl == 1800
+    assert '"social_provider": "google"' in raw_state
+    assert '"registration": true' in raw_state
+
+
+@pytest.mark.asyncio
+async def test_registration_requires_a_configured_social_provider(monkeypatch):
+    class Registry:
+        def get_enabled_plugins(self):
+            return ["keycloak"]
+
+    monkeypatch.setattr(auth, "get_plugin_registry", lambda: Registry())
+
+    with pytest.raises(BadRequestException, match="configured social provider"):
+        await auth.initiate_login(
+            provider="keycloak",
+            provider_hint=None,
+            registration=True,
+            request=SimpleNamespace(headers={}, url_for=lambda name, **kwargs: "http://localhost"),
+        )

--- a/computor-web/app/login/page.tsx
+++ b/computor-web/app/login/page.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/src/contexts/AuthContext';
+import Link from 'next/link';
+import Image from 'next/image';
+import SocialLoginButtons from '@/src/components/auth/SocialLoginButtons';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { loginWithSSO, isAuthenticated, isLoading } = useAuth();
-  const triggered = useRef(false);
+  const { isAuthenticated, isLoading, loginWithSSO } = useAuth();
 
   useEffect(() => {
     if (isLoading) return;
@@ -15,25 +17,40 @@ export default function LoginPage() {
       router.push('/dashboard');
       return;
     }
-    // Keycloak is the only identity provider — go straight there instead of
-    // showing an intermediate button. Guard against double-trigger in StrictMode.
-    if (!triggered.current) {
-      triggered.current = true;
-      loginWithSSO('keycloak');
-    }
-  }, [isAuthenticated, isLoading, loginWithSSO, router]);
+  }, [isAuthenticated, isLoading, router]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="text-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto" />
-        <p className="mt-4 text-gray-600">Redirecting to sign-in…</p>
-        <button
-          onClick={() => loginWithSSO('keycloak')}
-          className="mt-4 text-sm text-blue-600 hover:underline"
-        >
-          Click here if you are not redirected automatically
-        </button>
+    <div className="min-h-screen bg-gray-50 px-4 py-12">
+      <div className="mx-auto max-w-md">
+        <div className="rounded-2xl border border-gray-200 bg-white p-8 shadow-xl">
+          <div className="mb-8 text-center">
+            <Image src="/computor_logo.png" alt="Computor" width={48} height={48} className="mx-auto h-12 w-12" />
+            <h1 className="mt-4 text-2xl font-bold text-gray-900">Sign in to Computor</h1>
+            <p className="mt-2 text-sm text-gray-600">Use your institution or social account.</p>
+          </div>
+
+          <SocialLoginButtons />
+
+          <div className="my-6 flex items-center gap-3 text-xs text-gray-400">
+            <div className="h-px flex-1 bg-gray-200" />
+            <span>or</span>
+            <div className="h-px flex-1 bg-gray-200" />
+          </div>
+
+          <button
+            type="button"
+            onClick={() => loginWithSSO('keycloak')}
+            className="w-full rounded-lg bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800"
+          >
+            Continue with Computor SSO
+          </button>
+
+          <p className="mt-6 text-center text-sm text-gray-600">
+            New here?{' '}
+            <Link href="/register" className="font-medium text-blue-600 hover:underline">Create a student account</Link>
+          </p>
+        </div>
+        <Link href="/" className="mt-6 block text-center text-sm text-gray-600 hover:text-gray-900">← Back to home</Link>
       </div>
     </div>
   );

--- a/computor-web/app/page.tsx
+++ b/computor-web/app/page.tsx
@@ -96,6 +96,12 @@ export default function Home() {
           ) : (
             <div className="flex items-center space-x-3">
               <Link
+                href="/register"
+                className="px-4 py-2 text-gray-700 hover:text-gray-900 transition-colors font-medium"
+              >
+                Create Account
+              </Link>
+              <Link
                 href="/login"
                 className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
               >

--- a/computor-web/app/register/page.tsx
+++ b/computor-web/app/register/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/src/contexts/AuthContext';
+import SocialLoginButtons from '@/src/components/auth/SocialLoginButtons';
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading } = useAuth();
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) router.push('/dashboard');
+  }, [isAuthenticated, isLoading, router]);
+
+  if (isLoading) {
+    return <div className="flex min-h-screen items-center justify-center bg-gray-50 text-gray-600">Loading…</div>;
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 px-4 py-12">
+      <div className="mx-auto max-w-md">
+        <div className="rounded-2xl border border-gray-200 bg-white p-8 shadow-xl">
+          <div className="mb-8 text-center">
+            <Image src="/computor_logo.png" alt="Computor" width={48} height={48} className="mx-auto h-12 w-12" />
+            <h1 className="mt-4 text-2xl font-bold text-gray-900">Create your student account</h1>
+            <p className="mt-2 text-sm text-gray-600">Choose an account provider to get started.</p>
+          </div>
+
+          <SocialLoginButtons registration />
+
+          <p className="mt-6 rounded-lg bg-blue-50 p-3 text-center text-xs leading-5 text-blue-900">
+            Self-registration creates only a student account. You can join courses that have been marked public; it does not grant teaching or administrator access.
+          </p>
+
+          <p className="mt-6 text-center text-sm text-gray-600">
+            Already have an account?{' '}
+            <Link href="/login" className="font-medium text-blue-600 hover:underline">Sign in</Link>
+          </p>
+        </div>
+        <Link href="/" className="mt-6 block text-center text-sm text-gray-600 hover:text-gray-900">← Back to home</Link>
+      </div>
+    </main>
+  );
+}

--- a/computor-web/src/components/auth/SocialLoginButtons.tsx
+++ b/computor-web/src/components/auth/SocialLoginButtons.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/src/contexts/AuthContext';
+import { API_BASE_URL, apiFetch } from '@/src/utils/apiClient';
+
+type SocialProvider = 'google' | 'github' | 'gitlab';
+
+const PROVIDERS: Array<{ name: SocialProvider; label: string }> = [
+  { name: 'google', label: 'Google' },
+  { name: 'github', label: 'GitHub' },
+  { name: 'gitlab', label: 'GitLab' },
+];
+
+export default function SocialLoginButtons({ registration = false }: { registration?: boolean }) {
+  const { loginWithSSO } = useAuth();
+  const [enabled, setEnabled] = useState<SocialProvider[]>([]);
+
+  useEffect(() => {
+    apiFetch(`${API_BASE_URL}/auth/providers`)
+      .then(async (response) => {
+        if (!response.ok) return;
+        const providers = (await response.json()) as Array<{ name: string; enabled: boolean }>;
+        setEnabled(
+          PROVIDERS.map((provider) => provider.name).filter((name) =>
+            providers.some((provider) => provider.name === name && provider.enabled),
+          ),
+        );
+      })
+      .catch(() => setEnabled([]));
+  }, []);
+
+  if (enabled.length === 0) {
+    return (
+      <p className="text-center text-sm text-gray-600">
+        No social registration provider is configured for this instance.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3" aria-label="Social sign-in providers">
+      {enabled.map((provider) => {
+        const metadata = PROVIDERS.find((item) => item.name === provider)!;
+        return (
+          <button
+            key={provider}
+            type="button"
+            onClick={() => loginWithSSO(provider, registration)}
+            className="relative flex w-full items-center justify-center rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-800 shadow-sm transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+          >
+            <ProviderLogo provider={provider} />
+            <span>Continue with {metadata.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ProviderLogo({ provider }: { provider: SocialProvider }) {
+  if (provider === 'google') {
+    return (
+      <svg className="absolute left-4 h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="#4285F4" d="M21.35 12.27c0-.7-.06-1.37-.18-2.02H12v3.82h5.24a4.48 4.48 0 0 1-1.94 2.94v2.45h3.14c1.84-1.69 2.91-4.18 2.91-7.19Z" />
+        <path fill="#34A853" d="M12 21.6c2.63 0 4.84-.87 6.45-2.36l-3.14-2.45c-.87.58-1.98.93-3.31.93-2.54 0-4.69-1.72-5.46-4.03H3.3v2.53A9.74 9.74 0 0 0 12 21.6Z" />
+        <path fill="#FBBC05" d="M6.54 13.69a5.86 5.86 0 0 1 0-3.38V7.78H3.3a9.6 9.6 0 0 0 0 8.44l3.24-2.53Z" />
+        <path fill="#EA4335" d="M12 6.28c1.43 0 2.72.49 3.73 1.46l2.8-2.8C16.84 3.36 14.63 2.4 12 2.4a9.74 9.74 0 0 0-8.7 5.38l3.24 2.53C7.31 8 9.46 6.28 12 6.28Z" />
+      </svg>
+    );
+  }
+
+  if (provider === 'github') {
+    return (
+      <svg className="absolute left-4 h-5 w-5 text-gray-900" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 .5a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.25c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.74.08-.74 1.2.08 1.83 1.23 1.83 1.23 1.07 1.83 2.8 1.3 3.49.99.11-.77.42-1.3.76-1.6-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.38 1.23-3.22-.12-.3-.53-1.52.12-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.3-1.55 3.3-1.23 3.3-1.23.65 1.66.24 2.88.12 3.18.76.84 1.23 1.91 1.23 3.22 0 4.62-2.8 5.64-5.48 5.94.43.37.81 1.1.81 2.22v3.29c0 .32.22.69.83.57A12 12 0 0 0 12 .5Z" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg className="absolute left-4 h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
+      <path fill="#FC6D26" d="m22.2 13.4-1.25-3.84-2.47-7.6c-.13-.4-.7-.4-.83 0l-2.47 7.6H8.82l-2.47-7.6c-.13-.4-.7-.4-.83 0l-2.47 7.6L1.8 13.4a.83.83 0 0 0 .3.93l9.9 7.2 9.9-7.2a.83.83 0 0 0 .3-.93Z" />
+      <path fill="#E24329" d="m12 21.53 5.48-11.97H14.4L12 16.1l-2.4-6.54H6.52L12 21.53Z" />
+      <path fill="#FCA326" d="M12 21.53 3.05 14.33a.83.83 0 0 1-.3-.93l1.25-3.84h4.1L12 21.53Z" />
+    </svg>
+  );
+}

--- a/computor-web/src/contexts/AuthContext.tsx
+++ b/computor-web/src/contexts/AuthContext.tsx
@@ -16,7 +16,7 @@ interface AuthContextType {
   scopes: UserScopes | null;
   isAuthenticated: boolean;
   isLoading: boolean;
-  loginWithSSO: (provider?: string) => void;
+  loginWithSSO: (provider?: string, registration?: boolean) => void;
   logout: () => Promise<void>;
   refreshSession: () => Promise<AuthResponse>;
 }
@@ -81,8 +81,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     initAuth();
   }, [loadPermissions]);
 
-  const loginWithSSO = useCallback((provider: string = 'keycloak') => {
-    ssoAuthService.initiateSSO(provider);
+  const loginWithSSO = useCallback((provider: string = 'keycloak', registration = false) => {
+    ssoAuthService.initiateSSO(provider, registration);
   }, []);
 
   const logout = useCallback(async () => {

--- a/computor-web/src/interfaces/IAuthProvider.ts
+++ b/computor-web/src/interfaces/IAuthProvider.ts
@@ -59,7 +59,7 @@ export interface ISSOAuthProvider extends IAuthProvider {
    * Initiate SSO login flow
    * Redirects to SSO provider
    */
-  initiateSSO(provider?: string): void;
+  initiateSSO(provider?: string, registration?: boolean): void;
 
   /**
    * Handle SSO callback after redirect

--- a/computor-web/src/services/ssoAuthService.ts
+++ b/computor-web/src/services/ssoAuthService.ts
@@ -61,7 +61,7 @@ export class SSOAuthService implements ISSOAuthProvider {
    * Initiate SSO login by redirecting to the provider
    * Backend will set HttpOnly cookies after successful authentication
    */
-  initiateSSO(provider: string = 'keycloak'): void {
+  initiateSSO(provider: string = 'keycloak', registration = false): void {
     // Save current location to return after auth
     sessionStorage.setItem('auth_redirect', window.location.pathname);
 
@@ -69,11 +69,14 @@ export class SSOAuthService implements ISSOAuthProvider {
     const frontendCallbackUrl = `${window.location.origin}/auth/success`;
 
     // Redirect to SSO login with redirect_uri parameter
-    const params = new URLSearchParams({
-      redirect_uri: frontendCallbackUrl
-    });
+    const socialProvider = ['google', 'github', 'gitlab'].includes(provider) ? provider : null;
+    const params = new URLSearchParams({ redirect_uri: frontendCallbackUrl });
+    if (socialProvider) {
+      params.set('provider_hint', socialProvider);
+      params.set('registration', String(registration));
+    }
 
-    window.location.href = `${API_BASE_URL}/auth/${provider}/login?${params.toString()}`;
+    window.location.href = `${API_BASE_URL}/auth/${socialProvider ? 'keycloak' : provider}/login?${params.toString()}`;
   }
 
   /**

--- a/computor-web/src/types/js-yaml.d.ts
+++ b/computor-web/src/types/js-yaml.d.ts
@@ -1,0 +1,3 @@
+declare module 'js-yaml' {
+  export function load(input: string): unknown;
+}

--- a/data/keycloak/identity-providers.example.json
+++ b/data/keycloak/identity-providers.example.json
@@ -1,5 +1,56 @@
 [
   {
+    "alias": "google",
+    "displayName": "Google",
+    "enabled": false,
+    "providerId": "oidc",
+    "discoveryUrl": "https://accounts.google.com/.well-known/openid-configuration",
+    "clientId": "CHANGE_ME_GOOGLE_CLIENT_ID",
+    "clientSecretEnv": "GOOGLE_OAUTH_CLIENT_SECRET",
+    "defaultScopes": "openid email profile",
+    "trustEmail": true,
+    "syncMode": "FORCE",
+    "mappers": {
+      "email": "email",
+      "givenName": "given_name",
+      "familyName": "family_name",
+      "username": "email"
+    }
+  },
+  {
+    "alias": "github",
+    "displayName": "GitHub",
+    "enabled": false,
+    "providerId": "github",
+    "clientId": "CHANGE_ME_GITHUB_CLIENT_ID",
+    "clientSecretEnv": "GITHUB_OAUTH_CLIENT_SECRET",
+    "defaultScopes": "user:email",
+    "trustEmail": true,
+    "syncMode": "FORCE",
+    "mappers": {
+      "email": "email",
+      "givenName": "name",
+      "username": "login"
+    }
+  },
+  {
+    "alias": "gitlab",
+    "displayName": "GitLab",
+    "enabled": false,
+    "providerId": "gitlab",
+    "clientId": "CHANGE_ME_GITLAB_CLIENT_ID",
+    "clientSecretEnv": "GITLAB_OAUTH_CLIENT_SECRET",
+    "defaultScopes": "openid profile email",
+    "trustEmail": true,
+    "syncMode": "FORCE",
+    "mappers": {
+      "email": "email",
+      "givenName": "given_name",
+      "familyName": "family_name",
+      "username": "username"
+    }
+  },
+  {
     "alias": "example-oidc",
     "displayName": "Example Institute SSO",
     "enabled": false,

--- a/ops/docs/ENV_CONFIGURATION.md
+++ b/ops/docs/ENV_CONFIGURATION.md
@@ -93,6 +93,30 @@ CODER_ADMIN_API_SECRET=<set-in-.env>
 CODER_POSTGRES_USER=<set-in-.env>
 CODER_POSTGRES_PASSWORD=<set-in-.env>
 
+### Social self-registration (Optional)
+
+Google, GitHub, and GitLab registration is brokered by Keycloak. The backend
+does not receive upstream client secrets and the browser never gets them. Add
+only the providers that have been configured in the local, ignored
+`data/keycloak/identity-providers.json` file:
+
+```dotenv
+COMPUTOR_SOCIAL_LOGIN_PROVIDERS=google,github,gitlab
+GOOGLE_OAUTH_CLIENT_SECRET=<secret issued by Google>
+GITHUB_OAUTH_CLIENT_SECRET=<secret issued by GitHub>
+GITLAB_OAUTH_CLIENT_SECRET=<secret issued by GitLab>
+```
+
+The corresponding client IDs and provider settings live in the operator-managed
+Keycloak provider file, seeded from
+`data/keycloak/identity-providers.example.json`. Register each upstream OAuth
+client with Keycloak's broker callback URL:
+`https://<keycloak-public-host>/realms/<realm>/broker/<alias>/endpoint`.
+
+Social self-registration creates a Computor user without a global elevated
+role. Access to a course is granted separately by joining a course explicitly
+marked public, which creates only the course-scoped `_student` membership.
+
 # coder-registry has no auth — it is protected by docker-network isolation
 # instead (it does not join computor-network, so workspaces can't reach it
 # over TCP). See docker-compose.coder.yaml for details.

--- a/ops/environments/.env.common.template
+++ b/ops/environments/.env.common.template
@@ -332,6 +332,16 @@ KEYCLOAK_REALM=computor
 KEYCLOAK_CLIENT_ID=computor-backend
 KEYCLOAK_CLIENT_SECRET=CHANGE_ME_KEYCLOAK_CLIENT_SECRET
 
+# Optional upstream providers brokered by Keycloak. Keep this list limited to
+# providers that are present in data/keycloak/identity-providers.json. The
+# backend exposes matching buttons and never receives their client secrets.
+COMPUTOR_SOCIAL_LOGIN_PROVIDERS=
+# Override only when the Keycloak identity-provider alias differs from the
+# conventional provider name (google, github, or gitlab).
+KEYCLOAK_IDP_GOOGLE_ALIAS=google
+KEYCLOAK_IDP_GITHUB_ALIAS=github
+KEYCLOAK_IDP_GITLAB_ALIAS=gitlab
+
 # Secret for the 'forgejo' Keycloak client (declared in the Keycloak import and shared
 # with Forgejo's OIDC login source). Only used when GIT_SERVER=forgejo. Must be hex
 # (substituted into the Keycloak JSON via a /-delimited sed). setup-env.sh generates it.

--- a/ops/keycloak/setup_identity_providers.py
+++ b/ops/keycloak/setup_identity_providers.py
@@ -181,6 +181,13 @@ def upsert_provider(base, realm, token, entry):
 
 def _reconcile_mappers(base, realm, token, entry):
     """Create/update the claim->user mappers (username, email, names)."""
+    # Keycloak's built-in GitHub and GitLab providers already extract the
+    # provider profile into the brokered identity. The generic OIDC mapper
+    # factories are not compatible with every social-provider factory, so do
+    # not install OIDC mapper types on those providers.
+    if entry.get("providerId") in {"github", "gitlab"}:
+        return
+
     alias = entry["alias"]
     claim_map = entry.get(
         "mappers", {"email": "email", "givenName": "given_name", "familyName": "family_name"}


### PR DESCRIPTION
## Summary

Adds student-only self-registration through Google, GitHub, or GitLab accounts brokered by Keycloak.

- Adds a dedicated `/register` page and replaces the automatic login redirect with explicit, branded provider buttons.
- Exposes only the social providers enabled by `COMPUTOR_SOCIAL_LOGIN_PROVIDERS`.
- Keeps all upstream OAuth client secrets in Keycloak/server configuration; the browser only starts the normal Keycloak flow.
- Uses Keycloak's `kc_idp_hint` to select the requested provider.
- Prevents the registration flow from bootstrapping `_admin` from upstream groups.
- Refuses registration when the provider identity or email already belongs to a Computor account, so registration cannot attach a social identity to an existing staff/admin account.
- Documents example Google OIDC, GitHub, and GitLab broker configuration and callback setup.

Self-registration creates a normal user with no elevated system role. Course-scoped `_student` membership for public courses is provided by the separate public-course PR #210.

## Configuration

Set the allowlist in the server environment, then provide the corresponding client secrets to Keycloak:

```env
COMPUTOR_SOCIAL_LOGIN_PROVIDERS=google,github,gitlab
```

See `data/keycloak/identity-providers.example.json` and `ops/docs/ENV_CONFIGURATION.md` for provider setup and callback guidance.

## Verification

- `PYTHONPATH="$PWD/computor-backend/src:$PWD/computor-types/src:$PWD/computor-client/src" computor-backend/.venv/bin/pytest -q computor-backend/src/computor_backend/tests/test_social_auth.py computor-backend/src/computor_backend/tests/test_auth.py` — 5 passed, 1 skipped
- `npm run lint` — no errors; 6 existing warnings
- `npm run build` — passed

## Scope

This PR is intentionally based directly on `release/2026.10`. Public-course discovery and self-subscription are in #210 so the changes remain atomic.